### PR TITLE
fix(llms): correct MCP URL and remove GitHub link from Optional section

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -21,5 +21,4 @@
 
 ## Optional
 
-- [Gcore MCP Server](https://gcore.com/docs/account-settings/integrations/gcore-mcp-server-overview.md): Connect AI agents (Claude Code, Cursor IDE) to Gcore via MCP to manage Cloud, CDN, DNS, and other products through natural language commands.
-- [GitHub source](https://github.com/G-Core/product-documentation): Raw MDX source for all documentation pages.
+- [Gcore MCP Server](https://gcore.com/docs/developer-tools/mcp-server/gcore-mcp-server-overview.md): Connect AI agents (Claude Code, Cursor IDE) to Gcore via MCP to manage Cloud, CDN, DNS, and other products through natural language commands.

--- a/scripts/generate_llms_txt.py
+++ b/scripts/generate_llms_txt.py
@@ -34,8 +34,7 @@ log = logging.getLogger(__name__)
 BASE_URL_DEFAULT = "https://gcore.com/docs"
 DOCS_JSON_NAME = "docs.json"
 DOCUMENTATION_TAB = "Documentation"
-MCP_ARTICLE_PATH = "account-settings/integrations/gcore-mcp-server-overview"
-GITHUB_REPO_URL = "https://github.com/G-Core/product-documentation"
+MCP_ARTICLE_PATH = "developer-tools/mcp-server/gcore-mcp-server-overview"
 
 ROOT_SIZE_WARN = 50_000
 ROOT_SIZE_ERROR = 100_000
@@ -323,7 +322,6 @@ def build_root_llms(
         f"- [Gcore MCP Server]({mcp_url}): Connect AI agents (Claude Code, Cursor IDE)"
         " to Gcore via MCP to manage Cloud, CDN, DNS, and other products through"
         " natural language commands.",
-        f"- [GitHub source]({GITHUB_REPO_URL}): Raw MDX source for all documentation pages.",
     ]
 
     return "\n".join(lines) + "\n"


### PR DESCRIPTION
MCP path updated from account-settings/integrations/ to developer-tools/mcp-server/ after DOC-1338 relocation. GitHub source link removed from Optional section.