### PR TITLE
fix: remove unpublished per-product MCP entries from docs.json

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -328,9 +328,7 @@
                   "cdn/terraform/add-ssl-certificate-to-cdn-via-terraform",
                   "cdn/terraform/version-control-and-rollback-via-terraform"
                 ]
-              },
-              "cdn/manage-cdn-via-mcp-server",
-              {
+              },              {
                 "group": "Troubleshooting",
                 "pages": [
                   "cdn/troubleshooting/common-setup-issues",
@@ -393,8 +391,7 @@
                 ]
               },
               "fastedge/troubleshooting",
-              "fastedge/fastedge-cli",
-              "fastedge/manage-fastedge-via-mcp-server"
+              "fastedge/fastedge-cli"
             ]
           },
           {
@@ -666,15 +663,6 @@
               "cloud/manage-cloud-via-terraform",
               "cloud/manage-cloud-via-ansible",
               {
-                "group": "MCP Server",
-                "pages": [
-                  "cloud/mcp-server/manage-ai-ml-via-mcp-server",
-                  "cloud/mcp-server/manage-networking-via-mcp-server",
-                  "cloud/mcp-server/manage-storage-via-mcp-server",
-                  "cloud/mcp-server/manage-virtual-machines-via-mcp-server"
-                ]
-              },
-              {
                 "group": "Use cases",
                 "pages": [
                   "cloud/use-cases/set-up-a-mailing-server-in-gcore-cloud-vm"
@@ -688,7 +676,6 @@
               "edge-ai",
               "edge-ai/getting-started",
               "edge-ai/billing",
-              "edge-ai/manage-edge-ai-via-mcp-server",
               {
                 "group": "GPU cloud",
                 "pages": [
@@ -785,8 +772,7 @@
                   "dns/dns-plugins/use-gcore-dns-as-a-secondary-dns-with-octodns",
                   "dns/dns-plugins/get-a-let-s-encrypt-certificate-with-certbot"
                 ]
-              },
-              "dns/manage-dns-via-mcp-server"
+              }
             ]
           },
           {
@@ -1038,8 +1024,7 @@
               },
               "storage/request-content-directly-from-the-storage",
               "storage/check-storages-usage-reports",
-              "storage/4xx-errors-how-to-solve-storage-issues",
-              "storage/manage-storage-via-mcp-server"
+              "storage/4xx-errors-how-to-solve-storage-issues"
             ]
           },
           {
@@ -1171,13 +1156,6 @@
                   "streaming/video-hosting/subtitles-and-closed-captions-for-vod",
                   "streaming/video-hosting/timeline-hover-previews-use-in-players-and-roku-devices",
                   "streaming/video-hosting/upload-video-via-api"
-                ]
-              },
-              {
-                "group": "MCP Server",
-                "pages": [
-                  "streaming/mcp-server/manage-live-streaming-via-mcp-server",
-                  "streaming/mcp-server/manage-video-hosting-via-mcp-server"
                 ]
               }
             ]
@@ -1343,8 +1321,7 @@
                   "waap/troubleshooting/troubleshoot-blocked-users",
                   "waap/troubleshooting/troubleshoot-5xx-errors"
                 ]
-              },
-              "waap/manage-waap-via-mcp-server"
+              }
             ]
           }
         ]


### PR DESCRIPTION
These navigation entries (cdn, fastedge, cloud, edge-ai, dns, storage, streaming, waap MCP server pages) were accidentally included in the rename-description-to-ai-navigation commit. The corresponding MDX files exist only in the unpublished DOC-1303 branch and were causing broken sidebar links across all products.