### PR TITLE
Update protect-cdn-resources-with-basic-waf.mdx

### DIFF
--- a/cdn/cdn-resource-options/cdn-security/protect-cdn-resources-with-basic-waf.mdx
+++ b/cdn/cdn-resource-options/cdn-security/protect-cdn-resources-with-basic-waf.mdx
@@ -28,14 +28,6 @@ With built-in security rules, advanced behavioral analytics, and a range of avai
 
 5. Click **Save** to apply the changes.
 
-<Warning>
-  **Warning**
-
-  After enabling WAAP in CDN, you need to invalidate the cache. This is necessary to ensure that WAAP settings are properly applied. When "Secure Token" and/or "Referrer access policy" CDN options are enabled in conjunction with WAAP, the CDN may block WAAP requests.
-
-  These limitations will be removed soon.
-</Warning>
-
 Consider that it might take up to 20 minutes for the HTTP traffic to start passing through our WAAP after the activation.
 
 ### What to do if WAAP blocks content that shouldn't be blocked?


### PR DESCRIPTION
removing old warning as we moved to new architecture hence its not needed anymore