### PR TITLE
Revert docs(developer-tools): update token format 

### DIFF
--- a/developer-tools/rest-api/api-basics.mdx
+++ b/developer-tools/rest-api/api-basics.mdx
@@ -147,7 +147,7 @@ An environment variable stores a value in the terminal session. Instead of pasti
 
 ```bash
 # Set the variable (run this once per terminal session)
-export GCORE_API_KEY="29841_c767b250..."
+export GCORE_API_KEY="29841\$c767b250..."
 
 # Use it in any command (the shell substitutes $GCORE_API_KEY with the token value)
 curl "https://api.gcore.com/iam/clients/me" -H "Authorization: APIKey $GCORE_API_KEY"
@@ -155,6 +155,20 @@ curl "https://api.gcore.com/iam/clients/me" -H "Authorization: APIKey $GCORE_API
 
 <Warning>
 Environment variables are session-scoped — closing the terminal window loses all variables set with `export`, so the next session requires setting them again. To persist across sessions on macOS/Linux, add the `export` line to `~/.zshrc` (or `~/.bashrc`) and restart the terminal. On Windows PowerShell, add it to the profile file.
+</Warning>
+
+<Warning>
+Gcore API tokens contain a `$` character, which in bash triggers variable substitution inside double-quoted strings and silently truncates the token. Escape the `$` with a backslash when setting the variable:
+
+```bash
+# Wrong — shell expands $c767... as a variable name, truncating the token
+export GCORE_API_KEY="29841$c767b250..."
+
+# Correct — backslash escapes the dollar sign
+export GCORE_API_KEY="29841\$c767b250..."
+```
+
+When using `$GCORE_API_KEY` later in commands, no escaping is needed — the variable already holds the full token value.
 </Warning>
 
 ---

--- a/developer-tools/rest-api/authentication.mdx
+++ b/developer-tools/rest-api/authentication.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Authenticate to the Gcore API"
 sidebarTitle: "Authentication"
-ai-navigation: Create a permanent API token in the Gcore Customer Portal, store it as an environment variable, verify the token, and understand token roles, expiry limits, and SSO account behavior.
+ai-navigation: Create a permanent API token in the Gcore Customer Portal, store it as an environment variable with correct dollar sign escaping, verify the token, and understand token roles, expiry limits, and SSO account behavior.
 ---
 
 Every Gcore API request requires a permanent API token. The token goes in the `Authorization` header and works across all products — Cloud, CDN, DNS, Storage, and others.
@@ -26,10 +26,24 @@ Store the token in an environment variable so it can be used in every command wi
 Open a terminal and run:
 
 ```bash
-export GCORE_API_KEY="29841_c767..."
+export GCORE_API_KEY="29841\$c767..."
 ```
 
-Replace `29841_c767...` with the actual token value copied in Step 1.
+Replace `29841\$c767...` with the actual token value copied in Step 1.
+
+<Warning>
+Gcore tokens contain a `$` character. In bash, `$` inside a double-quoted string triggers variable expansion and silently truncates the token. Escape the dollar sign with a backslash (`\$`) when setting the variable:
+
+```bash
+# Wrong — token gets truncated at the $ character
+export GCORE_API_KEY="29841$c767b250..."
+
+# Correct
+export GCORE_API_KEY="29841\$c767b250..."
+```
+
+After setting the variable, `$GCORE_API_KEY` in commands refers to the full token — no escaping needed from that point on.
+</Warning>
 
 <Info>
 Environment variables are session-scoped — they disappear when the terminal is closed, so to persist across sessions, add the `export` line to `~/.zshrc` (macOS/Linux) or the PowerShell profile file (Windows).
@@ -105,7 +119,7 @@ If the command returns an error instead, the table below shows the most common c
 | Error message | Cause | Fix |
 |---------------|-------|-----|
 | `Authentication credentials were not provided.` | No `Authorization` header sent | Check that `-H "Authorization: APIKey $GCORE_API_KEY"` is present |
-| `Bad permanent token: 29841` | Token value is incomplete | Verify the full token value was copied correctly in Step 1 |
+| `Bad permanent token: 29841` | Token was truncated at the `$` character | Escape the `$` when setting the variable: `29841\$c767...` |
 | `Token is invalid or expired` | Token was deleted or has passed its expiry date | Create a new token in the portal |
 | `Given token not valid for any token type` | Using `Bearer` instead of `APIKey` | The scheme must be `APIKey`, not `Bearer` |
 

--- a/developer-tools/rest-api/first-api-call.mdx
+++ b/developer-tools/rest-api/first-api-call.mdx
@@ -17,10 +17,10 @@ If the token has not been created yet, follow [Authentication](/developer-tools/
 Then set it as an environment variable in the terminal:
 
 ```bash
-export GCORE_API_KEY="29841_c767..."
+export GCORE_API_KEY="29841\$c767..."
 ```
 
-Replace `29841_c767...` with the actual token value copied in Step 1.
+Replace `29841\$c767...` with the actual token. The backslash before `$` is intentional — Gcore tokens contain a dollar sign, and escaping it prevents the shell from misreading the token.
 
 Verify the variable was set correctly:
 

--- a/developer-tools/rest-api/sdks.mdx
+++ b/developer-tools/rest-api/sdks.mdx
@@ -192,6 +192,8 @@ for _, inst := range page.Results {
 
 No dedicated JavaScript SDK is published, so use the built-in `fetch` API (Node.js 18+, all modern browsers) or the popular [axios](https://axios-http.com) library.
 
+The `$` character in Gcore tokens requires no escaping in JavaScript — template literals handle it correctly.
+
 ### Node.js fetch (built-in, Node 18+)
 
 Both GET and POST requests follow the same pattern — add the `Authorization` header to every request:

--- a/developer-tools/rest-api/tools.mdx
+++ b/developer-tools/rest-api/tools.mdx
@@ -37,6 +37,10 @@ To import:
 
 All requests in the collection now automatically include the token.
 
+<Warning>
+Gcore tokens contain a `$` character. Postman does not use shell variable expansion, so paste the token value as-is — no backslash escaping needed.
+</Warning>
+
 ### Send a request
 
 1. In the collection, navigate to **IAM → Account → Get account details**.


### PR DESCRIPTION
from dollar sign To underscore, remove escaping warnings"

This reverts commit 9006b9131cc78f71a4855261b0ef1b08c064f201.