### PR TITLE
docs(DOC-1204): Update documentation

### DIFF
--- a/dns/dns-failover/configure-and-use-dns-failover.mdx
+++ b/dns/dns-failover/configure-and-use-dns-failover.mdx
@@ -65,7 +65,7 @@ DNS Healthchecks will send requests to web servers via ICMP protocol every 60 se
 <Info>
 **Info**
 
-If all Healthchecks fail, their A records will be included in the DNS response, while stoll adhering to other filters like _geo county_ or _first_n_.
+If all Healthchecks fail, their A records will be included in the DNS response, while still adhering to other filters like _geo county_ or _first_n_.
 </Info>
 
 4\. The DNS server removes the A record of the unavailable server from its responses. Any requests intended for the unavailable server are redirected to other available servers.


### PR DESCRIPTION
## Summary

Automated documentation update for DOC-1204.

## Changes

- **Path**: dns/dns-failover/configure-and-use-dns-failover.mdx - **Title**: What Healthcheck are and how to configure them Fix the typo `stoll` -> `still` in the DNS Healthchecks documentation articl

---
*Created by DocOps Agent*