### PR TITLE
docs(DOC-1203): Update documentation

### DIFF
--- a/dns/dns-records/configure-weight-balancing-and-geobalancing.mdx
+++ b/dns/dns-records/configure-weight-balancing-and-geobalancing.mdx
@@ -25,7 +25,7 @@ For example, you can set the "Continent" picker and add metadata of the "contine
 
 2\. Enable the **Dynamic response** toggle.
 
-3\. Select a picker preset from the "Presets" buttons or manually choose pickers from the list on the right. The order of the pickers in the left list dicatate priority: the top picker will be considered first, the second picker considered second, and so on.
+3\. Select a picker preset from the "Presets" buttons or manually choose pickers from the list on the right. The order of the pickers in the left list dictate priority: the top picker will be considered first, the second picker considered second, and so on.
 
 <Tip>
 **Tip**


### PR DESCRIPTION
## Summary

Automated documentation update for DOC-1203.

## Changes

- **Path**: dns/dns-records/configure-weight-balancing-and-geobalancing.mdx - **Title**: Dynamic response Fix the typo "dicatate" in the sentence describing picker order so that it reads "dictate".

---
*Created by DocOps Agent*