### PR TITLE
docs(DOC-1049): Automatic SHARP allocation for InfiniBand-based Bare Metal GPU clusters

### DIFF
--- a/edge-ai/ai-infrastructure/create-a-bare-metal-gpu-cluster.mdx
+++ b/edge-ai/ai-infrastructure/create-a-bare-metal-gpu-cluster.mdx
@@ -18,6 +18,8 @@ Each cluster consists of one or more dedicated bare-metal GPU servers. When crea
 
 For flavors with InfiniBand cards, high-speed inter-node networking is configured automatically. No manual network configuration is required for distributed training.
 
+On SHARP-capable InfiniBand hardware, the platform also configures and maintains SHARP (Scalable Hierarchical Aggregation and Reduction Protocol) reservations automatically. Collective operations between nodes can be offloaded to the InfiniBand fabric without any additional configuration in the Customer Portal.
+
 The platform provides the infrastructure layer: GPU servers, networking, storage options, and secure access. This allows installing and running preferred frameworks for distributed training, job scheduling, or container orchestration.
 
 For multi-node workloads, configure SSH trust between nodes to enable distributed training frameworks. File shares provide shared storage for datasets and checkpoints across all nodes.

--- a/edge-ai/ai-infrastructure/manage-a-bare-metal-gpu-cluster.mdx
+++ b/edge-ai/ai-infrastructure/manage-a-bare-metal-gpu-cluster.mdx
@@ -114,7 +114,7 @@ Interface types include:
 |------|-------------|
 | Public | External IP address for internet access |
 | Private | Internal network for communication with other cloud resources |
-| InfiniBand | High-speed, low-latency inter-node network for GPU-to-GPU communication |
+| InfiniBand | High-speed, low-latency inter-node network for GPU-to-GPU communication and collective operations offload on SHARP-capable hardware |
 
 <Frame>![Networking tab showing node and interface list](/images/docs/edge-ai/ai-infrastructure/manage-a-bare-metal-gpu-cluster/cluster-networking-tab.png)</Frame>
 
@@ -134,7 +134,7 @@ To add network interfaces on a specific node:
 4. Configure the interface type (public or private) and IP allocation settings as supported by the service.
 
 <Info>
-InfiniBand interfaces are managed automatically and cannot be modified or deleted. This prevents accidental disruption of inter-node communication.
+InfiniBand interfaces are managed automatically and cannot be modified or deleted. This prevents accidental disruption of inter-node communication and ensures that SHARP reservations for eligible clusters are created, updated, and removed by the platform without manual intervention.
 </Info>
 
 ## Console access


### PR DESCRIPTION
## Summary

Automated documentation update for DOC-1049: Automatic SHARP allocation for InfiniBand-based Bare Metal GPU clusters

## Files Changed (2)

- `edge-ai/ai-infrastructure/create-a-bare-metal-gpu-cluster.mdx`
- `edge-ai/ai-infrastructure/manage-a-bare-metal-gpu-cluster.mdx`

## Capabilities Used

- Multi-article search: True
- Cross-link planning: False
- UI verification: False
- Screenshot capture: False

---
*Created by DocOps Agent (Complex Update)*