### PR TITLE
docs(DOC-1194): Update documentation

### DIFF
--- a/cdn/troubleshooting/an-ssl-certificate-isn-t-working-how-to-solve-to-issue.mdx
+++ b/cdn/troubleshooting/an-ssl-certificate-isn-t-working-how-to-solve-to-issue.mdx
@@ -1,5 +1,5 @@
 ---
-title: "An SSL certificate isn't working: how to solve to issue"
+title: "An SSL certificate isn't working: how to solve the issue"
 sidebarTitle: Attaching or issuing an SSL certificate
 ---
 
@@ -16,7 +16,7 @@ Full instructions for attaching a certificate: [Add an SSL certificate to delive
 
 ## Can't get Let's Encrypt certificate
 
-**Check whether the[rules](/cdn/cdn-resource-options/rules-for-particular-files/create-a-rule-manually-or-from-a-template-to-configure-settings-for-particular-files) you created overlap the path "/.well-known/acme-challenge/".** This is the path for issuing a certificate, in many cases, such a rule (for example, with the path "/.*") does not allow issuing the certificate. Disable the rule, get the certificate, and enable the rule again.
+**Check whether the [rules](/cdn/cdn-resource-options/rules-for-particular-files/create-a-rule-manually-or-from-a-template-to-configure-settings-for-particular-files) you created overlap the path "/.well-known/acme-challenge/".** This is the path for issuing a certificate, in many cases, such a rule (for example, with the path "/.*") does not allow issuing the certificate. Disable the rule, get the certificate, and enable the rule again.
 
 You can check whether the rule blocks the certificate issuance path using [this service](https://regex101.com/r/Hy9bKy/1).
 


### PR DESCRIPTION
## Summary

Automated documentation update for DOC-1194.

## Changes

- **Path**: cdn/troubleshooting/an-ssl-certificate-isn-t-working-how-to-solve-to-issue.mdx - **Title**: An SSL certificate isn't working: how to solve to issue Fix typos in the article title and a mis

---
*Created by DocOps Agent*