### PR TITLE
Update annotations for LB

### DIFF
--- a/cloud/networking/load-balancers/use-annotations-for-load-balancers.mdx
+++ b/cloud/networking/load-balancers/use-annotations-for-load-balancers.mdx
@@ -128,16 +128,16 @@ spec:
 
 Replace `my-logs` and `15` with the appropriate LaaS topic name and destination region ID for the project.
 
-### External load balancer with floating IP
+### Internal load balancer with floating IP
 
-To create an external load balancer with automatic floating IP assignment:
+To create an internal load balancer with automatic floating IP assignment:
 
 ```yaml
 apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    loadbalancer.gcore.com/type: "external"
+    loadbalancer.gcore.com/type: "internal"
     loadbalancer.gcore.com/floating-ip: ""
     loadbalancer.gcore.com/floating-ip-cleanup: "true"
   name: web-service


### PR DESCRIPTION
Replaced deprecated annotations (loadbalancer.gcorelabs.com/*, service.beta.kubernetes.io/gcore-*) with new loadbalancer.gcore.com/* annotations for GCCM v2. Added new annotations: type, shared-load-balancer-name, node-selector, pool-proxy-protocol, pool timeouts, metadata, and reserved IP options. Reorganized into logical sections with updated examples.