### PR TITLE
Update SDK version, wasi target name

### DIFF
--- a/documentation/fastedge/create-apps.md
+++ b/documentation/fastedge/create-apps.md
@@ -11,6 +11,6 @@ pageDescription: A short overview of FastEdge applications and how they can be c
 
 FastEdge allows you to run applications in a serverless environment on Gcore’s scalable CDN network. You can create the following types of FastEdge apps: 
 
-* **HTTP applications**: manage apps that have their own URL and are built using <a href="https://github.com/G-Core/FastEdge-sdk-rust" target="_blank">FastEdge Rust SDK</a>  or <a href="https://github.com/G-Core/FastEdge-sdk-js" target="_blank">FastEdge Javascript SD</a>. 
+* **HTTP applications**: manage apps that have their own URL and are built using <a href="https://github.com/G-Core/FastEdge-sdk-rust" target="_blank">FastEdge Rust SDK</a>  or <a href="https://github.com/G-Core/FastEdge-sdk-js" target="_blank">FastEdge JavaScript SDK</a>.
 
 * **CDN applications**: manage apps that extend the functionality of Gcore CDN and use <a href="https://github.com/proxy-wasm/spec" target="_blank">Proxy-Wasm</a> spec. 

--- a/documentation/fastedge/create-apps/create-fastedge-apps.md
+++ b/documentation/fastedge/create-apps/create-fastedge-apps.md
@@ -38,7 +38,7 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 2\. Add the Wasm compilation target to Rust compiler:
 
 ```
-rustup target add wasm32-wasi
+rustup target add wasm32-wasip1
 ```
 
 #### Step 2. Prepare directory structure and a configuration file
@@ -58,7 +58,7 @@ mkdir myapp/.cargo
 
 ```
 [build]
-target = "wasm32-wasi"
+target = "wasm32-wasip1"
 ```
 
 4\. Create the project manifest file ```myapp/Cargo.toml``` with the following content:
@@ -73,7 +73,7 @@ edition = "2021"
 crate-type = ["cdylib"]
  
 [dependencies]
-fastedge = "0.1"
+fastedge = "0.2"
 ```
 #### Step 3. Create a source
 
@@ -103,7 +103,7 @@ Produce the Wasm binary:
 cargo build --release
 ```
 
-The resulting Wasm code will be written to the ```myapp/target/wasm32-wasi/release/myapp.wasm``` file.
+The resulting Wasm code will be written to the ```myapp/target/wasm32-wasip1/release/myapp.wasm``` file.
 
 ### Via JavaScript SDK
 

--- a/documentation/fastedge/fastedge-cli.md
+++ b/documentation/fastedge/fastedge-cli.md
@@ -61,7 +61,7 @@ Execute the following command:
 
 </code-block>
 
-For example:  `./target/release/cli http -w ../FastEdge-examples/rust/target/wasm32-wasi/release/print.wasm –-port 8080`
+For example:  `./target/release/cli http -w ../FastEdge-examples/rust/target/wasm32-wasip1/release/print.wasm –-port 8080`
 
 To view the list of all printed headers, run `curl http://localhost:8080`
 
@@ -77,7 +77,7 @@ Execute the following command:
 
 For example, to set the BASE variable to the URL of the repository’s README:  
 
-`./target/release/cli http -w ../FastEdge-examples/rust/target/wasm32-wasi/release/markdown.wasm env BASE=https://raw.githubusercontent.com/G-Core/FastEdge-lib/main --port 8080`
+`./target/release/cli http -w ../FastEdge-examples/rust/target/wasm32-wasip1/release/markdown.wasm env BASE=https://raw.githubusercontent.com/G-Core/FastEdge-lib/main --port 8080`
 
 After executing the command, you can run the FastEdge application, which will output the contents of the README: `http://localhost:8080/README.md`
 
@@ -91,7 +91,7 @@ FastEdge CLI can add sample geo headers to your application without using a real
 
 </code-block>
 
-For example:  `./target/release/cli http -w ../FastEdge-examples/rust/target/wasm32-wasi/release/print.wasm –-geo --port 8081` 
+For example:  `./target/release/cli http -w ../FastEdge-examples/rust/target/wasm32-wasip1/release/print.wasm –-geo --port 8081` 
 
 To view the list of sample geo headers, run `curl http://localhost:8081`. You should see an output similar to the following: 
 

