### PR TITLE
DOC-1046: Add Cloudflare to Gcore DNS migration guide

### DIFF
--- a/dns/llms.txt
+++ b/dns/llms.txt
@@ -5,6 +5,7 @@
 - [Overview](https://docs.gcore.com/dns.md): Configure Gcore Managed DNS with Anycast routing, dynamic response, Healthchecks, DNSSEC, and OctoDNS, Certbot, Terraform integrations; compare plans.
 - [Gcore Managed DNS glossary](https://docs.gcore.com/dns/gcore-dns-glossary.md): View Gcore Managed DNS terminology definitions - A, AAAA, CNAME, MX, TXT, SRV records, DNS zones, propagation, DNSSEC, and authoritative name servers.
 - [Getting started with Managed DNS](https://docs.gcore.com/dns/manage-a-dns-zone.md): Create and manage DNS zones in Gcore Managed DNS - add a zone, update NS records to Gcore nameservers, and manage records, TTL, and zone status.
+- [Migrate DNS from Cloudflare to Gcore](https://docs.gcore.com/dns/migrate-from-cloudflare.md): Migrate DNS records from Cloudflare to Gcore Managed DNS - export a zone file, import records, and switch nameservers at the registrar.
 
 ## Records
 - [Supported DNS record types](https://docs.gcore.com/dns/dns-records.md): Create A, AAAA, NS, CNAME, MX, TXT, SRV, CAA, HTTPS, SVCB, and PTR records in Gcore Managed DNS with TTL, class, and IPv4 and IPv6 address values.

--- a/dns/migrate-from-cloudflare.mdx
+++ b/dns/migrate-from-cloudflare.mdx
@@ -1,6 +1,7 @@
 ---
 title: Migrate DNS from Cloudflare to Gcore
 sidebarTitle: Migrate from Cloudflare
+ai-navigation: Migrate DNS records from Cloudflare to Gcore Managed DNS - export a zone file, import records, and switch nameservers at the registrar.
 ---
 
 {/* LEGAL REVIEW NEEDED: This doc mentions Cloudflare (third-party software) throughout. Requires legal clearance before publishing per DOC-1233 policy. */}
@@ -18,7 +19,11 @@ Lower the TTL on all your DNS records in Cloudflare before starting. A shorter T
 1. Log in to the Cloudflare dashboard and select your domain.
 2. Go to **DNS** > **Records**.
 3. Edit each record and set the TTL to **10 minutes** (or the lowest value available).
-4. Wait for the current TTL to expire before proceeding—this ensures old cached records stop being served.
+4. Wait for the current TTL to expire before proceeding. This ensures old cached records stop being served.
+
+<Warning>
+If DNSSEC is enabled on the domain in Cloudflare, handle it before switching nameservers. Changing nameservers while DNSSEC is active, without first removing or updating the DS record at the registrar, will cause DNSSEC validation to fail, and the domain will stop resolving for many users. The safest path: disable DNSSEC in Cloudflare, remove the DS record at the registrar, wait for the DS record TTL to expire, then proceed with the nameserver switch. Alternatively, configure DNSSEC in Gcore first, obtain the new DS record from Gcore, and update the DS record at the registrar at the same time the nameservers are switched.
+</Warning>
 
 ## Step 1. Export DNS records from Cloudflare
 
@@ -26,12 +31,14 @@ Lower the TTL on all your DNS records in Cloudflare before starting. A shorter T
 2. Click **Export** to download your DNS records as a BIND zone file (`.txt` format).
 
 <Warning>
-Cloudflare proxied records (those with the orange cloud icon enabled) export with Cloudflare's proxy IP addresses, not your origin server IPs. Before importing into Gcore, open the zone file and replace any Cloudflare proxy IPs with your actual origin server IPs.
+Cloudflare proxied records (those with the orange cloud icon enabled) export with Cloudflare's proxy IP addresses, not your origin server IPs. Before importing into Gcore, check all proxied A, AAAA, and CNAME records in the zone file and replace any Cloudflare proxy IPs with the real origin server IP, or with the appropriate Gcore CDN address if the record should continue to be served through a CDN.
 
-To find your origin IPs, temporarily disable the proxy (set the record to DNS-only) in Cloudflare before exporting.
+To find the real origin IPs, temporarily disable the proxy (set the record to DNS-only) in Cloudflare before exporting.
 </Warning>
 
 ## Step 2. Create a DNS zone in Gcore
+
+Create a DNS zone in the Gcore Customer Portal following the [standard process](/dns/manage-a-dns-zone), which includes screenshots for each step:
 
 1. Navigate to [DNS](https://portal.gcore.com/dns/zones) in the Gcore Customer Portal and click **Add zone**.
 2. Enter your domain name and click **Confirm**.
@@ -45,17 +52,25 @@ Check the **Skip scanning** box if you prefer to import all records manually fro
 
 1. In the [All zones](https://portal.gcore.com/dns/zones) tab, open the zone you just created.
 2. Click **Import records**.
-3. In the pop-up, either paste the contents of your Cloudflare zone file or click **Upload zone file** to select the `.txt` file you exported.
+3. In the pop-up, either paste the contents of your Cloudflare zone file directly, or rename the exported `.txt` file to `.zone` and click **Upload zone file** to upload it.
 4. Click **Import**.
 
-Review the imported records to confirm everything looks correct. Pay particular attention to A and AAAA records that were previously proxied through Cloudflare—verify they now point to your actual origin IPs.
+Review the imported records to confirm everything looks correct. Pay particular attention to A and AAAA records that were previously proxied through Cloudflare — verify they now point to actual origin IPs.
+
+<Info>
+Cloudflare supports CNAME flattening, which lets a CNAME record exist at the root of a domain (for example, `example.com` rather than `sub.example.com`). Standard DNS does not permit CNAME at the apex, so Cloudflare resolves the chain and exports the result as an A or AAAA record. Root records may look different after import. Check them carefully and confirm they resolve to the expected address.
+</Info>
+
+<Warning>
+Only DNS records are migrated. Cloudflare CDN, proxy rules, WAF, page rules, redirects, Workers, and SSL/TLS settings are not transferred automatically. These must be configured separately using Gcore or another service.
+</Warning>
 
 ## Step 4. Update nameservers at your registrar
 
-Point your domain to Gcore nameservers by updating the NS records at your **domain registrar** — the company where you purchased or manage your domain (such as GoDaddy, Namecheap, or Google Domains).
+Point your domain to Gcore nameservers by updating the NS records at the **domain registrar** (the company where the domain was purchased or is managed, such as GoDaddy, Namecheap, or Google Domains).
 
 <Warning>
-**You must change the nameservers at your domain registrar, not inside Cloudflare.** Updating NS records within the Cloudflare dashboard has no effect on delegation. The authoritative nameservers for your domain are controlled by glue records at your registrar. If those glue records don't change, the nameservers will never change — regardless of what Cloudflare shows.
+**Update the nameserver settings at the domain registrar, not inside Cloudflare.** Adding or editing NS records inside the Cloudflare dashboard does not change which DNS provider is authoritative for the domain. The registrar controls that setting. It must be changed there.
 </Warning>
 
 Set the nameservers to the following Gcore values:
@@ -72,15 +87,19 @@ Look for a **Nameservers** or **DNS** section in your registrar's control panel.
 DNS changes can take up to 24 hours to propagate globally. To check the status:
 
 - Use a DNS propagation checker tool to verify your domain's NS records are resolving to Gcore nameservers worldwide. {/* LEGAL REVIEW NEEDED: third-party tool reference removed pending legal clearance */}
-- In the Gcore Customer Portal, a notification will appear on your DNS zone until propagation is complete—this is expected and clears automatically.
+- In the Gcore Customer Portal, a notification will appear on your DNS zone until propagation is complete. This is expected and clears automatically.
 
 Once propagation is complete, your DNS is fully managed by Gcore.
+
+<Info>
+Keep the Cloudflare DNS zone intact for at least 48 hours after migration. If something goes wrong, switching the nameservers back at the registrar will restore Cloudflare as the authoritative DNS provider while the Gcore zone is debugged.
+</Info>
 
 ## Cloudflare feature comparison
 
 | Feature | Cloudflare | Gcore |
 |---|---|---|
-| HTTP proxy (orange cloud) | Yes | Not available in DNS — use [Gcore CDN](/cdn) |
+| HTTP proxy (orange cloud) | Yes | Not available in DNS. Use [Gcore CDN](/cdn) |
 | Anycast DNS | Yes | Yes |
 | GeoDNS / load balancing | Yes (paid) | Yes (on Pro and Enterprise plans) |
 | DNSSEC | Yes | Yes |

--- a/dns/migrate-from-cloudflare.mdx
+++ b/dns/migrate-from-cloudflare.mdx
@@ -6,71 +6,71 @@ ai-navigation: Migrate DNS records from Cloudflare to Gcore Managed DNS - export
 
 {/* LEGAL REVIEW NEEDED: This doc mentions Cloudflare (third-party software) throughout. Requires legal clearance before publishing per DOC-1233 policy. */}
 
-This guide explains how to move your DNS management from Cloudflare to Gcore Managed DNS. The process involves exporting your existing DNS records, importing them into Gcore, and then updating the nameservers at your domain registrar to point to Gcore infrastructure.
+Moving DNS from Cloudflare to Gcore Managed DNS means exporting the zone file, importing records into Gcore, then switching authoritative nameservers at the domain registrar. Nameserver changes can take up to 24 hours to propagate, so plan the cutover for a low-traffic window.
+
+## TTL preparation
+
+Lower the TTL on every DNS record in Cloudflare before the cutover, because a shorter TTL lets resolvers refresh records faster after the switch.
+
+1. Log in to the Cloudflare dashboard and select the domain.
+2. Navigate to **DNS** > **Records**.
+3. Edit each record and set the TTL to **10 minutes** (or the lowest available value).
+4. Wait for the current TTL to expire before continuing, so old cached records stop being served.
 
 <Warning>
-Changing nameservers causes a propagation period of up to 24 hours. Plan the migration during low-traffic hours to minimize impact.
-</Warning>
-
-## Before you begin
-
-Lower the TTL on all your DNS records in Cloudflare before starting. A shorter TTL means DNS resolvers refresh records more quickly, which reduces propagation time during the cutover.
-
-1. Log in to the Cloudflare dashboard and select your domain.
-2. Go to **DNS** > **Records**.
-3. Edit each record and set the TTL to **10 minutes** (or the lowest value available).
-4. Wait for the current TTL to expire before proceeding. This ensures old cached records stop being served.
-
-<Warning>
-If DNSSEC is enabled on the domain in Cloudflare, handle it before switching nameservers. Changing nameservers while DNSSEC is active, without first removing or updating the DS record at the registrar, will cause DNSSEC validation to fail, and the domain will stop resolving for many users. The safest path: disable DNSSEC in Cloudflare, remove the DS record at the registrar, wait for the DS record TTL to expire, then proceed with the nameserver switch. Alternatively, configure DNSSEC in Gcore first, obtain the new DS record from Gcore, and update the DS record at the registrar at the same time the nameservers are switched.
+If DNSSEC is enabled on the domain in Cloudflare, handle it before switching nameservers. Changing nameservers while DNSSEC is active, without first removing or updating the DS record at the registrar, causes DNSSEC validation to fail, and the domain stops resolving for many clients. The safest path is to disable DNSSEC in Cloudflare, remove the DS record at the registrar, wait for the DS record TTL to expire, then proceed with the nameserver switch. Alternatively, configure DNSSEC in Gcore first, obtain the new DS record from Gcore, and update the DS record at the registrar at the same time the nameservers are switched.
 </Warning>
 
 ## Step 1. Export DNS records from Cloudflare
 
-1. In the Cloudflare dashboard, select your domain and go to **DNS** > **Records**.
-2. Click **Export** to download your DNS records as a BIND zone file (`.txt` format).
+Download a BIND zone file from Cloudflare so the same records can be imported into Gcore.
+
+1. In the Cloudflare dashboard, select the domain and navigate to **DNS** > **Records**.
+2. Click **Export** to download the DNS records as a BIND zone file (`.txt` format).
 
 <Warning>
-Cloudflare proxied records (those with the orange cloud icon enabled) export with Cloudflare's proxy IP addresses, not your origin server IPs. Before importing into Gcore, check all proxied A, AAAA, and CNAME records in the zone file and replace any Cloudflare proxy IPs with the real origin server IP, or with the appropriate Gcore CDN address if the record should continue to be served through a CDN.
+Cloudflare proxied records (those with the orange cloud icon enabled) export with Cloudflare proxy IP addresses, not the origin server IPs. Before importing into Gcore, check all proxied A, AAAA, and CNAME records in the zone file and replace any Cloudflare proxy IPs with the real origin server IP, or with the appropriate Gcore CDN address if the record should continue to be served through a CDN.
 
 To find the real origin IPs, temporarily disable the proxy (set the record to DNS-only) in Cloudflare before exporting.
 </Warning>
 
 ## Step 2. Create a DNS zone in Gcore
 
-Create a DNS zone in the Gcore Customer Portal following the [standard process](/dns/manage-a-dns-zone), which includes screenshots for each step:
+Create a zone in the [Gcore Customer Portal](https://portal.gcore.com) so imported records have a destination. The [zone creation](/dns/manage-a-dns-zone) guide covers the same flow with screenshots.
 
-1. Navigate to [DNS](https://portal.gcore.com/dns/zones) in the Gcore Customer Portal and click **Add zone**.
-2. Enter your domain name and click **Confirm**.
-3. Gcore will scan and display any existing DNS records it can detect. Review them, then click **Confirm**.
+1. Navigate to [DNS](https://portal.gcore.com/dns/zones) in the Customer Portal and click **Add zone**.
+2. Enter the domain name and click **Confirm**.
+3. Gcore scans and displays any existing DNS records it can detect. Review them, then click **Confirm**.
 
 <Tip>
-Check the **Skip scanning** box if you prefer to import all records manually from your Cloudflare zone file in the next step.
+Check the **Skip scanning** box to import all records manually from the Cloudflare zone file in the next step.
 </Tip>
 
-## Step 3. Import your DNS records
+## Step 3. Import DNS records
 
-1. In the [All zones](https://portal.gcore.com/dns/zones) tab, open the zone you just created.
+Import the Cloudflare zone file into the new Gcore zone, then review every record before changing nameservers.
+
+1. In the All zones tab, open the newly created zone.
 2. Click **Import records**.
-3. In the pop-up, either paste the contents of your Cloudflare zone file directly, or rename the exported `.txt` file to `.zone` and click **Upload zone file** to upload it.
+3. In the pop-up, either paste the contents of the Cloudflare zone file directly, or rename the exported `.txt` file to `.zone` and click **Upload zone file** to upload it.
 4. Click **Import**.
 
-Review the imported records to confirm everything looks correct. Pay particular attention to A and AAAA records that were previously proxied through Cloudflare — verify they now point to actual origin IPs.
+Review the imported records and confirm they look correct. Pay particular attention to A and AAAA records that were previously proxied through Cloudflare, and verify they now point to actual origin IPs.
 
 <Info>
-Cloudflare supports CNAME flattening, which lets a CNAME record exist at the root of a domain (for example, `example.com` rather than `sub.example.com`). Standard DNS does not permit CNAME at the apex, so Cloudflare resolves the chain and exports the result as an A or AAAA record. Root records may look different after import. Check them carefully and confirm they resolve to the expected address.
+Cloudflare supports CNAME flattening, which lets a CNAME record exist at the domain root (`example.com`) rather than only on a subdomain (`sub.example.com`). Standard DNS does not permit CNAME at the apex, so Cloudflare resolves the chain and exports the result as an A or AAAA record. Root records may look different after import, so check them carefully and confirm they resolve to the expected address.
 </Info>
 
 <Warning>
-Only DNS records are migrated. Cloudflare CDN, proxy rules, WAF, page rules, redirects, Workers, and SSL/TLS settings are not transferred automatically. These must be configured separately using Gcore or another service.
+Only DNS records are migrated. Cloudflare CDN, proxy rules, WAF, page rules, redirects, Workers, and SSL/TLS settings are not transferred automatically. Configure those services separately in Gcore or another provider after the DNS cutover.
 </Warning>
 
-## Step 4. Update nameservers at your registrar
+## Step 4. Update nameservers at the registrar
 
-Point your domain to Gcore nameservers by updating the NS records at the **domain registrar** (the company where the domain was purchased or is managed, such as GoDaddy, Namecheap, or Google Domains).
+Point the domain to Gcore nameservers by updating the nameserver settings at the domain registrar (the company where the domain was purchased or is managed).
 
 <Warning>
-**Update the nameserver settings at the domain registrar, not inside Cloudflare.** Adding or editing NS records inside the Cloudflare dashboard does not change which DNS provider is authoritative for the domain. The registrar controls that setting. It must be changed there.
+Update the nameserver settings at the domain registrar, not inside Cloudflare. Adding or editing NS records inside the Cloudflare dashboard does not change which DNS provider is authoritative for the domain, because the registrar controls that setting.
 </Warning>
 
 Set the nameservers to the following Gcore values:
@@ -80,26 +80,28 @@ Set the nameservers to the following Gcore values:
 | NS 1 | `ns1.gcorelabs.net` |
 | NS 2 | `ns2.gcdn.services` |
 
-Look for a **Nameservers** or **DNS** section in your registrar's control panel. The exact steps vary by registrar.
+Look for a **Nameservers** or **DNS** section in the registrar control panel. The exact steps vary by registrar.
 
 ## Step 5. Verify propagation
 
-DNS changes can take up to 24 hours to propagate globally. To check the status:
+DNS changes can take up to 24 hours to propagate globally. Check progress in both of these places:
 
-- Use a DNS propagation checker tool to verify your domain's NS records are resolving to Gcore nameservers worldwide. {/* LEGAL REVIEW NEEDED: third-party tool reference removed pending legal clearance */}
-- In the Gcore Customer Portal, a notification will appear on your DNS zone until propagation is complete. This is expected and clears automatically.
+- Use a DNS propagation checker to verify that the domain's NS records resolve to Gcore nameservers worldwide. {/* LEGAL REVIEW NEEDED: third-party tool reference removed pending legal clearance */}
+- In the Customer Portal, a notification appears on the DNS zone until propagation is complete. This is expected and clears automatically.
 
-Once propagation is complete, your DNS is fully managed by Gcore.
+Once propagation is complete, DNS for the domain is fully managed by Gcore.
 
 <Info>
-Keep the Cloudflare DNS zone intact for at least 48 hours after migration. If something goes wrong, switching the nameservers back at the registrar will restore Cloudflare as the authoritative DNS provider while the Gcore zone is debugged.
+Keep the Cloudflare DNS zone intact for at least 48 hours after migration. If something goes wrong, switching the nameservers back at the registrar restores Cloudflare as the authoritative DNS provider while the Gcore zone is debugged.
 </Info>
 
 ## Cloudflare feature comparison
 
+After migration, DNS capabilities map between Cloudflare and Gcore as follows.
+
 | Feature | Cloudflare | Gcore |
 |---|---|---|
-| HTTP proxy (orange cloud) | Yes | Not available in DNS. Use [Gcore CDN](/cdn) |
+| HTTP proxy (orange cloud) | Yes | Use [Gcore CDN](/cdn) |
 | Anycast DNS | Yes | Yes |
 | GeoDNS / load balancing | Yes (paid) | Yes (on Pro and Enterprise plans) |
 | DNSSEC | Yes | Yes |

--- a/docs.json
+++ b/docs.json
@@ -928,6 +928,7 @@
               "dns",
               "dns/gcore-dns-glossary",
               "dns/manage-a-dns-zone",
+              "dns/migrate-from-cloudflare",
               {
                 "group": "Records",
                 "pages": [

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1,6 +1,6 @@
 # Gcore Docs - Full Index
 
-> Complete article index across all Gcore products. 609 articles.
+> Complete article index across all Gcore products. 610 articles.
 > Use this file for offline indexing, bulk vectorization, or large-context retrieval.
 # Gcore Account settings
 
@@ -560,6 +560,7 @@
 - [Overview](https://docs.gcore.com/dns.md): Configure Gcore Managed DNS with Anycast routing, dynamic response, Healthchecks, DNSSEC, and OctoDNS, Certbot, Terraform integrations; compare plans.
 - [Gcore Managed DNS glossary](https://docs.gcore.com/dns/gcore-dns-glossary.md): View Gcore Managed DNS terminology definitions - A, AAAA, CNAME, MX, TXT, SRV records, DNS zones, propagation, DNSSEC, and authoritative name servers.
 - [Getting started with Managed DNS](https://docs.gcore.com/dns/manage-a-dns-zone.md): Create and manage DNS zones in Gcore Managed DNS - add a zone, update NS records to Gcore nameservers, and manage records, TTL, and zone status.
+- [Migrate DNS from Cloudflare to Gcore](https://docs.gcore.com/dns/migrate-from-cloudflare.md): Migrate DNS records from Cloudflare to Gcore Managed DNS - export a zone file, import records, and switch nameservers at the registrar.
 
 ## Records
 - [Supported DNS record types](https://docs.gcore.com/dns/dns-records.md): Create A, AAAA, NS, CNAME, MX, TXT, SRV, CAA, HTTPS, SVCB, and PTR records in Gcore Managed DNS with TTL, class, and IPv4 and IPv6 address values.

--- a/llms.txt
+++ b/llms.txt
@@ -14,7 +14,7 @@
 - [Edge Cloud](https://docs.gcore.com/cloud/llms.txt): Gcore Cloud is an IaaS and PaaS platform providing on-demand compute, storage, networking, containers, databases, and managed services across more than 30 global regions (105 articles).
 - [AI](https://docs.gcore.com/edge-ai/llms.txt): Deploy AI inference and GPU-accelerated training using Gcore AI products - Everywhere Inference for low-latency model serving at the edge and GPU Cloud for Bare Metal and Virtual Machine compute (33 articles).
 - [Gclaw](https://docs.gcore.com/gclaw/llms.txt): Managed OpenClaw service with built-in inference for launching AI agents instantly (10 articles).
-- [Managed DNS](https://docs.gcore.com/dns/llms.txt): Configure Gcore Managed DNS with Anycast routing, dynamic response, Healthchecks, DNSSEC, and OctoDNS, Certbot, Terraform integrations; compare plans (19 articles).
+- [Managed DNS](https://docs.gcore.com/dns/llms.txt): Configure Gcore Managed DNS with Anycast routing, dynamic response, Healthchecks, DNSSEC, and OctoDNS, Certbot, Terraform integrations; compare plans (20 articles).
 - [Hosting](https://docs.gcore.com/hosting/llms.txt): Order and manage Gcore Dedicated Servers and Virtual Servers with BGP, DDoS protection, link aggregation, DNS hosting, billing, and account management (80 articles).
 - [Colocation](https://docs.gcore.com/colocation/llms.txt): Overview of Gcore Colocation - place customer hardware in facilities certified at Tier II and above across 29 global locations with DDoS protection and on-site support (4 articles).
 - [Object Storage](https://docs.gcore.com/storage/llms.txt): Store and manage data in Gcore Object Storage with S3 Fast, S3 Standard, and SFTP storage types supporting the S3 API and SFTP protocols (15 articles).


### PR DESCRIPTION
## Summary

Adds a new how-to guide covering the full DNS migration process from Cloudflare to Gcore Managed DNS.

**Covers:**
- Pre-migration TTL lowering
- Exporting DNS records from Cloudflare (BIND zone file)
- Creating a DNS zone and importing records in Gcore
- Updating nameservers at the domain registrar (with glue records explanation)
- Propagation verification

**Key callout:** Includes a prominent warning that NS changes must be made at the registrar level — not inside Cloudflare — based on real support case from the original ticket thread.

**Pending:** Legal review required for third-party (Cloudflare) mentions per DOC-1233 policy.

Closes DOC-1046

Made with [Cursor](https://cursor.com)