### PR TITLE
docs(DOC-1177): Fix typos in Let's Encrypt certificate article

### DIFF
--- a/cdn/ssl-certificates/configure-lets-encrypt-certificate.mdx
+++ b/cdn/ssl-certificates/configure-lets-encrypt-certificate.mdx
@@ -86,7 +86,7 @@ While the resource is active, the certificate is renewed automatically. An attem
 
 In the event of an unsuccessful attempt to reissue a certificate, the current certificate will remain active for another 30 days. After the certificate's end date, the content will become unavailable via HTTPS.
 
-To avoid interruption of content delivery, please reissue the certificate yourself. To do this, [revoke](/cdn/ssl-certificates/configure-lets-encrypt-certificate#revoke-a-lets-encrypt-certificate) the Let's Encrypt certificate in your account and then .
+To avoid interruption of content delivery, please reissue the certificate yourself. To do this, revoke the Let's Encrypt certificate in your account and then request a new certificate.
 
 ## Revoke a Let's Encrypt certificate
 
@@ -139,7 +139,7 @@ After selecting the "Get free Let's Encrypt certificate" option, if your CDN res
 
 
 
-However, if some issues get in the way of the ACME challenge, you will see the following description of the error of issuing. Such an error can occur if a CDN resource is still in the process of creation, for example. The next attempt will occured in fifteen minutes. If you want to accelerate the reattempt, click **force retry**. 
+However, if some issues get in the way of the ACME challenge, you will see the following description of the error of issuing. Such an error can occur if a CDN resource is still in the process of creation, for example. The next attempt will occur in fifteen minutes. If you want to accelerate the reattempt, click **force retry**. 
 
 
 <Frame>![Processing with issue status](/images/docs/cdn/ssl-certificates/configure-lets-encypt-certificate/force-retry-30.png)</Frame>


### PR DESCRIPTION
## Summary

- Fixed typo: 'occured' -> 'occur'
- Completed unfinished sentence

---
*Created by DocOps Agent*