--- a/documentation/fastedge/fastedge-cli.md
+++ b/documentation/fastedge/fastedge-cli.md
@@ -12,7 +12,7 @@ pageDescription: Explore FastEdge CLI tool and learn how to install, build, and 
 ---
 # FastEdge CLI  
 
-Run and test your FastEdge applications locally with the Gcore <a href="https://github.com/G-Core/FastEdge-lib" target="_blank">FastEdge CLI tool</a>. The following instructions will help you install, build, and execute some basic commands with FastEdge CLI. 
+Run and test your FastEdge HTTP applications locally with the Gcore <a href="https://github.com/G-Core/FastEdge-lib" target="_blank">FastEdge CLI tool</a>. The following instructions will help you install, build, and execute some basic commands with FastEdge CLI. 
 
 <alert-element type="tip" title="Tip">
 
@@ -41,11 +41,11 @@ To run the compiled CLI tool, use the following command:
 
 <code-block>
 
-./target/release/cli <span style="color:#FF5913">[command]</span>
+./target/release/fastedge-run <span style="color:#FF5913">[command]</span>
 
 </code-block>
 
-For example, if you want to open help and view the list of supported commands, run: `./target/release/cli http --help`.
+For example, if you want to open help and view the list of supported commands, run: `./target/release/fastedge-run http --help`.
 
 ## Example commands
 
@@ -57,11 +57,11 @@ Execute the following command:
 
 <code-block>
 
-./target/release/cli http –w <span style="color:#FF5913">[path-to-your-application]</span> –-port <span style="color:#FF5913">[port number]</span>
+./target/release/fastedge-run http –w <span style="color:#FF5913">[path-to-your-application]</span> –-port <span style="color:#FF5913">[port number]</span>
 
 </code-block>
 
-For example:  `./target/release/cli http -w ../FastEdge-examples/rust/target/wasm32-wasip1/release/print.wasm –-port 8080`
+For example:  `./target/release/fastedge-run http -w ../FastEdge-examples/rust/target/wasm32-wasip1/release/print.wasm –-port 8080`
 
 To view the list of all printed headers, run `curl http://localhost:8080`
 
@@ -71,13 +71,13 @@ Execute the following command:
 
 <code-block>
 
-./target/release/cli http –w <span style="color:#FF5913">[path-to-your-application]</span> –-env <span style="color:#FF5913">[variables]</span> --port <span style="color:#FF5913">[port number]</span> 
+./target/release/fastedge-run http –w <span style="color:#FF5913">[path-to-your-application]</span> –-env <span style="color:#FF5913">[variables]</span> --port <span style="color:#FF5913">[port number]</span> 
 
 </code-block>
 
 For example, to set the BASE variable to the URL of the repository’s README:  
 
-`./target/release/cli http -w ../FastEdge-examples/rust/target/wasm32-wasip1/release/markdown.wasm env BASE=https://raw.githubusercontent.com/G-Core/FastEdge-lib/main --port 8080`
+`./target/release/fastedge-run http -w ../FastEdge-examples/rust/target/wasm32-wasip1/release/markdown.wasm env BASE=https://raw.githubusercontent.com/G-Core/FastEdge-lib/main --port 8080`
 
 After executing the command, you can run the FastEdge application, which will output the contents of the README: `http://localhost:8080/README.md`
 
@@ -87,11 +87,11 @@ FastEdge CLI can add sample geo headers to your application without using a real
 
 <code-block>
 
-./target/release/cli http -w <span style="color:#FF5913">[path-to-your-application]</span> –geo –port <span style="color:#FF5913">[port number]</span> 
+./target/release/fastedge-run http -w <span style="color:#FF5913">[path-to-your-application]</span> –geo –port <span style="color:#FF5913">[port number]</span> 
 
 </code-block>
 
-For example:  `./target/release/cli http -w ../FastEdge-examples/rust/target/wasm32-wasip1/release/print.wasm –-geo --port 8081` 
+For example:  `./target/release/fastedge-run http -w ../FastEdge-examples/rust/target/wasm32-wasip1/release/print.wasm –-geo --port 8081` 
 
 To view the list of sample geo headers, run `curl http://localhost:8081`. You should see an output similar to the following: 
 


### PR DESCRIPTION
Updated FastEdge SDK version (`0.1` -> `0.2`), wasm32 target name (`wasm32-wasi` -> `wasm32-wasip1`, changed in recent Rust versions), corrected one small typo (`SD` -> `SDK`), fixed the name of FastEdge CLI binary (`cli` -> `fastedge-run`)