### PR TITLE
corrected typos

### DIFF
--- a/streaming/ai-video-service/generate-ai-subtitles-and-add-them-to-video/generate-captions-via-api.mdx
+++ b/streaming/ai-video-service/generate-ai-subtitles-and-add-them-to-video/generate-captions-via-api.mdx
@@ -11,11 +11,11 @@ You can upload videos and generate captions automatically during the process of 
 ## AI captions for a new video
 
 
-When uploading a video use new parameters in the end-point. The system will automatically create a task for transcribing the video and translating subtitles, and the finished result will be added to the video as a subtitle.
+When uploading a video, use new parameters in the endpoint. The system will automatically create a task for transcribing the video and translating subtitles, and the finished result will be added to the video as a subtitle.
 
 AI caption parameters:
-  - `auto_transcribe_audio_language: auto|<language_code>` – Immediately after successful transcoding, an AI task will be automatically created for transcription the video to original language. Output by default is one subtitle channel with original languages inside.
-  - `auto_translate_subtitles_language: default|<language_codes,>` – In additional to transcription on original language it's possible to translate to other languagaes, so AI-task of subtitles translation can be applied. Use that parameter for that. Here you can specify multiple set of languages to translate to, then a separate subtitle will be generated for each specified language.
+  - `auto_transcribe_audio_language: auto|<language_code>` – Immediately after successful transcoding, an AI task will be automatically created for transcribing the video to the original language. By default, the output is one subtitle channel with original languages inside.
+  - `auto_translate_subtitles_language: default|<language_codes,>` – In addition to transcription in the original language, it's possible to translate to other languages, so AI-task of subtitles translation can be applied. Use that parameter for that. Here you can specify multiple languages to translate to, then a separate subtitle will be generated for each specified language.
 
 Example to transcribe:
 ```sh
@@ -35,7 +35,7 @@ POST https://api.gcore.com/streaming/videos
     "name": "Spritefright Blender",
     "description": "Video copied from an external S3 Storage",
     "origin_url": "https://demo-files.gvideo.io/apidocs/spritefright-blender-cut30sec.mp4",
-    "auto_transcribe_audio_language": "eng"
+    "auto_transcribe_audio_language": "eng",
     "auto_translate_subtitles_language": "fre,ger,ita,spa"
 }
 ```
@@ -43,9 +43,9 @@ POST https://api.gcore.com/streaming/videos
 Read more about it in the API [`POST /streaming/videos`](/api-reference/streaming/videos/create-video).
 
 
-## AI captions for an exist video
+## AI captions for an existing video
 
-It's possible to use post-processing for generating AI captions. 
+You can use post-processing to generate AI captions. 
 Using new attributes for subtitles API you will be able to create subtitles automatically. 
 
 AI caption parameters are the same for uploading:
@@ -64,7 +64,7 @@ Example to transcribe from a detected language and translate to "fre,ger,ita,spa
 ```sh
 POST https://api.gcore.com/streaming/videos/{video_id}/subtitles
 {
-    "auto_transcribe_audio_language": "auto"
+    "auto_transcribe_audio_language": "auto",
     "auto_translate_subtitles_language": "fre,ger,ita,spa"
 }
 ```
@@ -74,7 +74,7 @@ Read more about it in the API [`POST /streaming/videos/{video_id}/subtitles`](/a
 
 ## Advanced use of native AI API for any video inside or outside the video streaming platform
 
-Methods above are for videos stored in the Gcore Video Platform only, because they were designed for simplicity. 
+The methods described above are for videos stored in the Gcore Video Platform only, because they were designed for simplicity. 
 
 Using AI API directly you can process any videos stored inside or outside Gcore Video Streaming Platform. 
 AI ​​system can process any video stored in an MP4 container and available via a direct download link. 
@@ -88,7 +88,7 @@ If the video is from an external source, get a link to it. The link must be in H
 
 Let's look at an example of getting a link from our video storage.
 
-To obtain an MP4 link to your video with 240p, 360p, or 468p quality. That quality is sufficient because it contains an [64Kbps audio track](/streaming/live-streams-and-videos-protocols-and-codecs/output-parameters-after-transcoding-bitrate-frame-rate-and-codecs#output-parameters-after-transcoding) suitable for AI automatic speech recognition and transcription. To get your MP4 link, execute the following API request /docs/api-reference/streaming/videos/get-video : 
+To obtain an MP4 link to your video with 240p, 360p, or 468p quality. That quality is sufficient because it contains a [64Kbps audio track](/streaming/live-streams-and-videos-protocols-and-codecs/output-parameters-after-transcoding-bitrate-frame-rate-and-codecs#output-parameters-after-transcoding) suitable for AI automatic speech recognition and transcription. To get your MP4 link, execute the following [API request](/api-reference/streaming/videos/get-video):
 
 ```sh
 GET https://api.gcore.com/streaming/videos/{id}
@@ -99,7 +99,7 @@ From the response, copy the value of the `mp4_url` field.
 <Warning>
 **Warning**
 
-If the mp4_url field isn't shown in the response, contact [technical support](maito:support@gcore.com). MP4 support may be disabled for your account. Technical support will enable it for you.
+If the mp4_url field isn't shown in the response, contact [technical support](mailto:support@gcore.com). MP4 support may be disabled for your account. Technical support will enable it for you.
 </Warning> 
 
 <Accordion title="Example of obtaining MP4 URL">
@@ -139,11 +139,12 @@ The value required for the next step is in the mp4_url field: `https://demo-publ
 To assign a transcription task to Gcore AI ASR, execute the following API request:
 
 ```sh
-curl -L 'https://api.gcore.com/streaming/ai/transcribe' \
+curl -L 'https://api.gcore.com/streaming/ai/tasks' \
 -H 'Content-Type: application/json' \
 -H 'Authorization: APIKey {your_api_key}' \
 -d '{
-    "url": "https://demo-files.gvideo.io/{your_video_url/{quality}.mp4" 
+    "url": "https://demo-files.gvideo.io/{your_video_url}/{quality}.mp4",
+    "task_name": "transcription"
 }'
 ```
 


### PR DESCRIPTION
Fixes in generate-captions-via-api.mdx:
Links:
API request /docs/api-reference/... -> [API request](/api-reference/...) (formatted as hyperlink, removed /docs/)
maito:support@gcore.com -> mailto:support@gcore.com
URL/JSON:
{your_video_url/{quality}.mp4 -> {your_video_url}/{quality}.mp4
/streaming/ai/transcribe -> /streaming/ai/tasks (+ added task_name)
Added 2 missing commas in JSON between fields
Grammar/Style:
languagaes -> languages
an exist video -> an existing video
an 64Kbps -> a 64Kbps
In additional to transcription on original language -> In addition to transcription in the original language,
transcription the video -> transcribing the video
Output by default is -> By default, the output is
multiple set of languages -> multiple languages
in the end-point -> in the endpoint (+ comma)
It's possible to use post-processing for generating -> You can use post-processing to generate
Methods above are -> The methods described above are