### PR TITLE
Add DDoS Event Logs page

### DIFF
--- a/documentation/ddos-protection/event-logs.md
+++ b/documentation/ddos-protection/event-logs.md
@@ -1,0 +1,32 @@
+---
+title: event-logs
+order: 60
+displayName: Event Logs
+published: true
+toc:
+pageTitle: DDoS Event Logs | Gcore
+pageDescription: Learn the details of previous DDoS attacks, so you can enhance your security in the future.
+---
+
+# DDoS Event Logs
+
+The DDoS event logs inform you about ongoing attacks and create an archive for retrospective analysis. They enable you to enhance your overall security posture by reviewing past incidents in depth, identifying trends, and strengthening your defences accordingly.
+
+The Event Logs provide details about **DDoS attacks of the past three months** and contain the following crucial information about each attack:
+
+* Start date and time
+* Bits per second (BPS)
+* Packets per second (PPS)
+* Attacked IP address
+* Number of attacking IP addresses
+
+## View the DDoS Event Logs
+
+To view the event logs, open the **Gcore Customer Portal** and navigate to **DDoS Protection > Reports > Event logs**.
+
+<img src="https://assets.gcore.pro/docs/ddos-protection/event-logs-navigation.png" alt="Gcore Customer Portal navigation" />
+
+An example event log looks like this:
+
+<img src="https://assets.gcore.pro/docs/ddos-protection/event-logs-example.png" alt="Example DDoS event log table" />
+


### PR DESCRIPTION
The DDoS section in the Customer Portal received a new event logs feature. This new page explains what it does and where to find it.

Related Jira task: N/A