### PR TITLE
Corrected typos and added Infiniband info to 2 articles

### DIFF
--- a/cloud/networking/create-and-manage-a-network.mdx
+++ b/cloud/networking/create-and-manage-a-network.mdx
@@ -108,8 +108,11 @@ If you've already created a cloud resource and want to add more networks to it, 
 
   * **Private** : Choose a network from the list or create a new one, then [configure a subnetwork](/cloud/networking/create-and-manage-a-subnetwork) according to your requirements.
 
+<Info>
+**Info**
 
-
+InfiniBand networks can only be attached to resources with flavors that support them.
+</Info>
 
 6\. (Optional) If your network contains both IPv6 and IPv4 addresses, you can enable IPv6 dual-stack and simultaneously use IPv4 and IPv6 protocols on the same network infrastructure. 
 
@@ -123,13 +126,13 @@ To remove an interface from your cloud resource, you need to detach all subnetwo
 
 1\. In the Gcore Customer Portal, navigate to **Cloud**. 
 
-2\. Open the relevant page with your resource: **Virtual Instances** or **Bare Metal**. 
+2\. Open the relevant page with the resource: **Virtual Instances** or **Bare Metal**. 
 
-2\. Find the needed resource and click its name to open it. 
+3\. Find the needed resource and click its name to open it. 
 
-3\. Go to the **Networks** tab and find the network you want to detach. 
+4\. Go to the **Networks** tab and find the network to detach. 
 
-4\. Click the three-dot icon next to each subnetwork within the network and select **Detach subnetwork**. 
+5\. Click the three-dot icon next to each subnetwork within the network and select **Detach subnetwork**. 
 
 
 <Frame>![Network settings with the detach subnetwork option](/images/docs/cloud/networking/create-and-manage-a-network/detach-subnetwork.png)</Frame>
@@ -138,7 +141,7 @@ To remove an interface from your cloud resource, you need to detach all subnetwo
 
 If you have a connected Floating IP, detach it before removing subnetworks.
 
-5\. Confirm the action by clicking **Detach**.
+6\. Confirm the action by clicking **Detach**.
 
 Repeat this step for all subnetworks within the network. 
 

--- a/cloud/virtual-instances/create-an-instance.mdx
+++ b/cloud/virtual-instances/create-an-instance.mdx
@@ -71,7 +71,7 @@ Choose one of the available flavors.
   <Info>
     **Info**
 
-    The bandwidth limit for the **Shared** flavor is up 100 Mbps. For other configurations it's up 1 Gbps.
+    The bandwidth limit for the **Shared** flavor is up to 100 Mbps. For other configurations it's up to 1 Gbps.
   </Info>
   - **Standard**. VMs best suited for a wide range of workloads that require predictable computing performance. Availability: all regions.
   - **vCPU**. CPU-optimized VMs. Ideal for CPU-intensive tasks that require predictable computing performance, such as batch processing of large data sets and video encoding. Availability: all Core regions.
@@ -80,6 +80,12 @@ Choose one of the available flavors.
   - **SGX**. VMs that support Intel SGX (Security Guard Extension) that helps to protect data from disclosure or modification by isolating private parts of code and data (enclaves). The best option for storing critical or sensitive data in the cloud. Availability: Luxembourg, Manassas, Singapore.
   - **GPU**. VMs with a graphics card. Suitable for working with graphic information, deep and machine learning applications, and high-performance computing. Availability: Luxembourg.
   - **GPU-HF**. VMs with a high clock rate of the CPU and with a graphics card, suitable for complex calculations that require graphics accelerator resources, high performance, and speed. Availability: Luxembourg.
+
+  <Info>
+    **Info**
+
+    InfiniBand networks can only be attached to VMs with flavors that support InfiniBand.
+  </Info>
 </Accordion>
 
 ## Step 4. Set up volumes
@@ -112,7 +118,7 @@ Enter a volume name, choose its type, and set its size in GiB.
   Availability: Amsterdam-2, Frankfurt, Hong Kong, Luxembourg-2, Manassas, Tokyo
 </Accordion>
 
-(optional) Add an **Attachment Tag**.
+(Optional) Add an **Attachment Tag**.
 
 ## Step 5. Add network interfaces
 
@@ -120,7 +126,7 @@ If you select a **public** interface, you can turn on the **Use reserved IP** to
 
 ![Use Reserved Ip Pn](/images/docs/cloud/virtual-instances/create/use-reserved-ip.png)
 
-If you select a **private** interface, configure a network and a subnetwork according to the following steps.
+For a **private** interface, configure a network and a subnetwork as described below.
 
 <Info>
   **Info**
@@ -138,9 +144,9 @@ If you select a **private** interface, configure a network and a subnetwork acco
     If you choose to add a new network, a new window will open where you'll configure the network settings:
 
     1. Enter the network name.
