### PR TITLE
docs(DOC-1208): Update documentation

### DIFF
--- a/streaming/live-streaming/protocols/srt.mdx
+++ b/streaming/live-streaming/protocols/srt.mdx
@@ -312,7 +312,7 @@ An example of a good send with a 2500 ms window and zero packet loss over a long
 ## SRT troubleshooting
 
 There are 2 main cases:
-1) Picture is falling apart. If the picture breakes into squares or just gray.
+1) Picture is falling apart. If the picture breaks into squares or just gray.
 2) Stream is frozen or buffered. If frames are dropped or player shows buffering.
 
 Both cases mean packet loss in the network from your encoder to our ingester. Reduce the bitrate of the master stream and set SRT latency and zerolatency tuning explicitly.


### PR DESCRIPTION
## Summary

Automated documentation update for DOC-1208.

## Changes

- **Path**: streaming/live-streaming/protocols/srt.mdx - **Title**: SRT Fix typo "breakes" → "breaks" in the troubleshooting section.

---
*Created by DocOps Agent*