### PR TITLE
Revert "Add tags limits"

### DIFF
--- a/cloud/networking/add-and-configure-a-firewall.mdx
+++ b/cloud/networking/add-and-configure-a-firewall.mdx
@@ -56,7 +56,7 @@ Outbound traffic on port 25 (SMTP) is closed by default to prevent abusive actio
 
 5\. (optional) Apply a firewall to a Virtual Machine by selecting it in the **Apply to Instance** drop-down list.
 
-6\. (optional) Add tags by switching on the **Add tags** toggle in the **Additional options** section. Tags are key-value pairs with the following constraints: both key and value must be between 3 and 255 characters, and leading or trailing whitespaces will be stripped.
+6\. (optional) Add tags by switching on the **Add tags** toggle in the **Additional options** section and specifying headers and tags. 
 
 7\. Click **Create firewall**.
 


### PR DESCRIPTION
Reverts G-Core/product-documentation#1730

The new article has to be created about global tags, not a point change in the article. 