-    2. (optional) Turn on the **Use reserved IP** toggle if you want to assign a [reserved IP address](/cloud/networking/ip-address/create-and-configure-a-reserved-ip-address) to the Virtual Machine. Select the desired IP from the list.
-    3. (optional) Turn on the **Use floating IP** toggle if you want to assign a [floating IP address](/cloud/networking/ip-address/create-and-configure-a-floating-ip-address) and receive incoming connections to the VM.
-    4. (optional) Turn on the **Enable IPv6 dual-stack** toggle to use IPv6 addresses.
+    2. (Optional) Turn on the **Use reserved IP** toggle if you want to assign a [reserved IP address](/cloud/networking/ip-address/create-and-configure-a-reserved-ip-address) to the Virtual Machine. Select the desired IP from the list.
+    3. (Optional) Turn on the **Use floating IP** toggle if you want to assign a [floating IP address](/cloud/networking/ip-address/create-and-configure-a-floating-ip-address) and receive incoming connections to the VM.
+    4. (Optional) Turn on the **Enable IPv6 dual-stack** toggle to use IPv6 addresses.
     5. Click **Create network**.
 
     <Frame>
@@ -151,7 +157,7 @@ If you select a **private** interface, configure a network and a subnetwork acco
     <Info>
       **Info**
 
-      If your VM has several subnetworks, [ ensure that only one subnetwork is routable](/cloud/networking/create-and-manage-a-subnetwork#set-up-the-default-gateway). Otherwise, there will be a conflict with the default gateway on the server, and you might not be able to connect to the VM.
+      If your VM has several subnetworks, [ensure that only one subnetwork is routable](/cloud/networking/create-and-manage-a-subnetwork#set-up-the-default-gateway). Otherwise, there will be a conflict with the default gateway on the server, and you might not be able to connect to the VM.
     </Info>
     Select an existing subnetwork from the dropdown list or create a new one by clicking **Add a new subnetwork**.
 
@@ -162,10 +168,10 @@ If you select a **private** interface, configure a network and a subnetwork acco
 
     1. Enter the subnetwork name.
     2. Set CIDR between ranges: 10.0.0.0 - 10.255.255.255, 172.16.0.0—172.31.255.255, 192.168.0.0—192.168.255.255. Set the mask between 16 and 29.
-    3. (optional) Turn on the **Enable DHCP** toggle to assign IP addresses to machines in the subnet automatically.
-    4. (optional) Turn on the **Non-routable subnetwork** toggle to block access to the subnet from external networks and other subnets. If you keep the network routable, you can specify the **Gateway IP** address. Otherwise, a random IP address will be assigned.
-    5. (optional) Enter **Custom DNS servers** to add specific DNS servers.
-    6. (optional) Turn on **Add tags** to add metadata to the subnetwork.
+    3. (Optional) Turn on the **Enable DHCP** toggle to assign IP addresses to machines in the subnet automatically.
+    4. (Optional) Turn on the **Non-routable subnetwork** toggle to block access to the subnet from external networks and other subnets. If you keep the network routable, you can specify the **Gateway IP** address. Otherwise, a random IP address will be assigned.
+    5. (Optional) Enter **Custom DNS servers** to add specific DNS servers.
+    6. (Optional) Turn on **Add tags** to add metadata to the subnetwork.
     7. Click **Create subnetwork**.
 
     <Frame>
@@ -213,7 +219,7 @@ If you want to create a new firewall, refer to our article on [adding and config
   </Tab>
 </Tabs>
 
-## Step 8 (optional). Configure additional options
+## Step 8 (Optional). Configure additional options
 
 Enable the **User data** toggle to customize your VM during the initial boot by a `cloud-init` agent.
 


### PR DESCRIPTION
## Pull Request Summary

### Typos Fixed

**`cloud/virtual-instances/create-an-instance.mdx`:**
- "up 100 Mbps" -> "up to 100 Mbps"
- "up 1 Gbps" -> "up to 1 Gbps"
- `[ ensure` -> `[ensure` (extra space in link)
- `(optional)` -> `(Optional)` (9 occurrences) (In both articles there were different, so, I based on style guide rules for **O**ptional)

**`cloud/networking/create-and-manage-a-network.mdx`:**
- Duplicate step numbering fixed: 1-2-2-3-4-5 -> 1-2-3-4-5-6 (two fixes)

---

### General Changes

**`cloud/virtual-instances/create-an-instance.mdx`:**
- Added Info block in "Description of flavors" Accordion documenting that InfiniBand networks require VM flavors with InfiniBand support

**`cloud/networking/create-and-manage-a-network.mdx`:**
- Added Info block in "Attach a network interface to an existing VM or Bare Metal" section documenting InfiniBand network compatibility requirements