### PR TITLE
fix: remove missing Managed Kubernetes nav entries from docs.json

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -701,13 +701,6 @@
                 ]
               },
               {
-                "group": "Managed Kubernetes",
-                "pages": [
-                  "edge-ai/managed-kubernetes/create-a-gpu-kubernetes-cluster",
-                  "edge-ai/managed-kubernetes/manage-a-gpu-kubernetes-cluster"
-                ]
-              },
-              {
                 "group": "Everywhere Inference",
                 "pages": [
                   "edge-ai/everywhere-inference",


### PR DESCRIPTION
Pages edge-ai/managed-kubernetes/create-a-gpu-kubernetes-cluster and manage-a-gpu-kubernetes-cluster were referenced in docs.json navigation but the MDX files are not yet merged into main, causing 404s in production.