### PR TITLE
fix: update broken Llama 3.2 announcement link in translate-text article

### DIFF
--- a/edge-ai/everywhere-inference/ai-models/translate-text-with-llama.mdx
+++ b/edge-ai/everywhere-inference/ai-models/translate-text-with-llama.mdx
@@ -4,7 +4,7 @@ sidebarTitle: Translate text
 ai-navigation: Use a deployed Llama 3.2 model on Gcore Everywhere Inference to translate text between languages. Covers the system prompt pattern, request parameters, curl, Python, and JavaScript code examples, edge case handling, and output style control.
 ---
 
-[Llama 3.2](https://ai.meta.com/blog/llama-3-2-connect-2024-vision-edge-mobile/) supports multilingual input and output across eight languages: English, French, German, Spanish, Italian, Portuguese, Hindi, and Thai. This article covers using a deployed Llama 3.2 model on [Gcore](https://gcore.com) Everywhere Inference to translate text via the API. The endpoint URL is available on the **Overview** tab of the deployment detail page.
+[Llama 3.2](https://ai.meta.com/blog/llama-3-2-connect-2024-vision-edge-mobile-devices/) supports multilingual input and output across eight languages: English, French, German, Spanish, Italian, Portuguese, Hindi, and Thai. This article covers using a deployed Llama 3.2 model on [Gcore](https://gcore.com) Everywhere Inference to translate text via the API. The endpoint URL is available on the **Overview** tab of the deployment detail page.
 
 <Info>
 Translation quality scales with model size. Llama 3.2 1B is suitable for short strings — UI labels, notifications, and short paragraphs — and performs best on European languages. Hindi and Thai, and any content longer than a paragraph, benefit from a larger variant: Llama 3.2 3B or Llama 3.3 70B.


### PR DESCRIPTION
Meta renamed the blog post slug from llama-3-2-connect-2024-vision-edge-mobile to llama-3-2-connect-2024-vision-edge-mobile-devices (404 reported by Daria).