### PR TITLE
Doc 1285

### DIFF
--- a/waap/waap-rules.mdx
+++ b/waap/waap-rules.mdx
@@ -7,7 +7,7 @@ WAAP rules allow you to specify how to inspect web requests to your domain and w
 
 For example, you can create a rule to block any request with common SQL injection patterns or require CAPTCHA validation to prevent spam. 
 
-## What rules can you create?
+## What rules can you create
 
 Depending on your [plan](https://gcore.com/pricing/security#waap), you can create the following rules: 
 

--- a/waap/waap-rules.mdx
+++ b/waap/waap-rules.mdx
@@ -11,7 +11,7 @@ For example, you can create a rule to block any request with common SQL injectio
 
 Depending on your [plan](https://gcore.com/pricing/security#waap), you can create the following rules: 
 
-  * [Firewall rules](/waap/ip-security/allow-and-block-ip-addresses) (allow and block IP addresses): Easy to configure and designed for use cases when you need a straightforward, simple tool to manage IP access to your domain. These rules form access control lists (ACLs) and are free for any plan that includes our WAAP product. 
+  * [Firewall rules](/waap/firewall/access-control#allowed-ips-and-blocked-ips) (allow and block IP addresses): Easy to configure and designed for use cases when you need a straightforward, simple tool to manage IP access to your domain. These rules form access control lists (ACLs) and are free for any plan that includes our WAAP product. 
 
   * [Custom rules](/waap/waap-rules/custom-rules): These rules contain "if/then" statements and cover more complicated scenarios, such as filtering requests from specified countries or organizations.
 

--- a/waap/waap-rules.mdx
+++ b/waap/waap-rules.mdx
@@ -7,7 +7,7 @@ WAAP rules allow you to specify how to inspect web requests to your domain and w
 
 For example, you can create a rule to block any request with common SQL injection patterns or require CAPTCHA validation to prevent spam. 
 
-## What rules can you create
+## Types of WAAP rules
 
 Depending on your [plan](https://gcore.com/pricing/security#waap), you can create the following rules: 
 
@@ -15,14 +15,14 @@ Depending on your [plan](https://gcore.com/pricing/security#waap), you can creat
 
   * [Custom rules](/waap/waap-rules/custom-rules): These rules contain "if/then" statements and cover more complicated scenarios, such as filtering requests from specified countries or organizations.
 
-  * [Advanced rules](/waap/waap-rules/advanced-rules): Designed for technical users who need even more control over rule creation. Can be configured via API and are available within the WAAP **Enterprise** plan.
+  * [Advanced rules](/waap/waap-rules/advanced-rules): Designed for technical users who need even more control over rule creation. Can be configured via API and are available in the WAAP Enterprise plan.
 
 
 
 
 ## Rule criteria
 
-For any WAAP rule, it's important to define the criteria that will put that rule into action. You can create WAAP rules based on a variety of conditions: 
+For any WAAP rule, it's important to define the criteria that trigger the rule. You can create WAAP rules based on a variety of conditions: 
 
   * Origin of the IP or IP range. 
 
@@ -34,10 +34,9 @@ For any WAAP rule, it's important to define the criteria that will put that rule
 
   * Specific [tags](/waap/waap-rules/custom-rules/tag-rules/predefined-tags). 
 
-  * SQL code that's likely to be malicious and used to extract data from your database, also known as SQL injection. 
+  * Potentially malicious SQL code used to extract data from your database, also known as SQL injection. 
 
   * Requests with potentially malicious scripts that can exploit vulnerabilities in web applications. This is known as cross-site scripting (XSS). 
-
 
   * Some rule types take sets of criteria. For example, you can specify up to 10,000 IP addresses or IP address ranges in an IP address rule.
 


### PR DESCRIPTION
Document: /waap/waap-rules.mdx

Updates done:

Renamed section heading from “What rules can you create?” to “Types of WAAP rules.”
Updated Firewall rules link:
From: /waap/ip-security/allow-and-block-ip-addresses
To: /waap/firewall/access-control#allowed-ips-and-blocked-ips
Edited wording in the Advanced rules description:
Changed “available within the WAAP Enterprise plan” to “available in the WAAP Enterprise plan.”
Removed bold formatting from “Enterprise.”
Updated Rule criteria intro sentence:
Changed “define the criteria that will put that rule into action” to “define the criteria that trigger the rule.”
Reworded SQL injection bullet for clarity:
From: “SQL code that's likely to be malicious and used to extract data from your database…”
To: “Potentially malicious SQL code used to extract data from your database…”
Minor formatting cleanup:
Removed extra blank line before the final bullet point in the Rule criteria section.