### PR TITLE
Update documentation for live streaming and video hosting features

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -966,11 +966,11 @@
             "pages": [
               "streaming-platform",
               {
-                "group": "AI Video Services",
+                "group": "AI video services",
                 "pages": [
                   "streaming-platform/video-hosting/ai-video-service",
                   {
-                    "group": "Content Moderation",
+                    "group": "Content moderation",
                     "pages": [
                       "streaming-platform/ai-video-service/content-moderation",
                       "streaming-platform/ai-video-service/content-moderation/nsfw-detection",
@@ -980,7 +980,7 @@
                     ]
                   },
                   {
-                    "group": "Generate and Translate Captions",
+                    "group": "Generate and translate captions",
                     "pages": [
                       "streaming-platform/video-hosting/ai-for-video/generate-ai-subtitles-and-add-them-to-video",
                       "streaming-platform/ai-video-service/generate-ai-subtitles-and-add-them-to-video/generate-captions-in-customer-portal",
@@ -991,7 +991,7 @@
               },              
               "streaming-platform/how-the-streaming-platform-and-additional-features-are-billed",
               {
-                "group": "Codecs and Protocols",
+                "group": "Codecs and protocols",
                 "pages": [
                   "streaming-platform/live-streams-and-videos-protocols-and-codecs/input-parameters-and-codecs",
                   "streaming-platform/live-streams-and-videos-protocols-and-codecs/output-parameters-and-codecs",
@@ -1001,7 +1001,7 @@
                 ]
               },
               {
-                "group": "Extra Features",
+                "group": "Extra features",
                 "pages": [
                   "streaming-platform/extra-features/customize-appearance-of-the-built-in-player",
                   "streaming-platform/api/player-api-tutorial",
@@ -1012,16 +1012,17 @@
               },
               "streaming-platform/how-the-streaming-platform-interact-with-the-cdn",
               {
-                "group": "Live Streaming",
+                "group": "Live streaming",
                 "pages": [
                   {
-                    "group": "Broadcasting Software",
+                    "group": "Broadcasting software",
                     "pages": [
                       "streaming-platform/live-streaming/broadcasting-software/ffmpeg",
                       "streaming-platform/live-streaming/broadcasting-software/larix",
                       "streaming-platform/live-streaming/broadcasting-software/obs"
                     ]
                   },
+                  "streaming-platform/live-streaming/clips",
                   "streaming-platform/live-streaming/create-a-live-stream",
                   "streaming-platform/live-streaming/pause-and-rewind-the-live-streams",
                   "streaming-platform/live-streaming/primary-backup",
@@ -1049,7 +1050,7 @@
                   "streaming-platform/troubleshooting/live-streaming-issues",
                   "streaming-platform/troubleshooting/vod-issues",
                   {
-                    "group": "WebRTC Common Issues",
+                    "group": "WebRTC common issues",
                     "pages": [
                       "streaming-platform/troubleshooting/real-time-video-issues/fix-the-camera-or-microphone-if-they-do-not-work",
                       "streaming-platform/troubleshooting/real-time-video-issues/audio-quality-is-reduced-when-using-bluetooth-headsets-in-video-call-apps"
@@ -1058,10 +1059,13 @@
                 ]
               },
               {
-                "group": "Video Hosting",
+                "group": "Video hosting",
                 "pages": [
+                  "streaming-platform/video-hosting/protect-your-videos-with-the-aes-128-encryption",
+                  "streaming-platform/video-hosting/hls-and-mp4",
+                  "streaming-platform/video-hosting/create-an-illusion-of-a-live-broadcast-with-uploaded-videos",
                   {
-                    "group": "Manage Videos",
+                    "group": "Manage videos in UI",
                     "pages": [
                       "streaming-platform/video-hosting/upload-a-video-and-embed-it-to-your-app",
                       "streaming-platform/video-hosting/organize-uploaded-videos",
@@ -1070,12 +1074,10 @@
                     ]
                   },
                   "streaming-platform/video-hosting/create-and-configure-playlists-for-videos",
-                  "streaming-platform/video-hosting/create-an-illusion-of-a-live-broadcast-with-uploaded-videos",
-                  "streaming-platform/video-hosting/protect-your-videos-with-the-aes-128-encryption",
-                  "streaming-platform/video-hosting/upload-video-via-api",
-                  "streaming-platform/video-hosting/hls-and-mp4",
+                  "streaming-platform/video-hosting/vod-status",
+                  "streaming-platform/video-hosting/subtitles-and-closed-captions-for-vod",
                   "streaming-platform/video-hosting/timeline-hover-previews-use-in-players-and-roku-devices",
-                  "streaming-platform/video-hosting/subtitles-and-closed-captions-for-vod"
+                  "streaming-platform/video-hosting/upload-video-via-api"
                 ]
               }
             ]

--- a/streaming-platform.mdx
+++ b/streaming-platform.mdx
@@ -2,21 +2,53 @@
 title: Overview
 ---
 
+## Introduction
+
 Welcome to the [Gcore Video Streaming](https://gcore.com/streaming-platform) documentation page! Here we explain how to use, configure, and troubleshoot Gcore's Video Streaming.
 
-Video Streaming is a service that transcodes media content, such as videos, live streams, and group video calls, into appropriate formats for fast and reliable delivery to millions of viewers worldwide.
+**Gcore Video Streaming** is a high-load video streaming PaaS. 
+Scale to 1M+ viewers and beyond:
+  - AI and computer vision
+  - Live: HLS MPEG-TS, HLS CMAF, MPEG-DASH CMAF
+  - Low-latency ±2 sec via LL-HLS, LL-DASH
+  - Overlays
+  - Player
+  - Playlists
+  - Recording and live clipping
+  - Restreams
+  - Statistics
+  - Subtitles
+  - VOD: audio only, SD, HD, FullHD, 4K and even 8K+
+  - WebRTC WHIP to HLS/DASH
 
-From the left-side menu, you can access in-depth documentation about Video Streaming:
-
-  * **AI Video Services** – advanced video processing features for both video on demand (VOD) and live streaming
-  * **Billing** – how the Video Streaming and additional features are billed
-  * **Codecs and Protocols** – initial parameters accepted, transcoded content parameters, adaptive streaming, low latency streaming
-  * **Extra features** – additional features for live streaming and video hosting, configuration
-  * **Interaction with CDN** – how the service for streaming video content interacts with CDN
-  * **Live Streaming** – manage live streams, configure additional features including restreaming, multicamera, recording, DVR
-  * **Statistics** – detailed statistics on the views of your videos through the built-in player or CDN
-  * **Troubleshooting** – solve streaming issues
-  * **Video Hosting** – upload a video in the Gcore Customer Portal or by API, embed video to the web application, organize videos, configure additional features including playlists, live imitation
+Video player demo:
+<iframe
+  src="https://player.gvideo.co/videos/2675_mvsPGvDVx0Hzbog"
+  width="100%"
+  height="360"
+  loading="lazy"
+  allow="autoplay; fullscreen; picture-in-picture"
+  allowFullScreen
+/>
 
 
-If you have any questions or if there is a streaming-related topic that you think we're missing, please leave a comment and our content team will address it.
+## API
+
+The Video Streaming API is accessible through Gcore’s public API endpoints. 
+All endpoints are available over HTTPS and require authentication with your Gcore API key.
+
+Full reference documentation, including request/response schemas and usage examples, is available at https://gcore.com/docs/api-reference/streaming/
+
+
+## Whats new
+
+- We've streamlined our AI service API by rewriting and combining the methods into a single, simplified method for easier integration. Jump to ["Create AI task"](/api-reference/streaming/ai/create-ai-task) for details.
+- Transcription & Translation of subtitles – AI subtitles generation and translation to 99+ languages feature has been added. Jump to ["AI Transcribe"](/api-reference/streaming/ai/create-ai-asr-task) for details.
+- Also:
+    - New MP4 downloading methods for VOD using extended options.
+    - Added stream recording type: pure original or transcoded with overlays. Details are in POST /streams in the "record_type" attribute.
+
+![AI Content Moderation: NSFW detection](https://demo-files.gvideo.io/apidocs/nsfw-detection.gif)
+
+
+Don’t change the channel... 

--- a/streaming-platform/ai-video-service/generate-ai-subtitles-and-add-them-to-video/generate-captions-via-api.mdx
+++ b/streaming-platform/ai-video-service/generate-ai-subtitles-and-add-them-to-video/generate-captions-via-api.mdx
@@ -1,12 +1,23 @@
 ---
-title: Generate and translate AI captions for a new VOD
+title: Generate and translate AI captions for VOD
 sidebarTitle: Via API
 ---
 
-You can upload videos and generate captions automatically during the process of uploading new videos to Gcire Video Streaming at /docs/api-reference/streaming/videos/create-video
+## Introduction
 
-When uploading a video, add one new attribute: "auto_transcribe_audio_language." The system will automatically create a task for transcribing the video, and the finished result will be added to the video as a subtitle.
+You can upload videos and generate captions automatically during the process of uploading new videos to Gcore Video Streaming or do it later for any earlier uploaded video. 
 
+
+## AI captions for a new video
+
+
+When uploading a video use new parameters in the end-point. The system will automatically create a task for transcribing the video and translating subtitles, and the finished result will be added to the video as a subtitle.
+
+AI caption parameters:
+  - `auto_transcribe_audio_language: auto|<language_code>` – Immediately after successful transcoding, an AI task will be automatically created for transcription the video to original language. Output by default is one subtitle channel with original languages inside.
+  - `auto_translate_subtitles_language: default|<language_codes,>` – In additional to transcription on original language it's possible to translate to other languagaes, so AI-task of subtitles translation can be applied. Use that parameter for that. Here you can specify multiple set of languages to translate to, then a separate subtitle will be generated for each specified language.
+
+Example to transcribe:
 ```sh
 POST https://api.gcore.com/streaming/videos
 {
@@ -17,20 +28,59 @@ POST https://api.gcore.com/streaming/videos
 }
 ```
 
-# Generate and translate AI captions for an existing VOD
-
-To create AI subtitles for an existing video, run the add subtitle method, but instead of specifying the subtitle text, specify the "auto_transcribe_audio_language" parameter. Subtitles will be generated and attached to the video: /docs/api-reference/streaming/subtitles/add-subtitle
-
+Example to transcribe from "eng" and translate to "fre,ger,ita,spa":
 ```sh
-POST hhttps://api.gcore.com/streaming/videos/{video_id}/subtitles
+POST https://api.gcore.com/streaming/videos
+{
+    "name": "Spritefright Blender",
+    "description": "Video copied from an external S3 Storage",
+    "origin_url": "https://demo-files.gvideo.io/apidocs/spritefright-blender-cut30sec.mp4",
+    "auto_transcribe_audio_language": "eng"
+    "auto_translate_subtitles_language": "fre,ger,ita,spa"
+}
+```
+
+Read more about it in the API [`POST /streaming/videos`](/api-reference/streaming/videos/create-video).
+
+
+## AI captions for an exist video
+
+It's possible to use post-processing for generating AI captions. 
+Using new attributes for subtitles API you will be able to create subtitles automatically. 
+
+AI caption parameters are the same for uploading:
+  - `auto_transcribe_audio_language: auto|<language_code>` – for transcribing.
+  - `auto_translate_subtitles_language: default|<language_codes,>` – for translating.
+
+Example to transcribe:
+```sh
+POST https://api.gcore.com/streaming/videos/{video_id}/subtitles
 {
     "auto_transcribe_audio_language": "auto"
 }
 ```
 
-# Extended use of AI API for any video inside or outside the video streaming platform
+Example to transcribe from a detected language and translate to "fre,ger,ita,spa":
+```sh
+POST https://api.gcore.com/streaming/videos/{video_id}/subtitles
+{
+    "auto_transcribe_audio_language": "auto"
+    "auto_translate_subtitles_language": "fre,ger,ita,spa"
+}
+```
 
-AI ​​system can process any video stored in an MP4 container and available via a direct download link. Please note that links to YouTube, Vimeo, etc., are not links to a video file, so they cannot be used for processing.
+Read more about it in the API [`POST /streaming/videos/{video_id}/subtitles`](/api-reference/streaming/subtitles/add-subtitle).
+
+
+## Advanced use of native AI API for any video inside or outside the video streaming platform
+
+Methods above are for videos stored in the Gcore Video Platform only, because they were designed for simplicity. 
+
+Using AI API directly you can process any videos stored inside or outside Gcore Video Streaming Platform. 
+AI ​​system can process any video stored in an MP4 container and available via a direct download link. 
+
+Please note that links to YouTube, Vimeo, etc., are not links to a video file, so they cannot be used for processing.
+
 
 ### Step 1. Obtain an MP4 link
 

--- a/streaming-platform/extra-features/customize-appearance-of-the-built-in-player.mdx
+++ b/streaming-platform/extra-features/customize-appearance-of-the-built-in-player.mdx
@@ -172,6 +172,6 @@ Applicable only for VOD.
 
 | **Argument**                                 | **Description**                                             | **Example**                                                                                                           |
 |----------------------------------------------|-------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------|
-| `sub_lang = (ISO language code, 2 letters)`  | Use two letters that correspond to the [ISO 639 language codes](https://en.wikipedia.org/wiki/List_of_ISO_639_language_codes). | `sub_lang=de`<br/><br/><code>https://player.gvideo.co/videos/2675_iKbrdNMcS9ylGuw?&sub_lang=de</code> |
+| `sub_lang = (ISO language code, 2 letters)`  | Use two letters that correspond to the [ISO 639 language codes](https://en.wikipedia.org/wiki/List_of_ISO_639_language_codes). | `sub_lang=de`<br/><br/><code>https://player.gvideo.co/videos/2675_iKbrdNMcS9ylGuw?sub_lang=de</code> |
 
 Please note that here a simplified 2-symbol language code is indicated as more understandable to the average user (while in the API 3 symbols are used everywhere for internal needs).

--- a/streaming-platform/extra-features/get-webhooks-from-the-streaming-platform.mdx
+++ b/streaming-platform/extra-features/get-webhooks-from-the-streaming-platform.mdx
@@ -13,21 +13,22 @@ A single universal endpoint is used for all types of webhooks.
 
 ```json
 {
-  "type": "stream|video|restream",
+  "type": "stream|video|video_delete|restream",
   "message": { ... } 
 }
 ```
 
 Supported entities:
-	1.	Live streams – `type: stream`
-	2.	VOD videos – `type: vod`
-	3.	Restreamings – `type: restream`
+	1. Live streams – `type: stream`
+	2. VOD videos – `type: vod`
+  4. VOD delete – `type: video_delete`
+	3. Restreamings – `type: restream`
 
 
 The webhook will contain main fields of the entity for which the event occurred. This allows you to not pull the API to get additional data each time.
 
 
-### Webhooks for Live
+## Webhooks for Live
 
 When the state of a live stream changes, the system triggers a webhook with type `stream`. The payload contains a message.stream object with stream properties.
 
@@ -46,8 +47,14 @@ When the state of a live stream changes, the system triggers a webhook with type
 | **client_user_id**  | string  | Optional client-defined user ID, `null` if not provided                    |
 | **client_entity_data** | string | Optional client metadata associated with the stream, `null` if not provided |
 | **pull**            | bool    | `true` if the stream is pulled from an external origin, `false` if pushed  |
-| **uri**             | string  | The source URI of the stream (e.g. HTTPS or SRT endpoint)                  |
-| **stream_source_type** | string | Type of the stream source (e.g. `https`, `rtmp`, `srt`)                      |
+| **uri**             | string  | The source URI of the stream:                                              |
+| **stream_source_type** | string | Type of the stream source: `rtmp`, `srt`, `webrtc`, `https`, etc         |
+
+<Info>
+  Stream segments become available in the CDN (and player) within ~2–5 seconds after the `type: stream (live=true)` webhook is issued.
+  
+  Read more in the article [Ingest & Backup](/streaming-platform/live-streaming/primary-backup#stream-availability).
+</Info>
 
 **Example:**
 
@@ -92,14 +99,15 @@ Stoped stream:
 ```
 
 
-### Webhooks for VOD
+## Webhooks for VOD
+
+### VOD create and update
 
 A webhook with type `video` fires when a VOD file is created, processed, or becomes playable. Use the payload to track processing progress and available renditions.
 
 **Behaviour:**
   - Sent on key status changes of a video: empty → pending → viewable → ready or error.  ￼
   - converted_videos[].status reflects per-rendition progress like processing or complete.  ￼
-
 
 **Fields:**
 | Field                | Type        | Description                                                                |
@@ -139,6 +147,7 @@ Video uploaded:
   }
 }
 ```
+
 Video becomes viewable (not all renditions are ready yet, but video can be watched by end-users already):
 ```json
 {
@@ -174,7 +183,43 @@ Video becomes viewable (not all renditions are ready yet, but video can be watch
 ```
 
 
-### Webhooks for Restream
+### VOD delete
+
+A webhook with type `video_delete` notify your system that a VOD entity was deleted so you can purge caches, revoke URLs, and clean metadata.
+
+**Behaviour:**
+  - Fired when a video is deleted via API or UI. 
+  - Emitted once per deletion event.
+
+**Fields:**
+
+| Field          | Type        | Description                                                                 |
+|----------------|-------------|-----------------------------------------------------------------------------|
+| **id**         | integer     | VideoID                                                                     |
+| **slug**       | string      | Public identifier used in playback URLs                                     |
+| **name**       | string      | Video name                                                                  |
+| **status**     | string      | Processing status of the video (e.g. `viewable`, `ready`)                   |
+| **deleted_at** | timestamp   | ISO-8601 UTC timestamp of when the deletion was committed in the system     |
+
+**Example:**
+
+```json
+{
+  "type": "video_delete",
+  "message": {
+    "video": {
+      "id": 2001,
+      "slug": "bJkptcIp9a5wrowz",
+      "name": "football_videoplayback_720",
+      "status": "ready",
+      "deleted_at": "2025-09-16T13:50:42.000Z"
+    }
+  }
+}
+```
+
+
+## Webhooks for Restream
 
 When a restream changes state (for example, starts or stops), the system sends a webhook with type `restream`. 
 The payload contains a message.restream object.

--- a/streaming-platform/extra-features/protect-your-content-with-temporary-links-and-secure-tokens.mdx
+++ b/streaming-platform/extra-features/protect-your-content-with-temporary-links-and-secure-tokens.mdx
@@ -9,8 +9,8 @@ By default, videos are available by their links with no restrictions and can be 
 
 Gcore has several methods of protecting video content:
 
-  1. Protected temporary links
-  2. [Country access policy (Geo-restrictions)](/cdn/cdn-resource-options/security/control-access-to-the-content-with-country-referrer-ip-and-user-agents-policies#country-access-policy)
+  1. Protected temporary links with secure token
+  2. [Country access policy (geo-restrictions)](/cdn/cdn-resource-options/security/control-access-to-the-content-with-country-referrer-ip-and-user-agents-policies#country-access-policy)
   3. [Referrer validation](/cdn/cdn-resource-options/security/control-access-to-the-content-with-country-referrer-ip-and-user-agents-policies#allow-referrer-policy)
   4. [AES-128 encryption](/streaming-platform/video-hosting/protect-your-videos-with-the-aes-128-encryption)
 
@@ -22,7 +22,7 @@ In this article, we will look at the first option: protected temporary links and
 
 ## What are protected temporary links?
 
-Protected temporary links are generated using the [Secure Token](/cdn/cdn-resource-options/security/use-a-secure-token/about-secure-token) feature, which allows configuring access with tokenized URLs. When using this option, you add a special character set to every URL. Check out the examples below with the special characters highlighted in bold. At Gcore, we call these special characters _Secure Tokens_.
+Protected temporary links are generated using the [CDN-resource Secure Token](/cdn/cdn-resource-options/security/use-a-secure-token/about-secure-token) feature, which allows configuring access with tokenized URLs. When using this option, you add a special character set to every URL. Check out the examples below with the special characters highlighted in bold. At Gcore, we call these special characters _Secure Tokens_.
 
 VOD:
   * Public: https://demo-public.gvideo.io/videos/2675_pG8TfmKx2LU2qs/master.m3u8
@@ -54,33 +54,43 @@ content-type: text/html
 content-length: 136
 ```
 
+
 ## CDN resources and scope of restrictions
 
 Video content hosted via the Video Streaming is viewed and delivered through our CDN, so by default your account has only one hidden CDN resource in the format _******.gvideo.io_.
 
 The restriction policies, such as the Secure Token for links protection, apply specifically to CDN resources because a CDN resource covers all video content at once. This means you don't need to create rules and make permissions for each video separately—it is enough to create and apply permissions only once to the CDN resource.
 
-Moreover, your account can have several CDN resources leading to the same content (origin). These CDN resources can be with different access policies. So you can combine open access on one CDN resource, and private access on another one, etc.
+Note: Your account can have several CDN resources leading to the same content (origin). These CDN resources can be with different access policies. So you can combine open access on one CDN resource, and private access on another one, etc.
+
+For example we have 2 demo domains for IP-binding and generic:
+  - For generic secure token use without IP-binding: https://demo-protected.gvideo.io/
+  - For IP-binded secure token: https://demo-protected-ip.gvideo.io/
+
 
 ## How to enable the secure token feature?
 
-To enable the Secure Token feature and start protecting your links, please [check out our product docs on the topic](/cdn/cdn-resource-options/security/use-a-secure-token/configure-and-use-secure-token).
+To enable the Secure Token feature and start protecting your links, please check out [the CDN page how to activate a secure token for CDN-resource](/cdn/cdn-resource-options/security/use-a-secure-token/about-secure-token).
 
-## Format of protected temporary links
+<Info>
+  To enable IP-based secure tokens, turn on the “Add client IP to token” option. Disable this option if IP binding is not required.
+</Info>
 
-Secure Token-protected temporary links have the following format: 
+
+## Secure token for HLS/DASH
+
+Secure token – protected temporary links have the following format: 
 
 ```sh
-https://domain.com/videos|cmaf/{client_id}_{video_id}/{token}/{expiration}/manifest.m3u8
+https://domain.com/videos|cmaf|mpegts/{client_id}_{video_id}/{token}/{expiration}/manifest.m3u8
  ```
 
 Where:
-
-  * `videos` – for VOD, `cmaf` – for LIVE
+  * `videos` – for VOD, `cmaf|mpegts` – for LIVE
   * `{client_id}` is your account ID
   * `{video_id}` is the identifier of the video or live stream
   * `{token}` is the MD5 hash of the video and other attributes
-  * `{expiration}` is the unix time in seconds of how long will the link be valid
+  * `{expiration}` is a Unix timestamp (in seconds) that defines until when the link remains valid
 
 
 For Gcore Video on Demand (VOD) and Gcore Live Streaming, a relative path is used for all file types used to deliver video content, such as additional manifests, chunks, and MP4 renditions. Therefore, the path of the main manifest is taken as the basis and the following path is built relative to it.
@@ -100,6 +110,24 @@ Examples of templates of protected links for LIVE:
   * `https://domain.com/cmaf/{client_id}_{stream_id}/{token}/{expiration}/`**004chunk-stream4-10000000-05213.m4s?part=4**
 
 
+## Advanced secure token for MP4
+
+A regular secure token for HLS/DASH from above protects the entire video entity. 
+When distributing MP4 files separately from ABR, use an MP4 advanced secure token as an additional query parameter. This restricts access to the specific MP4 rendition and prevents unauthorized MP4 distribution.
+
+<Info>
+  Advanced secure token for MP4 cannot be combined with generic secure token for HLS/DASH. In case of combination the secure token for HLS/DASH will have priority to resolve an accees.
+</Info>
+
+Advanced secure token for MP4 – protected temporary links have the following format: 
+```sh
+https://domain.com/videos/client_id_video_id/filename.mp4?md5={token}&expires={expiration}
+ ```
+
+Where:
+  * `{token}` is the MD5 hash of the MP4 file path and other options
+  * `{expiration}` is a Unix timestamp (in seconds) that defines until when the link remains valid
+
 
 ## A note on the expiration time
 
@@ -113,9 +141,29 @@ To handle both cases, ensure you set the expiration far enough into the future t
 expires = 1861919999 # Sunday, December 31, 2028 23:59:59 GMT
  ```
 
+
 ## How to create protected links with the secure token
 
-Note that generating a Secure Token requires the same process for both VOD and Live Streaming. 
+### Create secure token for HLS/DASH
+
+Pattern to generate token:
+1) Tokens without user ip: 
+```
+${client_id}_${video_id}_${secret}_${expires}_
+```
+2) Tokens with user ip: 
+```
+${client_id}_${video_id}_${secret}_${expires}_${user_ip}
+```
+
+| Parameter     | Required | Description                                                                |
+|---------------|----------|----------------------------------------------------------------------------|
+| **client_id** | yes      | URL of the MP4 file                                                        |
+| **video_id**  | yes      | Video_Slug or Stream_ID identifier                                         |
+| **secret**    | yes      | Secret phrase                                                              |
+| **expires**   | yes      | Expiration time (Unix timestamp, UTC)                                      |
+| **user_ip**   | optional | Client IP address. Required only if token was generated with IP binding    |
+
 
 <Tabs>
   <Tab title="Python">
@@ -125,11 +173,11 @@ Note that generating a Secure Token requires the same process for both VOD and L
     from time import time
 
     def gethash(client_id, video_id, secret, expires):
-        hash_body = "%s_%s_%s_%s_" % (client_id, video_id, secret, expires)   # set of unique parameters of video
-        hash_md5 =  base64.b64encode(                                         # get MD5 hash from parameters of video
-                md5(hash_body.encode()).digest()                            
-            ).decode().replace("+", "-").replace("/", "_").replace("=", "")   # preparation for use in URL 
-        return hash_md5
+      hash_body = "%s_%s_%s_%s_" % (client_id, video_id, secret, expires)   # set of unique parameters of video
+      hash_md5 =  base64.b64encode(                                         # get MD5 hash from parameters of video
+          md5(hash_body.encode()).digest()                            
+        ).decode().replace("+", "-").replace("/", "_").replace("=", "")   # preparation for use in URL 
+      return hash_md5
 
     client_id = "2675"       # enter your account ID here
     secret = ""              # enter your secret key from CDN-resource here
@@ -154,39 +202,227 @@ Note that generating a Secure Token requires the same process for both VOD and L
     package main
 
     import (
-        "crypto/md5"
-        "encoding/base64"
-        "fmt"
-        "time"
+      "crypto/md5"
+      "encoding/base64"
+      "fmt"
+      "time"
     )
 
     func gethash(clientId string, videoId string, secret string, expires int64) string {
-        hashBody := fmt.Sprintf("%s_%s_%s_%d_", clientId, videoId, secret, expires) // set of unique parameters of video
-
-        md5sum := md5.Sum([]byte(hashBody)) // get MD5 hash from parameters of video
-        hashMd5 := base64.RawURLEncoding.EncodeToString(md5sum[:])
-        return hashMd5
+      hashBody := fmt.Sprintf("%s_%s_%s_%d_", clientId, videoId, secret, expires) // set of unique parameters of video
+      md5sum := md5.Sum([]byte(hashBody)) // get MD5 hash from parameters of video
+      hashMd5 := base64.RawURLEncoding.EncodeToString(md5sum[:])
+      return hashMd5
     }
 
     func main() {
-        clientId := "2675" // enter your account ID here
-        secret := ""       // enter your secret key from CDN-resource here
+      clientId := "2675" // enter your account ID here
+      secret := ""       // enter your secret key from CDN-resource here
 
-        //VOD
-        videoSlug := "3dk4NsRt6vWsffEr"         // enter your video's slug here
-        expires := time.Now().Unix() + 24*60*60 // now + 24 hours, unixtime in seconds
+      //VOD
+      videoSlug := "3dk4NsRt6vWsffEr"         // enter your video's slug here
+      expires := time.Now().Unix() + 24*60*60 // now + 24 hours, unixtime in seconds
 
-        token := gethash(clientId, videoSlug, secret, expires)
-        fmt.Printf("https://demo-protected.gvideo.io/videos/%s_%s/%s/%d/master.m3u8 \n", clientId, videoSlug, token, expires)
+      token := gethash(clientId, videoSlug, secret, expires)
+      fmt.Printf("https://demo-protected.gvideo.io/videos/%s_%s/%s/%d/master.m3u8 \n", clientId, videoSlug, token, expires)
 
-        //LIVE
-        streamId := "201693"                   // enter your live stream id here
-        expires = time.Now().Unix() + 24*60*60 // now + 24 hours, unixtime in seconds
+      //LIVE
+      streamId := "201693"                   // enter your live stream id here
+      expires = time.Now().Unix() + 24*60*60 // now + 24 hours, unixtime in seconds
 
-        token = gethash(clientId, streamId, secret, expires)
-        fmt.Printf("https://demo-protected.gvideo.io/cmaf/%s_%s/%s/%d/master.m3u8 \n", clientId, streamId, token, expires)
+      token = gethash(clientId, streamId, secret, expires)
+      fmt.Printf("https://demo-protected.gvideo.io/cmaf/%s_%s/%s/%d/master.m3u8 \n", clientId, streamId, token, expires)
     }
 
     ```
+  </Tab>
+</Tabs>
+
+
+### Create advanced secure token for MP4
+
+The MP4 advanced secure token is generated from the full MP4 URL. You can optionally bind [MP4 speed limit](/streaming-platform/video-hosting/hls-and-mp4#mp4-dynamic-speed-limiting) to the token by including the `speed` and `buffer` parameters. This ensures that download rate limits cannot be bypassed – if a user tampers with these values, the request will return 403 Forbidden.
+If no speed limit is required, set both `speed` and `buffer` to an empty string when generating the token.
+
+Pattern to generate token:
+1) Tokens without user ip: 
+```
+${uri}_${secret}_${expires}_${speed}_${buffer}_
+```
+2) Tokens with user ip: 
+```
+${uri}_${secret}_${expires}_${speed}_${buffer}_${user_ip}
+```
+
+| Parameter   | Required | Description                                                                |
+|-------------|----------|----------------------------------------------------------------------------|
+| **uri**     | yes      | Path from MP4 file URL                                                     |
+| **secret**  | yes      | Secret phrase                                                              |
+| **expires** | yes      | Expiration time (Unix timestamp, UTC)                                      |
+| **speed**   | optional | Download speed limit in bytes/sec. Use an empty string if not required     |
+| **buffer**  | optional | Buffer size in bytes for rate limiting. Use an empty string if not required|
+| **user_ip** | optional | Client IP address. Required only if token was generated with IP binding    |
+ 
+Examples:
+Secret: `MySecr3tStr1ng`
+
+Without user ip:
+```
+string to sign: /videos/279481_1053391/qid2920v1_h264_4050_1080_1.mp4_MySecr3tStr1ng_1743167062___
+url: http://gvideo.dev/videos/279481_1053391/qid2920v1_h264_4050_1080_1.mp4?md5=QX39c77lbQKvYgMMAvpyMQ&expires=1743167062
+
+string to sign: /videos/279481_1053391/qid2920v1_h264_4050_1080_1.mp4_MySecr3tStr1ng_1743167062_1000k__
+url: http://gvideo.dev/videos/279481_1053391/qid2920v1_h264_4050_1080_1.mp4?md5=UcB_lMku9m-MtxIEos_V-w&expires=1743167062&speed=1000k
+
+string to sign: /videos/279481_1053391/qid2920v1_h264_4050_1080_1.mp4_MySecr3tStr1ng_1743167062_1000k_2000k_
+url: http://gvideo.dev/videos/279481_1053391/qid2920v1_h264_4050_1080_1.mp4?md5=yGa6cK0jM4YvwaSUEPvwMA&expires=1743167062&speed=1000k&buffer=2000k
+```
+
+With user ip 1.2.3.4
+```
+string to sign: /videos/279481_1053391/qid2920v1_h264_4050_1080_1.mp4_MySecr3tStr1ng_1743167062___1.2.3.4 
+url: http://gvideo.dev/videos/279481_1053391/qid2920v1_h264_4050_1080_1.mp4?md5=SZMnuXQv-81sVqslGtXwlA&expires=1743167062 
+
+string to sign: /videos/279481_1053391/qid2920v1_h264_4050_1080_1.mp4_MySecr3tStr1ng_1743167062_1000k__1.2.3.4 
+url: http://gvideo.dev/videos/279481_1053391/qid2920v1_h264_4050_1080_1.mp4?md5=fhhV7JWE7c1HGjD7Vu5XsA&expires=1743167062&speed=1000k 
+
+string to sign: /videos/279481_1053391/qid2920v1_h264_4050_1080_1.mp4_MySecr3tStr1ng_1743167062_1000k_2000k_1.2.3.4 
+url: http://gvideo.dev/videos/279481_1053391/qid2920v1_h264_4050_1080_1.mp4?md5=by-olfoRZ3-Nntli7_2Ecw&expires=1743167062&speed=1000k&buffer=2000k
+```
+
+<Tabs>
+  <Tab title="Python">
+    ```python
+    import base64
+    from hashlib import md5
+    from time import time
+    from datetime import datetime, timezone, timedelta
+
+    def gethash_mp4(uri, secret, expires, speed, buffer, ip):
+        hash_body = "%s_%s_%d_%s_%s_%s" % (uri, secret, expires, speed, buffer, ip)   # set of unique parameters of video
+        hash_md5 =  base64.b64encode(                                                 # get MD5 hash from parameters of video
+            md5(hash_body.encode()).digest()
+        ).decode().replace("+", "-").replace("/", "_").replace("=", "")   # preparation for use in URL
+        return hash_md5
+
+    secret = ""                                             # enter your secret key from the CDN-resource
+    uri = "/videos/2675_pG8TfmKx2LU2qs/qid3570v1_h264_1800_720.mp4"   # path of the MP4 file
+
+    # current time
+    time_now = datetime.now(timezone.utc)
+    expires = int(time()) + 24 * 60 * 60            # expiration = now + 24 hours, unixtime in seconds
+    expires_dt = datetime.fromtimestamp(expires, tz=timezone.utc)
+    time_format = "%Y-%m-%d %H:%M:%S %Z"
+    print("Now:     ", int(time_now.timestamp()), time_now.strftime(time_format))
+    print("Expires: ", expires, expires_dt.strftime(time_format))
+
+    # MP4 protected (the CDN resource must be with deactivated option "Add a client's IP to the token")
+    token = gethash_mp4(uri, secret, expires, "", "", "")
+    print(f"https://demo-protected.gvideo.io{uri}?md5={token}&expires={expires}")
+    print(f"https://demo-protected.gvideo.io{uri}/download?md5={token}&expires={expires}")
+    print(f"https://demo-protected.gvideo.io{uri}/download=my-awesome-video?md5={token}&expires={expires}")
+
+    # MP4 with speed limit
+    speed = "1M"
+    token = gethash_mp4(uri, secret, expires, speed, "", "")
+    print(f"https://demo-protected.gvideo.io{uri}?md5={token}&expires={expires}&speed={speed}")
+
+    # MP4 with speed and buffer limit
+    speed = "500K"
+    buffer = "10M"
+    token = gethash_mp4(uri, secret, expires, speed, buffer, "")
+    print(f"https://demo-protected.gvideo.io{uri}?md5={token}&expires={expires}&speed={speed}&buffer={buffer}")
+
+    # MP4 protected with user's IP address (the CDN resource must be with activated option "Add a client's IP to the token")
+    ip = "92.223.112.84"
+    token = gethash_mp4(uri, secret, expires, "", "", ip)
+    print(f"https://demo-protected-ip.gvideo.io{uri}?md5={token}&expires={expires}")
+    print(f"https://demo-protected-ip.gvideo.io{uri}/download?md5={token}&expires={expires}")
+    print(f"https://demo-protected-ip.gvideo.io{uri}/download=my-awesome-video?md5={token}&expires={expires}")
+
+    # MP4 protected with user's IP address and speed limit
+    speed = "1000K"
+    token = gethash_mp4(uri, secret, expires, speed, "", ip)
+    print(f"https://demo-protected-ip.gvideo.io{uri}?md5={token}&expires={expires}&speed={speed}")
+
+    # MP4 protected with user's IP address, speed and buffer limit
+    speed = "500K"
+    buffer = "10M"
+    token = gethash_mp4(uri, secret, expires, speed, buffer, ip)
+    print(f"https://demo-protected-ip.gvideo.io{uri}?md5={token}&expires={expires}&speed={speed}&buffer={buffer}")
+
+    ```
+    Python playground – https://www.onlineide.pro/playground/share/d6126cff-e97f-456b-b667-6a95030563b4 
+  </Tab>
+  <Tab title="Go">
+    ```go
+    package main
+
+    import (
+      "crypto/md5"
+      "encoding/base64"
+      "fmt"
+      "time"
+    )
+
+    func gethash_mp4(uri, secret string, expires int64, speed, buffer, ip string) string {
+      hashBody := fmt.Sprintf("%s_%s_%d_%s_%s_%s", uri, secret, expires, speed, buffer, ip)
+      md5sum := md5.Sum([]byte(hashBody))
+      hashMd5 := base64.RawURLEncoding.EncodeToString(md5sum[:])
+      return hashMd5
+    }
+
+    const time_format string = "2006-01-02 15:04"
+
+    func main() {
+      var token, speed, buffer string
+
+      secret := ""                                                     // enter your secret key from the CDN-resource
+      uri := "/videos/2675_pG8TfmKx2LU2qs/qid3570v1_h264_1800_720.mp4" // path of the MP4 file
+
+      //timeNow := time.Now().UTC()
+      timeNow, _ := time.Parse(time_format, "2025-09-16 23:00") // workaround for Go playground. As you know time.Now() doesn’t work in goplay.tools, because playground runs in a deterministic sandboxed environment where system time is not exposed.
+      expires := timeNow.Add(24 * time.Hour).Unix()             // expiration = now + 24 hours, unixtime in seconds
+
+      fmt.Println("Now:     ", timeNow.Unix(), timeNow.UTC().Format(time_format))
+      fmt.Println("Expires: ", expires, time.Unix(expires, 0).UTC().Format(time_format))
+
+      // MP4 protected (the CDN resource must be with deactivated option "Add a client's IP to the token")
+      token = gethash_mp4(uri, secret, expires, "", "", "")
+      fmt.Printf("https://demo-protected.gvideo.io%s?md5=%s&expires=%d\n", uri, token, expires)
+      fmt.Printf("https://demo-protected.gvideo.io%s/download?md5=%s&expires=%d\n", uri, token, expires)
+      fmt.Printf("https://demo-protected.gvideo.io%s/download=my-awesome-video?md5=%s&expires=%d\n", uri, token, expires)
+
+      // MP4 with speed limit
+      speed = "1M"
+      token = gethash_mp4(uri, secret, expires, speed, "", "")
+      fmt.Printf("https://demo-protected.gvideo.io%s?md5=%s&expires=%d&speed=%s\n", uri, token, expires, speed)
+
+      // MP4 with speed and buffer limit
+      speed = "500K"
+      buffer = "10M"
+      token = gethash_mp4(uri, secret, expires, speed, buffer, "")
+      fmt.Printf("https://demo-protected.gvideo.io%s?md5=%s&expires=%d&speed=%s&buffer=%s\n", uri, token, expires, speed, buffer)
+
+      // MP4 protected with user's IP address (the CDN resource must be with activated option "Add a client's IP to the token")
+      ip := "92.223.112.84" //
+      token = gethash_mp4(uri, secret, expires, "", "", ip)
+      fmt.Printf("https://demo-protected-ip.gvideo.io%s?md5=%s&expires=%d\n", uri, token, expires)
+      fmt.Printf("https://demo-protected-ip.gvideo.io%s/download?md5=%s&expires=%d\n", uri, token, expires)
+      fmt.Printf("https://demo-protected-ip.gvideo.io%s/download=my-awesome-video?md5=%s&expires=%d\n", uri, token, expires)
+
+      // MP4 protected with user's IP address and speed limit
+      speed = "1000K"
+      token = gethash_mp4(uri, secret, expires, speed, "", ip)
+      fmt.Printf("https://demo-protected-ip.gvideo.io%s?md5=%s&expires=%d&speed=%s\n", uri, token, expires, speed)
+
+      // MP4 protected with user's IP address, speed and buffer limit
+      speed = "500K"
+      buffer = "10M"
+      token = gethash_mp4(uri, secret, expires, speed, buffer, ip)
+      fmt.Printf("https://demo-protected-ip.gvideo.io%s?md5=%s&expires=%d&speed=%s&buffer=%s\n", uri, token, expires, speed, buffer)
+    }
+    ```
+    Go playground – https://goplay.tools/snippet/iqktoxSaTh3
   </Tab>
 </Tabs>

--- a/streaming-platform/live-streaming/clips.mdx
+++ b/streaming-platform/live-streaming/clips.mdx
@@ -1,0 +1,114 @@
+---
+title: "Instant clips"
+sidebarTitle: "Clips"
+description: Creating instant video clips from a live stream
+---
+
+## Main principles
+
+Clips let you cut a segment from an ongoing live stream without waiting for the broadcast to end or the full recording to complete. 
+This is useful for quickly publishing highlights from sports, news, concerts, or other live events.
+
+Why use clips?
+  - Deliver important moments to viewers instantly, while the event is still live.
+  - Share highlights across platforms without waiting for full VOD processing.
+  - Convert a short live excerpt into a standalone asset in HLS (.m3u8), MP4, or as a permanent VOD.
+
+<Frame>![clip_recording_mp4_hls](https://demo-files.gvideo.io/apidocs/clip_recording_mp4_hls.gif)</Frame>
+
+Common use cases:
+  - Sports highlights – publish goals, replays, or decisive moments immediatelly after they happen.
+  - News coverage – cut and share breaking news segments without waiting for the full recording.
+  - Live performances – highlight songs, interviews, or standout moments from concerts or shows.
+
+
+## Clips vs. traditional VOD
+
+| Feature                | Traditional VOD                                       | Clips                                                       |
+|-------------------------|-------------------------------------------------------|-------------------------------------------------------------|
+| **Source**             | Recording of the full live stream                      | Raw data from the ongoing live stream                       |
+| **Availability**       | Only after the live stream has ended and transcoding completes | Immediately after the selected segment is copied from DVR    |
+| **Use case**           | Full replays, long-term storage, on-demand catalogs    | Highlights, instant sharing, short previews                 |
+| **Formats**            | HLS, DASH, MP4 (transcoded renditions)                 | HLS, MP4                 |
+| **Latency to publish** | Minutes (depends on stream length & transcoding time) | Seconds (available right after clip duration ends)           |
+| **Lifetime**           | Permanent until manually deleted                       | Temporary (controlled by `expiration`)           |
+| **Storage impact**     | Requires full file storage                             | Lightweight, **stored in server memory** until expiration               |
+| **Conversion to VOD**  | N/A (already VOD)                                      | Can be converted to permanent VOD with `vod_required: true`  |
+| **Best for**           | Full-event replays, archives, monetization catalogs    | Instant highlights, social media snippets, news flashes      |
+
+
+## Clips lifetime
+
+Instant clips are a copy of the stream from DVR buffer.
+They are stored in memory for a limited time, after which the clip ceases to exist and you will receive a 404 on the link.
+
+Limits that you should keep in mind:
+  - The clip’s lifespan is controlled by `expiration` parameter.
+  - The default expiration value is 1 hour. The value can be set from 1 minute to 4 hours (but not more than the DVR duration of the stream, see the section below).
+  - If you want a video for longer or permanent viewing, then create a traditional VOD based on the clip. This way you can use the clip’s link for the first time, and immediately after the transcoded version is ready, you can change by yourself it to a permanent link of VOD.
+  - The clip becomes available only after it is completely copied from the live stream. So the clip will be available after `start + duration` exact time. If you try to request it before this time, the response will be error code 425 “Too Early”.
+
+
+## Cutting a clip from live stream
+
+API method – [`PUT /streaming/streams/{stream_id}/clip_recording`](/api-reference/streaming/streams/create-clip)
+```
+curl -L -X PUT 'https://api.gcore.com/streaming/streams/2409264/clip_recording' \
+-H 'Content-Type: application/json' \
+-H 'Authorization: APIKey 1234$1d3...d11' \
+-d '{
+  "duration": 60
+}'
+```
+
+Clips generation uses DVR buffer of a live stream. In order to use clips recording feature, DVR must be enabled for a stream: `dvr_enabled: true`. 
+You can generate a clip from any part of DVR window by specifying the start time and duration. Read more about DVR window on the page [DVR, Pause and rewind the live streams](/streaming-platform/live-streaming/pause-and-rewind-the-live-streams).
+
+Therefore, to create a clip, the DVR must have the necessary data for timeframe you would like to save. However, once a clip is created, it exists as an independent copy and remains accessible until its time expires, even if the DVR window has already expired.
+
+
+## Getting a clip
+
+Instant clip becomes available for viewing in the following formats:
+  - HLS .m3u8 with ABR,
+  - MP4 in different renditions,
+  - VOD in video hosting with a permanent link to watch video.
+
+Clips are cut on the server-side using video keyframes. While you can't specify the start and end times down to the millisecond, the edegs will be selected as close as possible to the nearest keyframe based on the timing you specify.
+One advantage of this approach is that clips aren't created by temporarily removing .ts files from the .m3u8 manifest and aren't dependent on chunk length.
+
+Example:
+```
+{
+    "id": "eycnb3utc6bk",
+    "start": 1758113719,
+    "duration": 60,
+    "expiration": 1758117379,
+    "created_at": "2025-09-17T12:55:19.393328284Z",
+    "vod_required": true,
+    "video_id": 11969118,
+    "renditions": [
+        "media_0_720",
+        "media_1_468",
+        "media_2_360"
+    ],
+    "hls_master": "https://cid.domain.com/rec/111_1000/rec_eycnb3utc6bk_qsid42_master.m3u8",
+    "mp4_master": "https://cid.domain.com/rec/111_1000/rec_eycnb3utc6bk_qsid42_master.mp4"
+}
+```
+
+By default, URLs include the master alias, which resolves to the highest available quality in the ABR set (based on video height metadata). 
+You can also request a specific rendition manually: replace `master` in the URL with a value from the renditions list to access an exact bitrate/quality. This applies to both HLS and MP4 outputs.
+
+Example:
+  - HLS ABR: `https://cid.domain.com/rec/111_1000/rec_eycnb3utc6bk_qsid42_master.m3u8`
+  - HLS 360p: `https://cid.domain.com/rec/111_1000/rec_eycnb3utc6bk_qsid42_media_0_720.m3u8`
+  - MP4 max: `https://cid.domain.com/rec/111_1000/rec_eycnb3utc6bk_qsid42_master.mp4`
+  - MP4 360p: `https://cid.domain.com/rec/111_1000/rec_eycnb3utc6bk_qsid42_media_2_360.mp4`
+
+
+## Getting permanent VOD
+
+To get permanent VOD version of a live clip use this parameter when making a request to create a clip: `vod_required: true`. 
+
+Later, when the clip is ready, grab `video_id` value from the response and query the video by regular `GET /streaming/video/` endpoint.

--- a/streaming-platform/live-streaming/create-and-configure-a-restream-to-social-media.mdx
+++ b/streaming-platform/live-streaming/create-and-configure-a-restream-to-social-media.mdx
@@ -112,6 +112,6 @@ If there is a problem getting the original stream, it will be re-requested multi
 1)  Original stream is active
 2)  If the original stream is unavailable and is down for more than ±3 seconds:
     1) The system will activate the retry mechanism.
-3)  The system will attempt to re-request (PULL) the original stream for approximately 10 minutes. 
+3)  The system will attempt to re-request (PULL) the original stream for approximately 60 minutes. 
     1) If original stream is back, the timer is reset to zero and the restream is restored. 
     2) Otherwise the restream stops permanently. To resume it, you will have to activate it manually or via API.

--- a/streaming-platform/live-streaming/primary-backup.mdx
+++ b/streaming-platform/live-streaming/primary-backup.mdx
@@ -129,6 +129,31 @@ By setting location correctly, you can minimize latency and improve performance.
 [Reach out to our support team](https://gcore.com/contact-us) or your account manager for setup assistance.
 
 
+## Stream availability
+
+A live stream typically requires a short initialization period before playback becomes available.
+Our system initializes all required services within ~2–5 seconds, from receiving a live stream at the ingester to publishing segments on the CDN.
+
+<Info>
+  Stream segments become available in the CDN (and player) within ~2–5 seconds after the `type: stream (live=true)` webhook is issued.
+</Info>
+
+Workflow when starting a stream on server:
+  - Accept and check the stream on the ingester
+  - Initialize the stream
+  - **Send a webhook**
+  - Start the transcoding process
+  - Publish the first segment to the CDN
+  - **Playback available** – here your player can start downloading video segments
+
+The table below compares how different platforms approach latency reduction. We evaluated multiple implementations and identified best practices for minimizing delay.
+
+<Frame>![Timing of live streaming](https://assets.gcore.pro/site-media/uploads-staging/how_we_solve_issues_of_rtmp_to_hls_streaming_on_ios_and_android_2_c737a90322.svg)</Frame>
+
+By collaborating with streaming platforms that deliver RTMP-to-HLS on iOS and Android, we defined best practices: optimize GOP size, enable background streaming, trigger player startup at the optimal moment, and adjust bitrate and delivery region dynamically. These improvements enhance playback stability, minimize startup delay, and reduce rebuffering.
+Read more in the blog article [How we solve issues of RTMP-to-HLS streaming on iOS and Android](https://gcore.com/blog/how-we-solve-issues-of-rtmp-to-hls-streaming-on-ios-and-android).
+
+
 ## Players behavior 
 
 Please note that the manifesto and fragments will be available again at the time indicated above. Consider your player configuration for automatic playback of restored live stream. Some players resume playback with a large delay automatically. But if you update them manually, the video will appear instantly.
@@ -141,7 +166,7 @@ For example:
   manifestLoadingMaxRetry: 10,
   manifestLoadingRetryDelay: 1000,
 
-  dasj.js:
+  dash.js:
   retryAttempts: { manifest: 100, media: 10, lowLatency: 10 },
   retryIntervals: { manifest: 1_000, media: 1_000, lowLatency: 1_000 },
   rebufferToLive: true,

--- a/streaming-platform/live-streaming/protocols/srt.mdx
+++ b/streaming-platform/live-streaming/protocols/srt.mdx
@@ -200,7 +200,7 @@ Practical setup notes:
  - Parameter location: Latency must be set on the sender side (caller or listener mode). Receiver should be equal or higher.
  - Default values are often too low (e.g., 120 ms) for WAN paths, which can cause instability.
  - Monitoring: Check SRT statistics for retransmissions, buffer usage, and packet drops. If drops occur, increase latency in steps of 100–200 ms.
- - In most cases URL attribute `latency` requiress a value in microseconds, so set it correctly – [ffmpeg](https://ffmpeg.org//ffmpeg-protocols.html#srt)
+ - Read your encoder docs carefully to see what the `latency` attribute is and what units it uses: s, ms, µs. In most cases, it will be ms (milliseconds). In the demo-script above we use ffmpeg so attribute `latency` requiress a value in µs (microseconds) – [ffmpeg](https://ffmpeg.org//ffmpeg-protocols.html#srt)
  - Encoder settings:
     - Enable tsbpd=1 (timestamp-based delivery).
     - Cap stream bitrate to ~70–80% of available uplink.
@@ -210,8 +210,8 @@ Practical setup notes:
 Also check official SRT statistics documentation – [github](https://github.com/Haivision/srt/blob/master/docs/API/statistics.md)
 
 Enable sender-side SRT stats and watch these fields:
- - RTT and jitter: round-trip time, variability. Drives latency sizing.  ￼
- - Loss and retransmissions: pkt*Loss, pkt*Retrans, pkt*Drop. Rising values → increase latency or reduce bitrate.  ￼
- - Throughput/bandwidth: current/peak send rate vs configured caps.  ￼
- - Buffer occupancy: send/receive buffer fill vs negotiated latency; approaching 0 under loss means too low latency.  ￼
+ - RTT and jitter: round-trip time, variability. Drives latency sizing.
+ - Loss and retransmissions: `pkt*Loss`, `pkt*Retrans`, `pkt*Drop`. Rising values → increase latency or reduce bitrate.
+ - Throughput/bandwidth: current/peak send rate vs configured caps.
+ - Buffer occupancy: send/receive buffer fill vs negotiated latency; approaching 0 under loss means too low latency.
  - Flight/window size, MSS/packet size: detects fragmentation or congestion.

--- a/streaming-platform/video-hosting/ai-for-video/generate-ai-subtitles-and-add-them-to-video.mdx
+++ b/streaming-platform/video-hosting/ai-for-video/generate-ai-subtitles-and-add-them-to-video.mdx
@@ -3,16 +3,28 @@ title: Generate and translate captions
 sidebarTitle: Generate and translate captions
 ---
 
+## Introduction
+
 Gcore [AI automated speech recognition (ASR)](https://gcore.com/streaming-platform/ai-for-video) functionality allows you to automatically generate [video captions](/streaming-platform/video-hosting/subtitles-and-closed-captions-for-vod#what-are-subtitles-and-closed-captions) (also referred to as subtitles) using AI models. This serves two use cases: 
 
   * **Transcription** : Generate video captions from the original audio. Our AI models transcribe the speech of one or multiple speakers, even if they use different languages. 
   * **Translation** : Translate captions into more than 100 languages to make your video accessible to multilingual audiences.
 
+HTML player with AI automatically generated captions:
+<iframe
+  src="https://player.gvideo.co/videos/2675_iKbrdNMcS9ylGuw?&sub_lang=en"
+  width="100%"
+  height="360"
+  loading="lazy"
+  allow="autoplay; fullscreen; picture-in-picture"
+  allowFullScreen
+/>
 
 
 ## How it works
 
 We use [Whisper ASR](https://openai.com/research/whisper) from OpenAI, along with a range of other specialized AI models. These AI ASR models operate on the Gcore infrastructure, so no files are transferred to external services. After processing, all original files are also deleted from the AI system's local storage. 
+
 
 ## Key benefits
 
@@ -20,7 +32,6 @@ We use [Whisper ASR](https://openai.com/research/whisper) from OpenAI, along wit
   * **Supported languages.** AI can recognize and transcribe audio in over 100 languages worldwide. If your desired language isn't listed, please contact [Gcore support team](maito:support@gcore.com), and we'll consider adding it in the future. 
   * **Multi-platform support**. Generate video captions for any MP4 video that's uploaded to Gcore Video Hosting or stored externally, for instance, on AWS. 
   * **Multi-language support.** We support the recognition of multiple spoken languages in a single video (the "code-switching" feature). This accounts for video participants switching between several languages in their speech.
-
 
 
 ## Generate and translate AI captions for your video content

--- a/streaming-platform/video-hosting/hls-and-mp4.mdx
+++ b/streaming-platform/video-hosting/hls-and-mp4.mdx
@@ -64,12 +64,8 @@ Where:
 
 
 For example, check out the following manifest links for a master playlist: 
-
-  * The link to the master playlist: https://demo-public.gvideo.io/videos/2675_FnlHXwA16ZMxmUr/master.m3u8
-
-  * The link to the master playlist with CMAF-based chunks: https://demo-public.gvideo.io/videos/2675_FnlHXwA16ZMxmUr/master-cmaf.m3u8
-
-
+  - The link to the master playlist: https://demo-public.gvideo.io/videos/2675_FnlHXwA16ZMxmUr/master.m3u8
+  - The link to the master playlist with CMAF-based chunks: https://demo-public.gvideo.io/videos/2675_FnlHXwA16ZMxmUr/master-cmaf.m3u8
 
 
 ## DASH format
@@ -91,8 +87,8 @@ Video content delivered in DASH format contains a manifest file (.mpd). This fil
 
 For DASH, chunks will also differ depending on the type of video codec that was used to encode the quality: 
 
-  * CMAF chunks for H264 and H265 video codecs 
-  * WebM chunks for AV1 video
+  - CMAF chunks for H264 and H265 video codecs 
+  - WebM chunks for AV1 video
 
 
 
@@ -142,6 +138,8 @@ Example of the manifest link:  https://demo-public.gvideo.io/videos/2675_FnlHXwA
 
 ## MP4 format
 
+### MP4 as a source
+
 Video can be streamed and downloaded using the .mp4 file format when you want to handle the whole file at once instead of in chunks. MP4 format allows users to:
 
   * Watch videos offline on mobile devices
@@ -150,43 +148,59 @@ Video can be streamed and downloaded using the .mp4 file format when you want to
   * Share videos on social networks and other streaming services
   * Content can be protected with [Secure Token](/streaming-platform/extra-features/protect-your-content-with-temporary-links-and-secure-tokens#how-to-enable-the-secure-token-feature). DRM protection isn't supported.
 
-
-
 When using the MP4 format, users can work with each available video resolution separately. For example, select the video quality version (720p) and download only that version: https://demo-public.gvideo.io/videos/2675_FnlHXwA16ZMxmUr/qid3570v3_h264_1566_720.mp4
 
 Example usage:
-
 ```html
 <video width="100%" height="auto" autoplay="autoplay" loop="true" playsinline="" oncanplay="this.play()">
      <source type="video/mp4" src="https://demo-public.gvideo.io/videos/2675_FnlHXwA16ZMxmUr/qid3570v3_h264_1566_720.mp4"/>
 </video>
  ```
 
+Link to the MP4 file contains information about the encoding method using format: 
+```
+<quality_version>_<codec>_<bitrate>_<height>.mp4
+```
+Where: 
+  - `<quality_version>` – Internal quality identifier and file version
+  - `<codec>` – Codec name that was used to encode the video, or audio codec if it is an audio-only file
+  - `<bitrate>` – Encoding bitrate in Kbps
+  - `<height>` – Video height, or word "audio" if it is an audio-only file
+
+Example: ``` /videos/{client_id}_{slug}/qid3567v1_h264_4050_1080.mp4 ```
+
+<Info>
+Avoid storing or relying on direct MP4 file links. These URLs are internal and dynamically generated, and their structure may change at any time without prior notice.
+</Info>
+
+
+### MP4 custom download
+
 Gcore supports regular download requests for entire MP4 file downloads. For each converted video, additional download endpoints are available from API. 
 An MP4 download enpoints look like:
-  - `/videos/{client_id}_{slug}/{filename}.mp4`
-  - `/videos/{client_id}_{slug}/{filename}.mp4/download`
-  - `/videos/{client_id}_{slug}/{filename}.mp4/download={custom_filename}`
+  1.  `/videos/{client_id}_{slug}/{filename}.mp4`
+  2.  `/videos/{client_id}_{slug}/{filename}.mp4/download`
+  3.  `/videos/{client_id}_{slug}/{filename}.mp4/download={custom_filename}`
 
 The first option returns the file as is.
 Response will be:
-```
-  GET .mp4
-  ...
-  content-type: video/mp4
+```sh
+GET /qid3576v3_h264_450_360.mp4
+...
+content-type: video/mp4
 ```
 
-The second option with /download will respond with HTTP response header that directly tells browsers to download the file instead of playing it in the browser:
+The second option with `/download` will respond with HTTP response header that directly tells browsers to download the file instead of playing it in the browser:
 
 ``` 
-  GET .mp4/download
-  ...
-  content-type: video/mp4
-  content-disposition: attachment
-  access-control-expose-headers: Content-Disposition
+GET /qid3576v3_h264_450_360.mp4/download
+...
+content-type: video/mp4
+content-disposition: attachment
+access-control-expose-headers: Content-Disposition
 ```
 
-The third option allows you to set a custom name for the file being downloaded. 
+The third option with `/download={custom_filename}` allows you to set a custom name for the file being downloaded. 
 Filename constraints:
   - Length: 1-255 characters
   - Must NOT include the .mp4 extension (it is added automatically)
@@ -195,17 +209,53 @@ Filename constraints:
   - Example valid filenames: ```holiday2025```, ```_backup.final```, ```clip-v1.2```
 
 ```  
-  GET .mp4/download={custom_filename}
-  ...
-  content-type: video/mp4
-  content-disposition: attachment; filename="{custom_filename}.mp4"
-  access-control-expose-headers: Content-Disposition                    
+GET /qid3576v3_h264_450_360.mp4/download={custom_filename}
+...
+content-type: video/mp4
+content-disposition: attachment; filename="{custom_filename}.mp4"
+access-control-expose-headers: Content-Disposition                    
 ```
 
 Example:
-- Video: ```https://demo-public.gvideo.io/videos/2675_1OFgHZ1FWZNNvx1A/qid3567v1_h264_4050_1080.mp4/download```
-- Video with custom download filename: ```https://demo-public.gvideo.io/videos/2675_1OFgHZ1FWZNNvx1A/qid3567v1_h264_4050_1080.mp4/download=highlights_v1.1_2025-05-30```
+- MP4 as is: ```https://demo-public.gvideo.io/videos/2675_1OFgHZ1FWZNNvx1A/qid3567v1_h264_4050_1080.mp4/download```
+- MP4 with custom download filename "`highlights_v1.1_2025-05-30`.mp4": ```https://demo-public.gvideo.io/videos/2675_1OFgHZ1FWZNNvx1A/qid3567v1_h264_4050_1080.mp4/download=highlights_v1.1_2025-05-30```
 
+
+### MP4 dynamic speed limiting
+
+This mode sets download limits for requests. To activate limits use special attributes in in a query string. 
+The `speed` sets the maximum download speed, while the buffer sets how much data will be transferred without the speed limit. The buffer argument is optional.
+
+Example with limit download speed to 500KB/s after downloading 10MB.
+``` 
+curl -L -o /dev/null -w "%{speed_download}\n" \
+"https://demo-public.gvideo.io/videos/2675_1OFgHZ1FWZNNvx1A/qid3576v1_h264_450_360.mp4?speed=500K&buffer=10M" \           
+| awk '{printf "Download speed: %.2f KB/s (%.2f MB/s)\n", $1/1024, $1/1048576}'
+
+  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
+                                 Dload  Upload   Total   Spent    Left  Speed
+100 14.4M  100 14.4M    0     0   501k      0  0:00:29  0:00:29 --:--:--  467k
+
+Download speed: 501.86 KB/s (0.49 MB/s)
+```
+
+
+### MP4 advanced secure token protection 
+
+A regular secure token protects the entire video entity, so it allows to play HLS/DASH ABR securely.
+
+When you need to distribute MP4 files separatelly from ABR use an advanced secure token provided as an additional query parameter. This ensures that only authorized requests can access a given MP4 version and prevents unauthorized distribution across qualities.
+MP4 advanced secure token can be combined with MP4 speed limit.
+
+Example:
+```
+???
+```
+
+Read more on the page [Protected temporary link](/streaming-platform/extra-features/protect-your-content-with-temporary-links-and-secure-tokens#advanced-secure-token-for-mp4).
+
+
+### MP4 range request
 
 We also support range requests specifying the HTTP "Range" header.
 
@@ -217,13 +267,17 @@ content-type: video/mp4
 content-length: 38878900
 content-range: bytes 4000000-42878899/42878900
 ...
- ```
+```
 
 <Tip>
 **Tip**
 
 You can protect MP4 files with the [Video protection via the Security Tokens feature](/streaming-platform/extra-features/protect-your-content-with-temporary-links-and-secure-tokens).
 </Tip>
+
+
+
+
 
 ## Get HLS, DASH, and MP4 links
 

--- a/streaming-platform/video-hosting/original-files.mdx
+++ b/streaming-platform/video-hosting/original-files.mdx
@@ -1,19 +1,21 @@
 ---
-title: "Original Files"
-description: "This article explains the storage of the original files uploaded for VOD streaming"
+title: "Download files"
+description: "This article explains the storage and capability to download transcoded versions"
 ---
 
 An original (video) file is a file you created when recording a video. In contrast to this original file, you can have multiple transcoded renditions with different video codecs or resolutions. These renditions are made from the original file, which forms the upper limit for the transcoding quality.
-
-When you upload an original video file to Gcore Video Streaming, it transcodes the file for [multiple codecs and resolutions](https://gcore.com/docs/streaming-platform/video-hosting/hls-and-mp4) to ensure viewers can watch it regardless of device performance, display resolution, or connection speed.
 
 <Info>
   **Gcore Video Streaming deletes the uploaded original files** after the transcoding is completed, so don’t rely on it to back up your originals.
 </Info>
 
+When you upload an original video file to Gcore Video Streaming, it transcodes the file for [multiple codecs and resolutions](/streaming-platform/video-hosting/hls-and-mp4) to ensure viewers can watch it regardless of device performance, display resolution, or connection speed.
+
+
 ## Download transcoded files
 
 While the original files aren’t available for download, you can get the transcoded files via the Gcore Customer Portal.
+
 
 ### Step 1. Open the Video Settings
 
@@ -21,12 +23,14 @@ You can find the video by navigating to **Gcore** **Customer Portal \> Streaming
 
 ![Original Files Vod 1 Pn](/images/original-files-vod-1.png)
 
+
 ### Step 2. Select video quality
 
 Scroll down the **Video Settings** until you see the **Download video** section on the bottom right, and select your desired **Video quality**.
 
 ![Original Files Vod 2 Pn](/images/original-files-vod-2.png)
 
-## Step 3. Finalize the download
+
+### Step 3. Finalize the download
 
 Click the **Download video** button to download the transcoded MP4 file.

--- a/streaming-platform/video-hosting/upload-video-via-api.mdx
+++ b/streaming-platform/video-hosting/upload-video-via-api.mdx
@@ -24,57 +24,27 @@ Only videos that follow these specifications (supported protocols, video/audio c
 
 ## Video upload and processing statuses
 
-When uploading a video to our storage and its processing, the file may have one of the following statuses: 
-
-  * **Empty** means the video entity has been created, but the origin video file has not yet been uploaded. In case of a long delay, check the "error" field for more details. 
-  * **Pending** means the video is being processed; the original video file has been downloaded and submitted for processing.
-  * **Viewable** means the video is available for watching at least in 1 quality (but not in all qualities.)
-  * **Ready** means the video is ready and available in all qualities.
+Statuses of video processing are described in the [Video Status article](/streaming-platform/video-hosting/vod-status).
 
 
+## Priority of processing
 
-**Note** : In the status "Viewable," manifest.m3u8 has already been generated. End users in any player can watch the video, but a limited number of qualities are available. Qualities will be added automatically to manifest.m3u8 as they are ready; you don't have to do anything. After adding all qualities, the video will be moved to "Ready."
+Every uploaded video enters a processing queue. 
 
-Example of the response of a video under processing:
+Scheduling is influenced by two levels of priority:
+	- Global priority – Managed automatically by the system on global scale. You cannot influence on it. It depends on converter availability in the processing cluster. This ensures that even without a dedicated region (this an option for enterprises), your videos usually start processing without significant delay.
+	- Account priority – Applied within your account. You can control it explicitly using the priority attribute.
 
-```json
-{ 
-  "id": 2558721, 
-  "name": "Gcore Demo", 
-  "description": "Video copied from an external S3 Storage", 
-  "status": "pending", 
-  "screenshots": [], 
-  "origin_url": "https://demo-files.gvideo.io/gcore.mp4", 
-  ... 
-  "converted_videos": [ 
-    { 
-      "name": "vod480n", 
-      "progress": 0, 
-      "status": "processing", 
-      "error": "", 
-      ... 
-   }, 
-   ... 
-  ] 
-}  
- ```
+You can control account priority using the `priority` field in uploaded videos. This field controls scheduling order for video processing tasks within your account. It lets you influence transcoding queue behavior when some jobs should be processed earlier than others (e.g., urgent uploads or sub-user on higher service tiers).
+Field `priority` in `POST /streaming/videos` method:
+	- Type: integer
+	- Range: -10 … 10
+	  - -10 = lowest priority (processed after others)
+	  - 0 = default priority
+	  - 10 = highest priority (processed first)
 
-If the video fails while uploading and checking, it will remain in "empty" status with details in the "error" field. Most commonly, this happens when an end user uploads a non-video file or has a connectivity issue. In that case, re-upload the video from the origin, or delete the entity and create a new one with the correct video file.
+This value does not guarantee absolute ordering but adjusts relative job weight in the processing queue.
 
-Example of the response if an error occurs during video processing:
-
-```json
-{ 
-  "id": 2558799, 
-  "name": "Gcore Demo", 
-  "description": "Video copied from an external S3 Storage", 
-  "status": "empty", 
-  "error": "File Invalid", 
-  "origin_url": "https://demo-files.gvideo.io/hls/master.m3u8", 
-  ... 
-  "converted_videos": [] 
-}  
- ```
 
 ## Copy from external storage
 
@@ -91,8 +61,10 @@ Available protocols for migration:
   * SFTP protocol
 
 
+<Info>
+The original file must be in MP4 format or one of the following formats: 3g2, 3gp, asf, avi, dif, dv, flv, f4v, m4v, mov, mp4, mpeg, mpg, mts, m2t, m2ts, qt, wmv, vob, mkv, ogv, webm, vob, ogg, mxf, quicktime, x-ms-wmv, mpeg-tts, vnd.dlna.mpeg-tts.
+</Info>
 
-**Note** : The original file must be in MP4 format or one of the following formats: 3g2, 3gp, asf, avi, dif, dv, flv, f4v, m4v, mov, mp4, mpeg, mpg, mts, m2t, m2ts, qt, wmv, vob, mkv, ogv, webm, vob, ogg, mxf, quicktime, x-ms-wmv, mpeg-tts, vnd.dlna.mpeg-tts.
 
 Streaming formats like HLS (.m3u8/.ts) and DASH (.mpd/.m4v) are intended for the final video distribution to end viewers, so they cannot be used as original file formats.
 
@@ -335,6 +307,14 @@ Most common TUS errors:
     * Error: token video (12345) does not match this video (23456)
     * Error: token client (123) does not match this client (234)
 
+
+## AI extra processing
+
+When uploading a video, it is possible to automatically create subtitles based on AI. 
+
+Use parameters `auto_transcribe_audio_language: auto|<language_code>` and `auto_translate_subtitles_language: default|<language_codes,>` when creating a new video via API. 
+
+Read more on the page [Generate and translate AI captions for a new VOD](/streaming-platform/ai-video-service/generate-ai-subtitles-and-add-them-to-video/generate-captions-via-api).
 
 
 ## Batch upload to migrate a vast number of videos from other services

--- a/streaming-platform/video-hosting/vod-status.mdx
+++ b/streaming-platform/video-hosting/vod-status.mdx
@@ -1,0 +1,248 @@
+---
+title: "Video Lifecycle and Statuses"
+sidebarTitle: "Status"
+description: Understanding Video Transcoding and Processing Statuses
+---
+
+## VOD Status
+
+When a video is uploaded and processed, the status field reflects the current state of the file:
+  - `Empty` – Video entity created, but no source file has been uploaded yet. For prolonged delays, inspect the error field.
+  - `Pending` – Source file uploaded and queued for processing.
+  - `Viewable` – **Playback available already**. At least one rendition is available for playback, but not all target renditions are complete.
+  - `Ready` – Playback in all qualities. All renditions have been successfully processed and are available for playback.
+  - `Error` – Processing failed. Details available in the `error` field.
+
+<Info>
+**When playback starts:**
+
+Playback becomes available immediately when the video reaches `Viewable` status, even if only a subset of renditions is ready. 
+
+Additional renditions are appended automatically to manifest.m3u8 and master.mpd as processing completes. When all renditions are available, the status transitions to `Ready`. 
+So no waiting for `Ready` is required to start playback.
+</Info>
+
+
+Workflow: 
+```
+    Empty -> Pending -> Viewable -> Ready
+    [Any status] -> Error
+```
+
+
+Example of a response for a video under processing:
+
+```json
+{ 
+  "id": 2558721, 
+  "name": "Gcore Demo", 
+  "description": "Video copied from an external S3 Storage", 
+  "status": "pending", 
+  "screenshots": [], 
+  "origin_url": "https://demo-files.gvideo.io/gcore.mp4", 
+  ... 
+  "converted_videos": [ 
+    { 
+      "name": "vod480n", 
+      "progress": 0, 
+      "status": "processing", 
+      "error": "", 
+      ... 
+   }, 
+   ... 
+  ] 
+}  
+ ```
+
+If the video fails while uploading and checking, it will remain in "empty" status with details in the "error" field. Most commonly, this happens when an end user uploads a non-video file or has a connectivity issue. In that case, re-upload the video from the origin, or delete the entity and create a new one with the correct video file.
+
+Example of the response if an error occurs during video processing:
+
+```json
+{ 
+  "id": 2558799, 
+  "name": "Gcore Demo", 
+  "description": "Video copied from an external S3 Storage", 
+  "status": "empty", 
+  "error": "File Invalid", 
+  "origin_url": "https://demo-files.gvideo.io/hls/master.m3u8", 
+  ... 
+  "converted_videos": [] 
+}  
+ ```
+
+## Uploading process
+
+Process of uploading is described in the [Upload video via API article](/streaming-platform/video-hosting/upload-video-via-api).
+
+Briefly:
+	1.	You create a video (TUS upload or copy from external origin_url).
+	2.	Backend schedules transcodes for the target quality set.
+	3.	Each rendition becomes an item in `converted_videos`. Fields update as jobs run.
+
+
+## Renditions status
+
+Each video entity is transcoded into several qualities – each such individual quality is called a **rendition**.
+So for a video entity there is always a set of renditions with specified parameters: quality and size. 
+
+An array of renditions for each playback of the video entity in API has name of `converted_videos`. Each element contains playback metadata for the rendition and status of processing.
+
+Status lifecycle per rendition:
+  - `processing` – transcode job accepted and running for this quality.
+  - `complete` – rendition finished. mp4_url becomes available and the quality is appended to HLS/DASH manifests.
+  - `error` – rendition failed. Inspect the item’s error string.  ￼
+
+<Info>
+**When playback starts:**
+
+Playback can be started once at least one rendition is `complete`. Additional renditions appear automatically as they complete. No need to wait for all renditions are ready.
+</Info>
+
+What you can read from each rendition (read more in API [GET `/streaming/videos/{video_id}`](/api-reference/streaming/videos/get-video#response-converted-videos)):
+  - Dimensions and approximate bitrate proxy: width, height, size.
+  - Completion percent: progress (0–100).
+  - Availability: status, mp4_url presence.
+  - Failure reason: error.
+  - Name/label for UI or logging: name (e.g., vod720p).  ￼
+
+Transcoder workers report the state of each rendition. The API translates these states into processing, complete, or error, and updates the converted_videos array in the response of GET `/streaming/videos/{video_id}`. Completion events can also be delivered via webhooks. Read more about [Webhooks here](/streaming-platform/extra-features/get-webhooks-from-the-streaming-platform#webhooks-for-vod). ￼
+
+
+## Long video processing
+
+The duration of video transcoding is directly proportional to the length of the original video. A 1 minute video will be processed in a matter of seconds. A 10 hour video will take a long time to process, possibly tens of minutes due to a queue of other videos.
+
+All renditions are queued at the same time. Remember that the lower the quality, the easier it is to transcode and the faster you can get the result. That's why SD and other medium resolutions often become available faster than 1080, 2K and 4K.
+
+
+## Error handling
+
+During upload and processing, the API may return errors in the `error` field of the video object or in a specific rendition (`converted_videos[i].error`).  
+Each error indicates the reason why the system was unable to fetch, parse, or process the video file.  
+
+If a video remains in `empty` or `pending` state for long period, inspect the check the `error` field and check corresponding `converted_videos[].status` values for details.
+In most cases, the video cannot be processed correctly due to problems with the original file. It may not fit to [recommended input parameters](/streaming-platform/live-streams-and-videos-protocols-and-codecs/input-parameters-and-codecs).
+
+If you encounter an error, first check the error message against the list below. Then validate your input (URL, headers, original video file) and retry the operation. If the issue persists or is caused by quota limitations, contact the Support Team.
+
+| Error message                                   | Description                                                                   |
+|-------------------------------------------------|-----------------------------------------------------------------------------------------|
+| **Encoding problems**                           |                                                                                         |
+| Encoding has failed                             | Transcoding stopped due to broken/corrupted frames. Ensure source file is playable.     |
+| Unable to analyze the origin file               | File structure could not be parsed. Confirm input format.                               |
+| Unable to validate video file                   | File validation failed. Confirm input format.                                           |
+| Video file has codec parameters issue           | Codec parameters unsupported. Check codec against system requirements.                  |
+| Video file has empty streams                    | No video streams detected in file. Validate content before upload.                      |
+| Video file is invalid                           | File is not a recognized format or container. Verify input format.                      |
+| **Clips**                                       |                                                                                         |
+| Requested encoding duration exceeds clip length | Requested clip duration exceeds actual file duration. Review start/end range.           |
+| **Limits**                                      |                                                                                         |
+| The storage limit has been exceeded             | Storage or encoding quota exceeded. Contact support to increase limits.                 |
+| **Migration from external origin**              |                                                                                         |
+| Access to the origin is forbidden               | `origin_url` requires authentication but failed. Check URL and `origin_http_headers`.   |
+| Connection reset by peer                        | `origin_url` exists but the external server dropped the connection.                     |
+| Network timeout occurred                        | `origin_url` exists but external server did not respond. Network timeout occurred.      |
+| The downloaded file is incomplete               | File download started but finished incomplete. Validate the URL and source server.      |
+| The requested origin was not found              | `origin_url` points to a non-existent HTTP resource. Verify the URL.                    |
+
+
+Example:
+```sh
+GET /streaming/videos/{video_id}
+{
+    "id": 11936778,
+    "status": "viewable",
+    "error": "The storage limit has been exceeded",
+    ...
+}
+```
+
+Other problems you can see in UI and solution are described in the [VOD issues article](/streaming-platform/troubleshooting/vod-issues).
+
+
+## Demo video with "viewable" status
+
+We prepared a demo video which has the status `viewable` and was not fully processed. In this demo video, one quality has a deliberate conversion error.
+
+HTML player:
+<div style={{ display: "flex", justifyContent: "center" }}>
+<iframe
+  src="https://player.gvideo.co/videos/2675_vGcX1W3aTFEL"
+  height="480"
+  width="270"
+  loading="lazy"
+  allow="autoplay; fullscreen; picture-in-picture"
+  allowFullScreen
+/>
+</div>
+
+The video itself is already available for playback and download, you can see in the player above. 
+However, the rendition "vod1080p" encountered a storage space limitation problem and has an "error" status.
+
+Status:
+  - Entity status: `viewable`
+  - Renditions status: 
+    - vod360p: `complete`
+    - vod480p: `complete`
+    - vod720p: `complete`
+    - vod1080p: `error`
+
+
+In master.m3u8 you will see 3 completed renditions:
+```
+curl https://demo-public.gvideo.io/videos/2675_vGcX1W3aTFEL/master.m3u8
+
+#EXTM3U
+#EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=1800000,RESOLUTION=720x1280,FRAME-RATE=23.980,CODECS="avc1.64001f",VIDEO-RANGE=SDR
+index-s0q3570v1-v1.m3u8
+#EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=800000,RESOLUTION=468x832,FRAME-RATE=23.980,CODECS="avc1.4d401e",VIDEO-RANGE=SDR
+index-s0q3573v1-v1.m3u8
+#EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=450000,RESOLUTION=360x640,FRAME-RATE=23.980,CODECS="avc1.42c01e",VIDEO-RANGE=SDR
+index-s0q3576v1-v1.m3u8
+
+#EXT-X-I-FRAME-STREAM-INF:BANDWIDTH=130266,RESOLUTION=720x1280,CODECS="avc1.64001f",URI="iframes-s0q3570v1-v1.m3u8",VIDEO-RANGE=SDR
+#EXT-X-I-FRAME-STREAM-INF:BANDWIDTH=71689,RESOLUTION=468x832,CODECS="avc1.4d401e",URI="iframes-s0q3573v1-v1.m3u8",VIDEO-RANGE=SDR
+#EXT-X-I-FRAME-STREAM-INF:BANDWIDTH=43082,RESOLUTION=360x640,CODECS="avc1.42c01e",URI="iframes-s0q3576v1-v1.m3u8",VIDEO-RANGE=SDR
+```
+
+
+In API you will see details of the issue:
+```json
+{
+    "id": 11936778,
+    "status": "viewable",
+    "error": "The storage limit has been exceeded",
+    "hls_url": "https://demo-public.gvideo.io/videos/2675_vGcX1W3aTFEL/master.m3u8",
+    "dash_url": "https://demo-public.gvideo.io/videos/2675_vGcX1W3aTFEL/master.mpd",
+    "converted_videos": [
+        {
+            "name": "vod1080p",
+            "progress": 0,
+            "status": "error",
+            ...
+        },
+        {
+            "name": "vod720p",
+            "progress": 100,
+            "status": "complete",
+            "mp4_url": "https://demo-public.gvideo.io/videos/2675_vGcX1W3aTFEL/qid3570v1_h264_1800_1280.mp4"
+            ...
+        },
+        {
+            "name": "vod480p",
+            "progress": 100,
+            "status": "complete",
+            "mp4_url": "https://demo-public.gvideo.io/videos/2675_vGcX1W3aTFEL/qid3573v1_h264_800_832.mp4"
+            ...
+        },
+        {
+            "name": "vod360p",
+            "progress": 100,
+            "status": "complete",
+            "mp4_url": "https://demo-public.gvideo.io/videos/2675_vGcX1W3aTFEL/qid3576v1_h264_450_640.mp4"
+            ...
+        }
+    ],
+}
+```


### PR DESCRIPTION
- Increased the retry duration for re-requesting the original stream from 10 minutes to 60 minutes in the restream configuration.
- Added a new section on stream availability and initialization process in the primary-backup documentation.
- Enhanced the SRT protocol documentation with detailed latency settings and monitoring tips.
- Introduced an introduction section and HTML player example for AI-generated subtitles in the video hosting documentation.
- Improved clarity and formatting in the HLS and MP4 documentation, including new sections on MP4 dynamic speed limiting and advanced secure token protection.
- Updated the original files documentation to clarify the download process for transcoded files.
- Revised the upload video via API documentation to include detailed processing statuses and error handling.
- Added a new section on instant clips for live streaming, detailing the creation and management of clips from live streams.
- Created a comprehensive VOD status documentation to explain the video lifecycle and processing statuses.