### PR TITLE
docs(DOC-1206): Update documentation

### DIFF
--- a/streaming/live-streaming/protocols/rtmp-srt.mdx
+++ b/streaming/live-streaming/protocols/rtmp-srt.mdx
@@ -31,7 +31,7 @@ When the network is unstable:
  - Packets that miss the latency budget are discarded
  - Decoders receive incomplete GOPs and break
 
-SRT prioritizes stable abd predictable latency. It exposes real network limitations instead of masking them with unlimited buffering.
+SRT prioritizes stable and predictable latency. It exposes real network limitations instead of masking them with unlimited buffering.
 
 **Note**: This is also the main advantage of SRT. It manages packets independently and can send data for transcoding even with dropped packets. Broadcast may visually suffer for a few frames, but it won't stop, and the frame-rate will remain stable.
 
@@ -95,7 +95,7 @@ Conclusion of demo: SRT is a modern protocol, but it requires you to adjust its 
 <iframe width="100%" src="https://player.gvideo.co/videos/2675_kbo9xHApXyhYO1Sj" title="RTMP, SRT comparing on a poor internet connection" frameborder="0" allow="fullscreen; accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 </Frame>
 
-In the video OBS SRT2 lowlatency tuning sesttings are:
+In the video OBS SRT2 lowlatency tuning settings are:
  - Stream URL: `&latency=2000` is added
  - Output, Encoder Settings: 
    - Keyframe Interval: `1sec`


### PR DESCRIPTION
## Summary

Automated documentation update for DOC-1206.

## Changes

- **Path**: streaming/live-streaming/protocols/rtmp-srt.mdx - **Title**: RTMP vs SRT: protocol comparison Fix two typos in the RTMP-SRT streaming documentation:

---
*Created by DocOps Agent*