### PR TITLE
fix(gclaw): add Gclaw section to docs.json navigation

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -399,7 +399,6 @@
                   "fastedge/kv-stores/bloom-filter"
                 ]
               },
-              "fastedge/cache",
               "fastedge/troubleshooting",
               "fastedge/fastedge-cli"
             ]
@@ -739,6 +738,26 @@
                   }
                 ]
               }
+            ]
+          },
+          {
+            "group": "Gclaw",
+            "pages": [
+              "gclaw",
+              "gclaw/getting-started",
+              "gclaw/manage-instance",
+              "gclaw/api-keys",
+              {
+                "group": "Integrations",
+                "pages": [
+                  "gclaw/connect-telegram",
+                  "gclaw/connect-discord"
+                ]
+              },
+              "gclaw/security",
+              "gclaw/limits",
+              "gclaw/pricing",
+              "gclaw/ssh-access"
             ]
           },
           {


### PR DESCRIPTION
Gclaw files were present on main but missing from docs.json navigation, making the entire section inaccessible. Restore navigation group with all pages including new ssh-access article from PR #2029.