### PR TITLE
feat: add agent infrastructure for AI-assisted documentation

### DIFF
--- a/.agents/PLAN.md
+++ b/.agents/PLAN.md
@@ -1,0 +1,725 @@
+# Agent Infrastructure Plan — Gcore Product Documentation
+
+## Context for a new session
+
+This file is the source of truth for building the agent orchestration system
+in this repository. Read it at the start of any session before doing anything.
+The working directory is `C:\Projects\product-documentation`.
+
+### What this repo is
+
+Mintlify-based documentation site for Gcore products. Content is MDX files
+organized by product folder (`cloud/`, `cdn/`, `dns/`, etc.). The custom
+`MethodSwitch` component handles tabbed articles (Customer Portal / REST API /
+Terraform / CLI) in a single MDX file. OpenAPI specs live in
+`api-reference/services_documented/`.
+
+### What we are building
+
+An agent orchestration system that lets two audiences use AI to work with
+this documentation:
+
+**Technical writers (internal team):**
+- Update an existing article
+- Write a new article from scratch
+- Analyze a Jira ticket to understand what needs documenting
+- Add a REST API tab to an existing Customer Portal article
+- Run a full audit of an article: test every step in the real portal or via
+  API, find discrepancies, update the article
+
+**Contributors (product teams):**
+- Provide context about a new feature or change, get a draft PR back
+
+**Special format:**
+- Cookbook articles: given a topic, collect steps from multiple articles and
+  compile into one end-to-end guide
+
+### Available MCP tools
+
+The following MCP servers are configured in this environment:
+
+| MCP | Use for |
+|-----|---------|
+| Jira | Reading tickets, acceptance criteria, linked issues |
+| Confluence | Internal product docs, release notes, specs |
+| Playwright | Browser-based portal testing at https://portal.gcore.com |
+
+---
+
+## Architecture
+
+```
+product-documentation/
+│
+├── AGENTS.md                         ← AI entry point (auto-loaded by agent)
+├── CONTRIBUTING.md                   ← Human entry point (leave for later)
+│
+└── .agents/
+    ├── PLAN.md                       ← THIS FILE
+    │
+    ├── skills/
+    │   ├── update-page/
+    │   │   └── SKILL.md
+    │   ├── write-from-scratch/
+    │   │   └── SKILL.md
+    │   ├── jira-context/
+    │   │   └── SKILL.md
+    │   ├── api-use-case/
+    │   │   └── SKILL.md
+    │   ├── full-audit/
+    │   │   └── SKILL.md
+    │   ├── feature-draft/
+    │   │   └── SKILL.md
+    │   └── cookbook/
+    │       └── SKILL.md
+    │
+    └── references/
+        ├── style-guide.md
+        ├── mdx-rules.md
+        ├── content-types.md
+        └── mcp-tools.md
+```
+
+---
+
+## Implementation order and status
+
+Work through files in this exact order. Update the status column as you go.
+
+## Source files (read before writing any skill or reference)
+
+These existing files contain ready-made content. Do not write from scratch
+what already exists here. Adapt, extract, and combine.
+
+| Source file | Contains | Used by |
+|-------------|----------|---------|
+| `C:\Projects\docops-agent2\CLAUDE.md` | api-use-case algorithm (4 phases), article structure A+B, code style, quality checklist, MDX rules | `skills/api-use-case`, `references/mdx-rules` |
+| `C:\Projects\update_outdated_articles\CLAUDE.md` | full-audit algorithm (4 phases), Playwright protocol, screenshot standards, git workflow, SSO login flow, portal quirks | `skills/full-audit`, `references/mcp-tools` |
+| `C:\Projects\docops-agent2\.continue\guides\style-guide.md` | 694-line style guide: voice, formulas, forbidden words, Gcore naming | `references/style-guide` |
+| `C:\Projects\docops-agent2\.continue\guides\style-rules-formatting.md` | Bold rules, em-dash, cognitive load density | `references/style-guide` |
+| `C:\Projects\docops-agent2\.continue\guides\style-rules-links.md` | Link text rules, duplicate link rules, banned patterns | `references/style-guide` |
+| `C:\Projects\docops-agent2\.continue\guides\style-rules-structure.md` | Heading rules, forbidden sections, prose-before-code | `references/style-guide` |
+| `C:\Projects\docops-agent2\.continue\guides\style-rules-voice.md` | No "you/your", forbidden words, connector rules | `references/style-guide` |
+| `C:\Projects\docops-agent2\.continue\guides\scope-guide.md` | 6-category Jira classification, matrix, red/green flags, examples | `skills/jira-context` |
+| `C:\Projects\docops-agent2\.continue\guides\reflection-guide.md` | Logical reasoning rules, anti-patterns, source verification | `AGENTS.md` (add section) |
+| `C:\Projects\docops-agent2\.continue\reference\jira-statuses.md` | Which Jira statuses allow work, which do not | `skills/jira-context` |
+| `C:\Projects\docops-agent2\.continue\guides\proofreading-checklist.md` | Pre-commit checklist | `skills/full-audit`, `skills/write-from-scratch` |
+| `C:\Projects\product-documentation\CONTRIBUTING.md` | MethodSwitch rules, MDX gotchas, frontmatter fields | `references/mdx-rules` |
+
+---
+
+## Implementation order and status
+
+Work through files in this exact order. Update the status column as you go.
+
+| # | File | Status | Action | Primary source |
+|---|------|--------|--------|----------------|
+| 1 | `.agents/PLAN.md` | DONE | Written | — |
+| 2 | `AGENTS.md` | DONE | Written | — |
+| 3 | `.agents/references/style-guide.md` | DONE | Adapt + combine | docops-agent2/guides/style-*.md (5 files) |
+| 4 | `.agents/references/mdx-rules.md` | DONE | Combine | CONTRIBUTING.md + both CLAUDE.md MDX sections |
+| 5 | `.agents/references/content-types.md` | DONE | Write new | — |
+| 6 | `.agents/references/mcp-tools/` | DONE | Подпапка: playwright.md + jira.md + confluence.md + setup.md | update_outdated_articles/CLAUDE.md + jira-statuses.md |
+| 6b | `.agents/references/review-process.md` | DONE | Write new | docops-agent2/guides/review-process.md + proofreading-checklist.md |
+| 6c | `.agents/references/procedures.md` | DONE | Write new | Cloudflare procedures.md + new rules not in docops-agent2 |
+| 7 | `.agents/skills/update-page/SKILL.md` | DONE | Write new | reflection-guide.md + style/mdx references |
+| 8 | `.agents/skills/jira-context/SKILL.md` | DONE | Adapt | scope-guide.md + jira-statuses.md |
+| 9 | `.agents/skills/write-from-scratch/SKILL.md` | DONE | Write new | docops-agent2/CLAUDE.md Phase 3 + content-types.md |
+| 10 | `.agents/skills/api-use-case/SKILL.md` | DONE | Adapt | docops-agent2/CLAUDE.md (near-complete) |
+| 11 | `.agents/skills/full-audit/SKILL.md` | DONE | Adapt | update_outdated_articles/CLAUDE.md (near-complete) |
+| 12 | `.agents/skills/feature-draft/SKILL.md` | DONE | Write new | Combine Jira + Playwright + draft phases |
+| 13 | `.agents/skills/cookbook/SKILL.md` | DONE | Write new | — |
+
+---
+
+## File specifications
+
+What each file must contain. Use this as the brief when writing each file.
+
+---
+
+### File 2: `AGENTS.md`
+
+**Purpose:** The only file an agent reads automatically. It is a dispatch
+table, not a manual. Every critical rule that applies to ALL tasks goes here
+inline. Everything task-specific stays in skills.
+
+**Must contain:**
+
+1. One-paragraph repo overview (framework, content format, key constraint)
+2. Folder structure — patterns only, no file lists:
+   - `/{product}/{section}/article.mdx` — content
+   - `/api-reference/services_documented/{product}_api.yaml` — OpenAPI specs
+   - `/snippets/` — shared JSX/MDX components
+   - `/.agents/skills/` — skills (load on demand)
+   - `/.agents/references/` — references (load when skill says to)
+3. Three critical inline rules (apply to every task, no exceptions):
+   - Never create separate files for Portal/API/Terraform — use MethodSwitch tabs
+   - Never use `description` in frontmatter — use `ai-navigation`
+   - Internal links must be root-relative, no `https://docs.gcore.com` prefix
+4. Task → Skill mapping table (all 6 skills)
+5. Hard stop: "Load one skill per task. Read no other files until the skill
+   tells you to."
+
+**Must NOT contain:**
+- Lists of actual article files
+- Full MDX syntax rules (those go in mdx-rules.md)
+- Style rules (those go in style-guide.md)
+- Anything that makes the agent want to explore the repo before getting a task
+
+---
+
+### File 3: `.agents/references/mdx-rules.md`
+
+**Purpose:** All technical MDX rules distilled from CONTRIBUTING.md.
+Loaded only when a skill explicitly says to.
+
+**Must contain:**
+
+1. MethodSwitch component — full rules:
+   - Import line (with `.jsx` extension — critical, blank page without it)
+   - Structure: `<MethodSwitch>` → `<MethodSection id="..." label="...">` 
+   - Tab IDs and labels table (portal, api, terraform, cli)
+   - Order: portal always first
+   - Heading rules: use `##` and `###` only, never `####` inside MethodSection
+   - List before `</MethodSection>` — closing tag must NOT be indented
+2. Frontmatter rules:
+   - `title` — required
+   - `sidebarTitle` — optional, shorter sidebar label
+   - `ai-navigation` — required for tabbed articles, max 160 chars, starts with
+     action verb, mentions all methods, no "you/your/this article"
+   - `description` — DO NOT USE (Mintlify renders it as visible page text)
+3. MDX parsing gotchas:
+   - `{identifier}` inside backtick inline code → use `<code>` with `&nbsp;`
+   - UTF-8 BOM at file start → breaks YAML frontmatter parser
+   - `####` (h4) inside MethodSection → appears in wrong tab's TOC
+4. Internal links:
+   - Always root-relative: `/cloud/virtual-instances/create-an-instance`
+   - Never old paths: `/cloud/api/...` directory no longer exists
+   - Anchor links work as normal: `/cloud/virtual-instances/create-an-instance#step-1`
+5. Validation command (local):
+   ```
+   node -e "const {compile}=require('@mdx-js/mdx'); ..."
+   ```
+
+**Source:** CONTRIBUTING.md in this repo (already written, needs distillation)
+
+---
+
+### File 4: `.agents/references/style-guide.md`
+
+**Purpose:** Writing rules — voice, structure, formatting. Loaded by skills
+that write or review content.
+
+**Must contain:**
+
+1. Voice and tone:
+   - Gcore audience: technical, cloud infrastructure, developer-oriented
+   - Direct, no marketing language, no filler phrases
+   - Second person "you" is fine, but don't overuse
+2. Sentence structure:
+   - Steps use imperative: "Click Save", "Enter the value", "Run the command"
+   - One action per step
+   - Result statements after the action: "The instance appears in the list."
+3. Headings:
+   - `##` for main sections
+   - `###` for sub-steps or sub-sections
+   - Title case for `##`, sentence case for `###`
+   - Never skip levels
+4. Code blocks:
+   - Always specify language identifier
+   - Terminal commands: no `$` prefix
+   - Placeholders: use `<angle-brackets>` not `{curly-braces}` in prose
+5. `ai-navigation` field rules (critical, repeated from mdx-rules for emphasis):
+   - One sentence, max 160 characters
+   - Starts with action verb
+   - Describes all methods in the article
+6. Links:
+   - Link text describes the destination, not "click here"
+   - External links: full URL
+   - Internal links: root-relative path
+
+**Note:** We don't have a full written style guide yet. Build this from
+patterns in existing articles + team knowledge. Start with what's known,
+expand over time.
+
+---
+
+### File 5: `.agents/references/content-types.md`
+
+**Purpose:** Defines the types of articles that exist, their structure, and
+when to use each type. Loaded by write-from-scratch and feature-draft skills.
+
+**Must contain:**
+
+1. Tabbed article (most common in this repo):
+   - When: feature accessible via both Portal and API
+   - Structure: MethodSwitch with portal + api sections
+   - Both sections use same `##` headings (parallel structure)
+2. Single-method article:
+   - When: Portal-only or API-only feature
+   - No MethodSwitch needed
+3. Overview article:
+   - When: product or section landing page
+   - Typically short, links to sub-articles
+4. Concept article:
+   - When: explaining what something is, not how to do it
+   - No step-by-step, mostly prose
+5. Cookbook article (special, built by cookbook skill):
+   - When: end-to-end scenario spanning multiple products/sections
+   - Structure: scenario → prerequisites → ordered steps pulling from
+     multiple source articles → expected outcome
+
+For each type: filename pattern, frontmatter fields, section structure.
+
+---
+
+### File 6: `.agents/references/mcp-tools.md`
+
+**Purpose:** Documents available MCP tools and how to use them. Loaded only
+by skills that need external data (jira-context, full-audit, feature-draft).
+
+**Must contain:**
+
+1. Jira MCP:
+   - Use for: ticket context, acceptance criteria, linked tickets, comments
+   - Key operations: get issue, search by JQL, get linked issues
+   - What to extract: summary, description, acceptance criteria, labels,
+     linked design docs or Confluence pages
+
+2. Confluence MCP:
+   - Use for: internal product specs, release notes, architecture docs
+   - Key operations: get page by ID, search by keyword
+   - What to look for: feature descriptions, API changes, known limitations
+
+3. Playwright MCP:
+   - Use for: testing UI steps described in an article
+   - Entry point: https://portal.gcore.com
+   - Standard testing protocol:
+     a. Open the portal
+     b. Navigate to the relevant section
+     c. Execute each UI step from the article
+     d. Verify the result matches what the article says
+     e. Note discrepancies: wrong button names, missing fields, changed flows
+     f. Take note of any steps the article skips
+   - What counts as a passed step vs a failed step
+   - How to report findings: structured list, not prose
+
+---
+
+### File 7: `.agents/skills/update-page/SKILL.md`
+
+**Purpose:** Update an existing article. Simplest skill.
+
+**Inputs:** article path + description of what to change
+
+**Scope — read exactly these files:**
+1. This SKILL.md
+2. The article file specified by the user
+3. `.agents/references/mdx-rules.md` — only if editing MethodSwitch structure
+4. `.agents/references/style-guide.md` — only if rewriting significant prose
+
+**Process:**
+1. Read the article
+2. Apply the requested change
+3. Check: no new MDX parsing issues introduced
+4. Check: `ai-navigation` still accurate after the change
+5. Show diff to user before saving (or save and report what changed)
+
+**Output:** Updated file. Short summary of what changed and why.
+
+---
+
+### File 8: `.agents/skills/jira-context/SKILL.md`
+
+**Purpose:** Analyze a Jira ticket and produce a structured brief of what
+needs to be documented.
+
+**Inputs:** Jira ticket ID or URL
+
+**Scope — read exactly these files:**
+1. This SKILL.md
+2. `.agents/references/mcp-tools.md` — Jira and Confluence sections
+3. Jira ticket (via MCP) — fetched, not a local file
+4. Linked Confluence pages (via MCP) — fetched if referenced in ticket
+5. Existing article in repo — only if ticket references one
+
+**Process:**
+1. Fetch ticket from Jira MCP
+2. Extract: what changed, what is new, affected product/feature
+3. Search Confluence for related internal docs
+4. Search repo for existing article about this feature
+5. Produce structured output (see Output section)
+
+**Output format:**
+```
+## Jira context: [TICKET-ID]
+
+### What changed
+[one paragraph]
+
+### Affected documentation
+- Existing article: [path or "none found"]
+- Action needed: [update existing / create new / no doc needed]
+
+### Scope of documentation work
+[bullet list: what to add, what to remove, what to verify]
+
+### Suggested next skill
+- If updating existing: load skill update-page
+- If creating new: load skill write-from-scratch
+- If needs testing: load skill full-audit
+```
+
+---
+
+### File 9: `.agents/skills/write-from-scratch/SKILL.md`
+
+**Purpose:** Write a new article from a source (Jira, Confluence, or direct
+description).
+
+**Inputs:** topic + source (Jira ticket ID, Confluence URL, or free text
+description) + article type (tabbed / single-method / overview / concept)
+
+**Scope — read exactly these files:**
+1. This SKILL.md
+2. `.agents/references/content-types.md` — structure for the chosen type
+3. `.agents/references/style-guide.md` — writing rules
+4. `.agents/references/mdx-rules.md` — MDX and MethodSwitch rules
+5. One existing article of the same type as a style reference
+6. Source material (Jira/Confluence via MCP, or user input)
+
+**Process:**
+1. Determine article type
+2. Read one reference article of the same type from the repo
+3. Pull source material
+4. Determine file path: `/{product}/{section}/{article-name}.mdx`
+5. Write article following the type structure
+6. Validate: frontmatter complete, ai-navigation present, no MDX issues
+7. If tabbed article: both Portal and API sections must be present or explicitly
+   marked as TODO
+
+**Output:** New file at the determined path. Show full content before saving.
+
+---
+
+### File 10: `.agents/skills/api-use-case/SKILL.md`
+
+**Purpose:** Add a REST API tab to an existing Customer Portal article using
+the OpenAPI spec already in the repo.
+
+**Inputs:** path to existing Portal article
+
+**Scope — read exactly these files:**
+1. This SKILL.md
+2. The existing article file
+3. The relevant OpenAPI YAML from `/api-reference/services_documented/`
+   (determine which one from the product folder of the article)
+4. `.agents/references/mdx-rules.md` — MethodSwitch rules
+
+**Process:**
+1. Read the existing article — understand all Portal steps
+2. Identify the product (from file path)
+3. Load the corresponding OpenAPI spec
+4. For each Portal step, find the equivalent API endpoint:
+   - Map UI action → API operation (e.g., "Click Create" → `POST /cloud/v1/instances`)
+   - Extract required parameters, request body schema, example values
+5. Write the REST API MethodSection:
+   - Parallel structure to Portal section (same `##` headings)
+   - Each step: explain what the call does + code block with curl example
+   - Include: authentication header, required params, example response
+6. Wrap existing Portal content in `<MethodSection id="portal">` if not already
+7. Add `<MethodSection id="api">` after Portal section
+8. Update `ai-navigation` to mention both methods
+
+**Output:** Updated article with both tabs. Show full diff.
+
+---
+
+### File 11: `.agents/skills/full-audit/SKILL.md`
+
+**Purpose:** Test every step of an existing article in real conditions using
+the portal (Playwright) or API, find discrepancies, update the article.
+
+**Inputs:** path to article to audit
+
+**Scope — read exactly these files:**
+1. This SKILL.md
+2. The article to audit
+3. `.agents/references/mcp-tools.md` — Playwright protocol section
+4. `.agents/references/mdx-rules.md` — only if making structural edits
+
+**Process:**
+
+Phase 1 — Parse the article:
+- Extract all numbered steps and UI element names
+- Identify which steps are Portal steps vs API steps
+- Build a test checklist
+
+Phase 2 — Execute tests:
+For each Portal step:
+  1. Use Playwright to navigate to the relevant portal section
+  2. Execute the step exactly as written
+  3. Record: PASS (matches article) / FAIL (discrepancy found)
+  4. For FAIL: note exact discrepancy (wrong label, missing button, changed
+     flow, prerequisite not mentioned in article)
+
+For each API step:
+  1. Execute the curl/API call from the article
+  2. Check response against expected outcome in article
+  3. Record: PASS / FAIL + details
+
+Phase 3 — Produce findings report:
+```
+## Audit findings: [article path]
+
+### Tested: [date]
+### Steps tested: [N]
+### Steps passed: [N]
+### Steps failed: [N]
+
+### Discrepancies
+1. [Step N] FAIL — Article says "X", portal shows "Y"
+2. [Step N] FAIL — Step skips prerequisite: user must first do Z
+...
+
+### Missing content
+- [anything the article should mention but doesn't]
+
+### Outdated content
+- [anything that is no longer true]
+```
+
+Phase 4 — Apply fixes (after user confirms findings):
+- Update article with confirmed fixes
+- Preserve voice and structure
+- Update `ai-navigation` if scope changed
+
+**Output:** Findings report first. Apply fixes only after user review.
+
+---
+
+### File 12: `.agents/skills/feature-draft/SKILL.md`
+
+**Purpose:** For product teams (non-writers). Takes a feature description
+and produces a documentation draft ready for writer review.
+
+**Inputs:** one or more of:
+- Jira ticket ID
+- Confluence page URL
+- Free-text description of the feature
+
+**Scope — read exactly these files:**
+1. This SKILL.md
+2. `.agents/references/mcp-tools.md` — all three MCP sections
+3. `.agents/references/content-types.md`
+4. `.agents/references/style-guide.md`
+5. `.agents/references/mdx-rules.md`
+6. Source material via MCP (Jira, Confluence)
+7. Existing article if updating, or one reference article if creating new
+
+**Process:**
+
+Phase 1 — Research:
+- Fetch Jira ticket (if provided): summary, description, acceptance criteria
+- Fetch Confluence pages (if linked): internal spec, release notes
+- Determine: is this a new feature (new article) or change to existing feature
+  (update existing article)?
+
+Phase 2 — Locate or create article:
+- If updating: find existing article path
+- If creating: determine correct product folder and article name
+
+Phase 3 — Test (if Playwright available and feature is UI-accessible):
+- Open portal, navigate to the new/changed feature
+- Execute the main user flow
+- Document steps from direct observation (not from spec alone)
+
+Phase 4 — Write draft:
+- Follow content-types.md for structure
+- Follow style-guide.md for voice
+- Mark uncertain sections with `{TODO: verify}` inline
+- For tabbed articles: write Portal section from Playwright observation,
+  mark API section as `{TODO: API section needed}`
+
+Phase 5 — Style check:
+- Verify frontmatter fields
+- Verify `ai-navigation` present and valid
+- Check for MDX issues
+- Check internal links are root-relative
+
+Phase 6 — Create PR draft:
+- Commit to a new branch: `feature-draft/{ticket-id}` or `feature-draft/{slug}`
+- PR title: `[Product] Draft: [feature name]`
+- PR body: brief summary + link to Jira ticket + `{TODO}` items listed
+
+**Output:** PR URL. The writer reviews and refines from there.
+
+---
+
+### File 13: `.agents/skills/cookbook/SKILL.md`
+
+**Purpose:** Compile a cookbook article — an end-to-end scenario guide that
+pulls steps from multiple existing articles.
+
+**Inputs:** scenario topic (e.g. "Set up CDN for video streaming with DDoS
+protection")
+
+**Scope — read exactly these files:**
+1. This SKILL.md
+2. `.agents/references/content-types.md` — cookbook structure
+3. `.agents/references/style-guide.md`
+4. `.agents/references/mdx-rules.md`
+5. Source articles found during step 2 of the process (search, then read)
+
+**Process:**
+
+Phase 1 — Understand the scenario:
+- Parse the topic into: who is the user, what do they want to achieve,
+  what Gcore products are involved
+
+Phase 2 — Find source articles:
+- Search repo for articles related to each product in the scenario
+- Read only the articles that contain relevant steps (not all articles)
+- Build a map: scenario step → source article → section
+
+Phase 3 — Design the structure:
+- Determine the end-to-end sequence of steps
+- Identify prerequisites (what the user must have set up already)
+- Identify the expected final outcome
+
+Phase 4 — Write the cookbook article:
+Structure:
+  ```
+  ---
+  title: [Scenario title]
+  ai-navigation: [one sentence, all products mentioned]
+  ---
+
+  ## Overview
+  [What this guide achieves, who it's for]
+
+  ## Prerequisites
+  [What must be in place before starting]
+
+  ## Step 1. [First major action]
+  [Steps + link to full article for details]
+
+  ## Step 2. [Second major action]
+  ...
+
+  ## Expected outcome
+  [What the user should see when done]
+  ```
+
+- Each step: brief instructions + reference link to the source article
+  for full details. Don't copy entire articles — link to them.
+- Use cross-product links, not inline repetition.
+
+**Output:** New file at `/cookbook/{scenario-slug}.mdx` or in the most
+relevant product folder. Show full content before saving.
+
+---
+
+## Key decisions made in the planning session
+
+1. **Two audiences, separate files:** CONTRIBUTING.md for humans (untouched
+   for now), AGENTS.md for AI agents.
+
+2. **AGENTS.md is a dispatch table**, not a manual. Critical rules inline,
+   everything else in skills and references.
+
+3. **Skills use explicit scope sections:** each SKILL.md starts with "read
+   exactly these files." This prevents the agent from reading all 1000 files
+   to "understand context."
+
+4. **References are pull, not push:** AGENTS.md does not tell the agent to
+   read references. Skills tell the agent to read specific references only
+   when the task requires it.
+
+5. **full-audit uses Playwright MCP** for real portal testing — not visual
+   inspection but actual step execution. Output is a structured findings report
+   before any edits are made.
+
+6. **api-use-case uses the OpenAPI YAML** already in the repo
+   (`/api-reference/services_documented/`) rather than guessing API behavior.
+
+7. **feature-draft creates a draft PR**, not a final article. The writer
+   reviews and refines. Uncertain sections are marked `{TODO: verify}`.
+
+8. **cookbook articles link to source articles**, not copy them. They are
+   navigation guides for end-to-end scenarios.
+
+---
+
+## Improvement backlog — findings from Cloudflare comparison
+
+Compared our system against `C:\Projects\cloudflare-docs\.agents\` on 2026-06-06.
+Items below are genuine gaps — things not found in docops-agent2 source files either.
+
+### HIGH priority
+
+**1. `AGENTS.md` — add "Common mistakes" section** DONE
+10 Gcore-specific mistakes added: MethodSwitch .jsx, description frontmatter,
+{identifier} in inline code, </MethodSection> indent, <p> wrap in MethodSection,
+#### heading leak, ai-navigation forbidden chars, image without extension,
+git add ., branching from stale main.
+
+**2. `style-guide.md` — missing specific rules:** DONE
+- Numbers formatting: added (spell out 0–9, digits for 10+, space before unit)
+- Voice rules: added (We/1st person for Gcore, but not every sentence; contractions OK except you're/I'm)
+- Contractions: explicitly allowed (it's, don't, can't, won't)
+- Heading: no infinitives, Step N. format: added
+- Product capitalization (Title Case): added
+- "(Optional)", "log in to", location/purpose before action: moved to procedures.md
+- Sentence length, "select vs click", placeholder format: not added — Cloudflare-specific, not Gcore convention
+
+**3. Adversarial review pattern** — NOT APPLICABLE
+Cloudflare uses this because they cannot run real tests. We already have something
+stronger: api-use-case has real API testing (Phase 2), full-audit has real Playwright
+testing. Real test results are stronger than any logical review by a second agent.
+The {TODO: verify} markers in write-from-scratch cover the case where testing
+is impossible (feature not yet live).
+
+### MEDIUM priority
+
+**4. Separate `skills/pr/SKILL.md`** DONE
+Standalone PR skill created. Product bracket inferred from file path via table.
+Skills write-from-scratch, api-use-case, update-page, full-audit now reference it.
+feature-draft already had its own PR logic (kept as-is, more detailed for contributors).
+
+**5. ELI5 / simplification skill** — NOT APPLICABLE
+Gcore's approach is to write accessibly from the start (medium-technical audience,
+value before mechanics, define terms on first use). Simplification is built into
+the style guide, not a post-processing step. A separate skill would duplicate this.
+
+### LOW priority (already mostly covered, minor gaps)
+
+**6. Reserved example values**
+No list of safe placeholder values for IPs and domains. Add to style-guide.md:
+`192.0.2.0/24`, `example.com` (RFC 5737 — don't resolve to live origins).
+
+**7. Inclusive language rules**
+Not in docops-agent2 source files. allowlist/blocklist, gender-neutral pronouns.
+Low priority for technical cloud docs aimed at developers.
+
+### What was NOT missing (clarifications)
+
+- **procedures.md**: Cloudflare separates step-writing rules into a dedicated file, but we
+  already have most of these rules in `style-guide.md`. Not a separate file needed.
+  The specific rules that ARE missing (Optional prefix, log in to, location/purpose before
+  action) are captured in item #2 above.
+- **Oxford comma**: Confirmed NOT in docops-agent2 source files. Cloudflare-specific.
+- **Many of the "missing" rules**: Were actually in docops-agent2 style-guide.md and
+  transferred to our style-guide.md correctly. The 2-sentence max, causal connectors,
+  forbidden words, cognitive load rules — all present.
+
+---
+
+## How to resume after a session restart
+
+Tell Claude:
+
+> "Read .agents/PLAN.md and continue from where we left off."
+
+That's it. No need to re-explain the architecture.

--- a/.agents/references/content-types.md
+++ b/.agents/references/content-types.md
@@ -1,0 +1,496 @@
+# Content Types — Gcore Product Documentation
+
+Defines the article types used in this repository, when to use each,
+and the required structure for each type.
+Load this file when a skill tells you to. Do not load it proactively.
+
+---
+
+## Decision: which type to use
+
+Answer these two questions before starting any article:
+
+**1. Does the feature have both a Customer Portal UI and a REST API?**
+- Yes → use a **Tabbed article** (MethodSwitch with portal + api sections)
+- Portal only → use a **Portal-only article**
+- API only → use an **API-only article**
+
+**2. For the API section — do the steps require sequential execution?**
+- Yes (outputs of earlier steps feed into later steps) → use **Structure A** (Quickstart + Step-by-step)
+- No (operations are independent, can be done in any order) → use **Structure B** (standalone sections)
+
+**Rule of thumb:** "create" and "deploy" articles are almost always sequential (Structure A).
+"manage" and "configure" articles are almost always independent (Structure B).
+Test: "Can the user do Step 3 without having done Steps 1 and 2?" If yes → Structure B.
+
+---
+
+## Type 1: Tabbed article (most common)
+
+### When to use
+
+The feature is accessible via both the Customer Portal UI and the REST API.
+All methods live in one MDX file — never create separate files per method.
+
+### File location
+
+```
+/{product}/{section}/{article-name}.mdx
+```
+
+### Frontmatter
+
+```yaml
+---
+title: Create a Virtual Machine
+sidebarTitle: Create an instance
+ai-navigation: Create Linux or Windows Virtual Machines in Gcore Cloud via Customer Portal by configuring image, flavor, volumes, network, and firewall, or via REST API using the Instances API.
+---
+```
+
+### Structure
+
+```mdx
+---
+title: ...
+sidebarTitle: ...
+ai-navigation: ...
+---
+
+import { MethodSwitch, MethodSection } from "/snippets/method-switch.jsx";
+
+<MethodSwitch>
+  <MethodSection id="portal" label="Customer Portal">
+
+  {Portal content — see Portal section rules below}
+
+  </MethodSection>
+  <MethodSection id="api" label="REST API">
+
+  {API content — use Structure A or Structure B depending on the flow}
+
+  </MethodSection>
+</MethodSwitch>
+```
+
+### Portal section rules
+
+- Opening sentence inside `<MethodSection>` — what the user will accomplish
+- Numbered steps using `1.` (not `1\.`) — see mdx-rules.md
+- Prose paragraphs between steps wrapped in `<p>` tags
+- Screenshots in `<Frame>` blocks after the relevant step
+- Bold for UI element names: Click **Create Instance**, In the **Name** field
+- No `####` headings — use bold text for sub-labels instead
+
+### API section — Structure A (sequential flow)
+
+Use when steps must be executed in order and outputs feed into later steps.
+
+```mdx
+<MethodSection id="api" label="REST API">
+
+{One intro sentence: what this section enables — not "The steps below..."}
+
+<Info>
+A permanent [API token](/account-settings/api-tokens) is required, along with a
+[project ID](...) and a [region ID](...).
+</Info>
+
+## Quickstart
+
+{One sentence: what the scripts do. Not "Complete scripts for the full flow."}
+
+<Tabs>
+  <Tab title="Python SDK">
+    ```python
+    # Step 1. ...
+    # Step 2. ...
+    ```
+  </Tab>
+  <Tab title="Go SDK">
+    ```go
+    // Step 1. ...
+    // Step 2. ...
+    ```
+  </Tab>
+</Tabs>
+
+## Step-by-step
+
+<p>Each step below explains what the call does, which parameters matter, and what the response looks like.</p>
+
+<Accordion title="Show all steps">
+
+### Step 1. {Verb + object}
+
+{One sentence: why this step is needed.}
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `param` | Yes | What it does |
+
+<Tabs>
+  <Tab title="Python SDK">```python ... ```</Tab>
+  <Tab title="Go SDK">```go ... ```</Tab>
+  <Tab title="curl">```bash ... ```</Tab>
+</Tabs>
+
+The API returns:
+
+```json
+{"tasks": ["abc-123"]}
+```
+
+</Accordion>
+
+</MethodSection>
+```
+
+### API section — Structure B (independent operations)
+
+Use when operations are unrelated and can be performed in any order.
+
+```mdx
+<MethodSection id="api" label="REST API">
+
+{One intro sentence.}
+
+<Info>...</Info>
+
+## {Operation name}
+
+{One sentence: what this operation does.}
+
+<Tabs>
+  <Tab title="Python SDK">```python ... ```</Tab>
+  <Tab title="Go SDK">```go ... ```</Tab>
+  <Tab title="curl">```bash ... ```</Tab>
+</Tabs>
+
+The API returns:
+
+```json
+{...}
+```
+
+## {Another operation name}
+
+...
+
+</MethodSection>
+```
+
+---
+
+## Type 2: Portal-only article
+
+### When to use
+
+The feature exists only in the Customer Portal UI, or the API tab has not been written yet.
+Mark the API tab as TODO if you know it will be added later.
+
+### Structure
+
+Same as Tabbed article but with only the portal `<MethodSection>`.
+If an API section will be added in the future:
+
+```mdx
+<MethodSwitch>
+  <MethodSection id="portal" label="Customer Portal">
+  {Portal content}
+  </MethodSection>
+  <MethodSection id="api" label="REST API">
+  <p>{TODO: API section — link to Jira ticket or note what is needed.}</p>
+  </MethodSection>
+</MethodSwitch>
+```
+
+Do not publish a completely empty API section — add the TODO note.
+
+---
+
+## Type 3: API-only article
+
+### When to use
+
+A standalone guide for performing a workflow entirely via REST API.
+Lives in `/{product}/via-api/` or `/{product}/api/`.
+No Customer Portal steps — no MethodSwitch component.
+
+### File location
+
+```
+/{product}/via-api/{article-name}.mdx
+```
+
+### Frontmatter
+
+```yaml
+---
+title: Deploy a Linux VM via API
+sidebarTitle: Deploy a VM
+ai-navigation: Deploy a Linux Virtual Machine using the Gcore Cloud REST API — create SSH keys, select a flavor and image, create the instance, and assign a floating IP address.
+---
+```
+
+### Structure A: sequential creation flow
+
+```mdx
+---
+...
+---
+
+{Opening sentence: what is built and why. No "This guide..."}
+
+<Info>
+A permanent [API token](/account-settings/api-tokens) is required, along with a
+[project ID](...) and a [region ID](...).
+</Info>
+
+Open a terminal and set these environment variables before running the examples:
+
+```bash
+export GCORE_API_KEY="{YOUR_API_KEY}"
+export GCORE_CLOUD_PROJECT_ID="{YOUR_PROJECT_ID}"
+export GCORE_CLOUD_REGION_ID="{YOUR_REGION_ID}"
+```
+
+## Quickstart
+
+{One sentence describing what the scripts do.}
+
+<Tabs>
+  <Tab title="Python SDK">```python ... ```</Tab>
+  <Tab title="Go SDK">```go ... ```</Tab>
+</Tabs>
+
+## Step-by-step
+
+<p>Each step below explains what the call does, which parameters matter,
+and what the response looks like.</p>
+
+<Accordion title="Show all steps">
+
+### Step 1. {Verb + object}
+
+{One sentence: why this step matters in the flow.}
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+
+<Tabs>
+  <Tab title="Python SDK">```python ... ```</Tab>
+  <Tab title="Go SDK">```go ... ```</Tab>
+  <Tab title="curl">```bash ... ```</Tab>
+</Tabs>
+
+The API returns:
+
+```json
+{"tasks": ["abc-123"]}
+```
+
+</Accordion>
+
+## {Optional section — standalone ##}
+
+{e.g., ## Clean up, ## Add an SSH key, ## Filter by OS}
+```
+
+### Structure B: independent operations (manage/configure)
+
+```mdx
+---
+...
+---
+
+{Opening sentence.}
+
+<Info>...</Info>
+
+```bash
+export GCORE_API_KEY="{YOUR_API_KEY}"
+...
+```
+
+## {Operation name}
+
+{One sentence.}
+
+<Tabs>
+  <Tab title="Python SDK">```python ... ```</Tab>
+  <Tab title="Go SDK">```go ... ```</Tab>
+  <Tab title="curl">```bash ... ```</Tab>
+</Tabs>
+
+## {Another operation name}
+```
+
+### Code tab order
+
+Always: **Python SDK → Go SDK → curl** (curl is always last).
+In Quickstart: Python SDK and Go SDK only — curl cannot be a single runnable script.
+
+### Quickstart script rules
+
+- Every logical step: `# Step 1.` (Python) or `// Step 1.` (Go) — never `# Step 3+4`
+- Script must run as-is after setting the three env vars — no other substitutions
+- Never hardcode region-specific IDs (flavor names, image IDs):
+  - Flavor: select by characteristics — `next(f for f in flavors if f.vcpus == 2 and f.ram == 4096)`
+  - Image: search by name pattern — `"ubuntu-22.04" in img.name`
+- Add a comment when selecting: `# IDs are region-specific; selects 2 vCPU / 4 GB RAM`
+
+### Forbidden sections in API articles
+
+- `## Prerequisites` — put requirements in the `<Info>` block
+- `## Next steps` / `## What's next` — use inline cross-links
+- `## Clean up` inside the accordion — it is always a standalone `##` section at the end
+
+---
+
+## Type 4: Overview / landing article
+
+### When to use
+
+A product or section landing page. Introduces the product, lists what the section covers,
+links to the main articles. Usually the `index.mdx` or `overview.mdx` of a folder.
+
+### Structure
+
+```mdx
+---
+title: Virtual Machines
+sidebarTitle: Overview
+ai-navigation: Overview of Gcore Cloud Virtual Machines — create, manage, connect, and configure VM instances using the Customer Portal or REST API.
+---
+
+{One paragraph: what this product is and what it enables. Value before mechanics.}
+
+## {Main topic 1}
+
+{One sentence intro.}
+
+- [Article name](/path/to/article)
+- [Article name](/path/to/article)
+
+## {Main topic 2}
+
+...
+```
+
+**Rules:**
+- No step-by-step instructions — link to the relevant how-to articles
+- No `## What's next` or `## Next steps`
+- No standalone link-dump sections — every link must have a sentence of context
+
+---
+
+## Type 5: Concept article
+
+### When to use
+
+Explaining what something is, how it works architecturally, when to use it.
+Not a step-by-step guide. No MethodSwitch.
+
+### Structure
+
+```mdx
+---
+title: Load Balancer overview
+sidebarTitle: Overview
+ai-navigation: ...
+---
+
+{One paragraph: what this thing is and what problem it solves.}
+
+## How it works
+
+{Explanation of the mechanism. Use Formula A/B from style-guide.md.}
+
+## {Use cases / When to use}
+
+{Describe the scenarios where this applies.}
+
+## {Limitations / Known constraints}
+
+{Only if there are non-obvious constraints the reader needs before starting.}
+```
+
+**Rules:**
+- No numbered steps — this is explanation, not instruction
+- No `## Prerequisites`
+- Link to the relevant how-to article at the end using an inline link, not a `## Next steps` section
+
+---
+
+## Type 6: Cookbook article
+
+### When to use
+
+An end-to-end scenario guide that pulls steps from multiple products or sections.
+The reader wants to accomplish a complete real-world goal (e.g., "set up CDN for video
+streaming with DDoS protection"). Lives in `/cookbook/` or in the most relevant product folder.
+
+### File location
+
+```
+/cookbook/{scenario-slug}.mdx
+```
+or
+```
+/{primary-product}/use-cases/{scenario-slug}.mdx
+```
+
+### Structure
+
+```mdx
+---
+title: {Scenario title — what the reader will have when done}
+sidebarTitle: {Short label}
+ai-navigation: {All products involved, the outcome.}
+---
+
+{One paragraph: who this guide is for and what they will achieve.
+Mention all Gcore products involved.}
+
+## Prerequisites
+
+{Integrate as prose in the opening paragraph OR as a brief inline list.
+Never as a separate `## Prerequisites` section with bullets.}
+
+## Step 1. {First major action}
+
+{Brief instructions — 3–5 sentences max. Then link to the source article for full details.}
+
+See [full instructions](/path/to/source-article) for the complete steps.
+
+## Step 2. {Second major action}
+
+...
+
+## Expected outcome
+
+{What the reader should see when done. One paragraph.}
+```
+
+**Rules:**
+- Each step: brief instructions + link to the source article for full details
+- Do NOT copy entire articles — link to them
+- Cross-product links, not inline repetition of other articles' content
+- `## Expected outcome` is the only section allowed at the end — no `## Next steps`
+
+---
+
+## Choosing between existing types: quick reference
+
+| Situation | Type to use |
+|-----------|-------------|
+| Feature exists in Portal AND API, steps are sequential | Tabbed, Structure A |
+| Feature exists in Portal AND API, operations are independent | Tabbed, Structure B |
+| Feature exists only in Portal | Portal-only |
+| Standalone API guide, sequential flow | API-only, Structure A |
+| Standalone API guide, manage/configure | API-only, Structure B |
+| Section landing page | Overview |
+| Explaining what something is | Concept |
+| End-to-end scenario across products | Cookbook |
+| API tab not yet written | Tabbed with TODO placeholder in api section |

--- a/.agents/references/mcp-tools/confluence.md
+++ b/.agents/references/mcp-tools/confluence.md
@@ -1,0 +1,100 @@
+# Confluence MCP — Reference
+
+Instructions for using Confluence MCP to find internal product documentation.
+Load this file when a skill tells you to. Do not load it proactively.
+
+---
+
+## When to use Confluence
+
+Confluence contains internal Gcore documentation that is not in Jira or in the
+public docs repo. Use it when you need:
+
+- Product specs and technical requirements for a feature
+- Release notes and changelogs written by engineering
+- Architecture decisions and design docs
+- Known limitations and edge cases documented by the product team
+- API field definitions and expected behavior
+
+**Do not use Confluence content directly in public documentation.** It is internal.
+Use it to understand the feature, then write the public doc in your own words following
+the style guide.
+
+---
+
+## Key operations
+
+```
+confluence_get_page(page_id)           — fetch a specific page by ID
+confluence_search(query, space)        — search pages by keyword
+confluence_get_page_children(page_id)  — list child pages under a page
+confluence_get_space(space_key)        — get info about a Confluence space
+```
+
+---
+
+## What to look for
+
+When researching a feature for documentation:
+
+| What to find | What it tells you |
+|---|---|
+| Feature spec or PRD | What the feature does, who it is for, edge cases |
+| Release notes (internal) | Exact changes, affected endpoints, rollout status |
+| Architecture doc | How the system works — useful for concept articles |
+| Known issues or limitations | What to warn users about |
+| API field definitions | Field names, types, allowed values — verify against OpenAPI YAML |
+
+---
+
+## Search strategy
+
+Start broad, then narrow:
+
+1. **Search by feature name:**
+   ```
+   confluence_search("load balancer L7 policies")
+   ```
+
+2. **Search by Jira ticket key** — engineers often link Confluence pages in tickets:
+   ```
+   confluence_search("DOC-1142")
+   ```
+
+3. **Search by product area:**
+   ```
+   confluence_search("CDN origin groups", space="CLOUD")
+   ```
+
+4. **Follow links from Jira** — the linked dev ticket often has a Confluence page
+   linked in its description or comments. Fetch that page directly by ID.
+
+---
+
+## Using Confluence content safely
+
+Confluence pages are internal and may contain:
+- Information not yet released to customers
+- Internal implementation details not suitable for public docs
+- Placeholder text or draft content that has not been reviewed
+
+**Rules:**
+- Never copy Confluence text verbatim into public documentation
+- Verify technical details (field names, values, behavior) against the OpenAPI YAML
+  in `/api-reference/services_documented/` — Confluence may be outdated
+- If Confluence contradicts the OpenAPI spec, trust the spec
+- If Confluence describes a feature as "not yet released" — do not document it without
+  confirming with the user
+
+---
+
+## When Confluence is not helpful
+
+Confluence search may return:
+- Unrelated pages with the same keywords
+- Outdated docs from old product versions
+- Internal team wikis not related to the feature
+
+If you cannot find useful content after 2–3 searches, proceed with what you have
+from the Jira ticket, the OpenAPI spec, and (for portal features) Playwright testing.
+Do not block work on finding a Confluence page.

--- a/.agents/references/mcp-tools/jira.md
+++ b/.agents/references/mcp-tools/jira.md
@@ -1,0 +1,177 @@
+# Jira MCP — Reference
+
+Instructions for using Jira MCP to fetch and process documentation tickets.
+Load this file when a skill tells you to. Do not load it proactively.
+
+---
+
+## Project and ticket format
+
+- **Project:** DOC
+- **Ticket format:** `DOC-{number}` — e.g. `DOC-1030`, `DOC-1142`
+- Tickets that do not start with `DOC-` are not documentation tickets — stop processing
+
+---
+
+## Key operations
+
+```
+jira_get_issue(issue_id)          — fetch full ticket with all fields and comments
+jira_search(jql)                  — search tickets by JQL query
+jira_get_linked_issues(issue_id)  — get tickets linked to this one
+jira_add_comment(issue_id, text)  — add a comment to a ticket
+jira_transition(issue_id, id)     — change ticket status (use transition IDs below)
+```
+
+---
+
+## What to extract from a ticket
+
+When fetching a ticket, collect:
+
+| Field | Why |
+|-------|-----|
+| `summary` | The headline — what needs to be documented |
+| `description` | Full context of the change |
+| `status` | Determines if work can start — see status table below |
+| `reporter` | Who created the ticket (SME or team contact) |
+| `assignee` | Who is responsible |
+| `labels` | May indicate product area or type |
+| `linked issues` | Usually points to the dev ticket with technical details |
+| `comments` | May contain blockers, updates, clarifications from SMEs |
+| `attachments` | Screenshots, specs, Confluence links |
+
+Read all comments — blockers and important clarifications often appear in comments,
+not in the description.
+
+---
+
+## Status table
+
+| Status | Category | Agent can work? |
+|--------|----------|-----------------|
+| Backlog | To Do | **YES** |
+| To Do | To Do | **YES** |
+| Reopened | To Do | **YES** — treat as To Do |
+| In Progress | In Progress | NO — someone else is working |
+| In Review | In Progress | NO — already submitted |
+| Blocked | In Progress | NO — on hold |
+| BLOCKED- Need Info | In Progress | NO — waiting for SME answer |
+| In SEO review | In Progress | NO — treat as In Review |
+| Done | Done | NO — already completed |
+| Cancelled | Done | NO |
+
+**If the status is not in the YES list — stop immediately.** Do not read the article,
+do not make changes. Report the status and why work cannot start.
+
+---
+
+## Blocker detection in comments
+
+Before starting work, scan all comments for:
+- "wait for..." / "waiting for..."
+- "not ready" / "on hold"
+- "blocked by..." / "depends on..."
+- "feature not released" / "not in production"
+- Any indication work should not start yet
+
+If blocking comments are found — stop and report to the user.
+
+---
+
+## Status transitions
+
+### When to change status
+
+| Event | New status | Transition ID |
+|-------|-----------|---------------|
+| Starting work on a ticket | In Progress | 11 (from To Do) |
+| Need SME answer | BLOCKED- Need Info | 91 |
+| Draft ready, PR created | In Review | 81 (from In Progress) |
+| Ticket is not documentable | Cancelled | 131 |
+
+### Full transition path (Backlog → In Review)
+
+```
+Backlog --[101]--> To Do --[11]--> In Progress --[81]--> In Review
+```
+
+**Rules:**
+- Never change the status of a ticket that is not in To Do / Backlog
+- Always add a comment when changing status — explain why
+- Use "BLOCKED- Need Info" (not "Blocked") when waiting for answers
+- Use @mention for the reporter or assignee when adding a blocking comment
+
+---
+
+## JQL queries
+
+### Find tickets ready to work on
+
+```jql
+project = DOC
+AND status IN (Backlog, "To Do", Reopened)
+AND assignee IS EMPTY
+ORDER BY created DESC
+```
+
+### Find all unfinished tickets
+
+```jql
+project = DOC
+AND status NOT IN (Done, Cancelled)
+ORDER BY updated DESC
+```
+
+### Find tickets waiting for info
+
+```jql
+project = DOC
+AND status = "BLOCKED- Need Info"
+ORDER BY updated DESC
+```
+
+### Search by keyword
+
+```jql
+project = DOC
+AND text ~ "load balancer"
+AND status IN (Backlog, "To Do")
+ORDER BY created DESC
+```
+
+---
+
+## Linked dev ticket
+
+Most DOC tickets have a linked dev ticket (from engineering). Always fetch it:
+
+1. Get linked issues from the DOC ticket
+2. Find the link with type "is caused by" or "relates to" or "is blocked by"
+3. Fetch that ticket to get technical details:
+   - What changed in the product
+   - Which API endpoints were added or modified
+   - Which UI screens were affected
+   - Acceptance criteria (most detailed technical spec)
+
+Dev ticket stakeholders matter:
+- If stakeholders are **only internal teams** (Team DX, DevOps, Support, Backend Team)
+  → the change is likely not customer-facing → classify as INTERNAL_DOC or NOT_DOCUMENTABLE
+- If stakeholders include customers or customer-facing teams → proceed with documentation
+
+---
+
+## Ticket classification (quick rules)
+
+Before doing any documentation work, classify the ticket. Full classification logic is
+in `.agents/skills/jira-context/SKILL.md`. Quick rules:
+
+| Signal | Classification |
+|--------|----------------|
+| `[BUG]` in title (product bug, not doc typo) | BUG_FIX → cancel |
+| `/admin/` API, internal stakeholders only | INTERNAL_DOC → cancel |
+| Refactoring, library update, DB migration | NOT_DOCUMENTABLE → cancel |
+| New feature visible to customers | PUBLIC_PRODUCT_DOC → proceed |
+| Customer-visible error or troubleshooting | PUBLIC_TROUBLESHOOTING → proceed |
+| Doc typo, grammar, outdated screenshot | PUBLIC_PRODUCT_DOC → update |
+| `api-reference/` YAML file changes | NOT_DOCUMENTABLE → cancel (backend owns this) |

--- a/.agents/references/mcp-tools/playwright.md
+++ b/.agents/references/mcp-tools/playwright.md
@@ -1,0 +1,273 @@
+# Playwright MCP — Browser Testing Guide
+
+Instructions for using Playwright MCP to test portal UI steps and capture screenshots.
+Load this file when a skill tells you to. Do not load it proactively.
+
+---
+
+## Available tools
+
+```
+mcp__playwright__browser_navigate   — open a URL
+mcp__playwright__browser_click      — click a UI element
+mcp__playwright__browser_type       — type into a field
+mcp__playwright__browser_snapshot   — get DOM/accessibility tree (read UI labels)
+mcp__playwright__browser_screenshot — capture the current page visually
+mcp__playwright__browser_evaluate   — run JavaScript (scroll, zoom, collapse sidebar)
+mcp__playwright__browser_select     — select from a dropdown
+mcp__playwright__browser_hover      — hover over an element
+```
+
+**Key distinction:**
+- Use `browser_snapshot` to **read** current UI element names, labels, button text
+- Use `browser_screenshot` to **capture** a visual for comparison or saving
+
+When verifying that UI matches an article — always `browser_snapshot` first to read
+the actual labels, then `browser_screenshot` to capture if a new screenshot is needed.
+
+---
+
+## Portal access
+
+```
+URL:   https://portal.gcore.com/
+Login: SSO only — use sergey.kostichev@gcore.com
+```
+
+Do not use username/password login — it will not work on this account.
+
+---
+
+## SSO login flow
+
+The SSO login requires one manual step from the user. Follow this sequence:
+
+1. Navigate to `https://auth.gcore.com/login/signin`
+2. Click **SSO**
+3. Enter `gcore.com` in the "Work domain" field and press Enter
+4. Microsoft login page appears — enter `sergey.kostichev@gcore.com` and click **Next**
+5. **STOP — ask the user to complete Windows Hello authentication** (Face, fingerprint, PIN, or security key). A native OS-level dialog appears on their desktop. Playwright cannot automate this step.
+6. After the user confirms, the browser lands on `https://portal.gcore.com/accounts/reports/dashboard`
+
+**Why user input is required:** Playwright runs a fresh browser context with no cached
+credentials. Microsoft's FIDO2/passkey flow opens a native OS dialog that cannot be
+automated. Do not attempt to bypass it — ask the user to confirm, then continue.
+
+---
+
+## Screenshot capture standards
+
+### Before every screenshot
+
+1. **Collapse the portal sidebar.** The left sidebar occludes the main content area.
+   Use `browser_evaluate` to collapse it, or click the collapse icon on the left edge.
+   Verify the sidebar is gone before taking the screenshot.
+
+2. **Scroll to the target element:**
+   ```javascript
+   // browser_evaluate
+   document.querySelector('selector').scrollIntoView()
+   ```
+
+3. **Set zoom if needed:**
+   ```javascript
+   // Zoom in — target is small or text is hard to read
+   document.body.style.zoom = '1.25'
+
+   // Zoom out — target is wide (tables, multi-column layouts)
+   document.body.style.zoom = '0.8'
+
+   // Reset after capturing
+   document.body.style.zoom = '1'
+   ```
+
+### Capture settings
+
+| Setting | Rule |
+|---------|------|
+| Browser width | 1280px minimum (1440px for wide layouts) |
+| Zoom | 100% unless adjusted per above |
+| Theme | Light mode only |
+| Language | English (US) |
+| Personal data | None visible — no real emails, names, user IDs, tokens |
+| Browser chrome | Crop out toolbar, tab bar, address bar, OS taskbar |
+| Cursor | Not visible in screenshot |
+| Selected text | Not visible in screenshot |
+
+### Framing
+
+Do not submit a full-page screenshot when the subject is a small part of the page.
+
+- **Crop to the dialog or form:** use the `clip` parameter in `browser_screenshot`
+- **Zoom in** when controls or labels would otherwise be too small to read
+- **Zoom out** when a wide table would cause horizontal scrolling artifacts
+- Be dynamic — adjust zoom, scroll position, and clip per screenshot
+
+### File format
+
+- **Format:** PNG for all UI screenshots
+- **Extension:** lowercase `.png` — never `.PNG`
+- **Size:** under 500 KB — compress with pngquant if over limit
+
+### Naming
+
+- Descriptive lowercase names with hyphens only — no spaces, underscores, camelCase
+- Name describes what is shown, not the step number:
+  - Good: `create-instance-form.png`
+  - Bad: `step-3.png`
+- **Always rename when replacing a screenshot** — reusing the same filename causes CDN
+  caching where the old image stays visible after publishing
+- **Delete the old file** after renaming: `git rm old-name.png`
+
+### Alt text
+
+- Required on every image
+- Under 125 characters, sentence case (capitalize first word only)
+- Describe what is shown, not what the user should do
+- Do not start with "Screenshot of", "Image of", "A picture of"
+
+| Bad | Good |
+|-----|------|
+| `Screenshot of the DNS page` | `DNS records list with the Add record button highlighted` |
+| `Image showing the create form` | `Instance creation form with flavor and region fields` |
+
+### Annotations
+
+- No red arrows
+- Highlight rectangles (subtle stroke) only when the target is not obvious from the text
+- Annotations are done in Figma using the Screenshots for product docs library
+
+---
+
+## Image verification before publishing
+
+Before finalising any article that contains images, verify every image actually exists.
+
+### Check each image reference
+
+For each `<Frame>`, `<img>`, or `![]()` in the article:
+
+1. Extract the path from `src="..."` or `![](...)`
+2. Check the file exists:
+   ```powershell
+   Test-Path "C:\Projects\product-documentation{image-path}"
+   ```
+3. If the file does not exist — flag it. Do not change the path without confirming
+   the file exists at the new location.
+
+**Critical rule:** never change an image path without first verifying the file
+exists with the new name. Changing a path to a non-existent file breaks the image silently.
+
+### Detect corrupted image files
+
+Some files in the repo are data URIs saved as files instead of actual images.
+Check the first bytes before using a file:
+
+```powershell
+$bytes = [System.IO.File]::ReadAllBytes("C:\Projects\product-documentation\images\file.png")[0..3]
+```
+
+Valid signatures:
+- PNG: `137 80 78 71` (bytes: `0x89 0x50 0x4E 0x47`)
+- JPEG: `255 216 255` (bytes: `0xFF 0xD8 0xFF`)
+- GIF: `71 73 70` (bytes: `0x47 0x49 0x46`)
+
+If the file starts with `100 97 116 97 58` (= "data:") — it is a corrupted data URI:
+
+```powershell
+$content = Get-Content "corrupted-file" -Raw
+if ($content -match "base64,(.+)") {
+    $decoded = [Convert]::FromBase64String($Matches[1])
+    [System.IO.File]::WriteAllBytes("fixed-file.png", $decoded)
+}
+```
+
+### Fix broken images
+
+If an image file is missing or has no extension:
+1. Rename/copy to correct name with `.png` extension
+2. Update the path in the article to match
+3. Both changes go in the same commit
+4. Note the change in the changelog file
+
+**Images must have a file extension.** A file without `.png`, `.jpg`, or `.gif`
+will not display in browsers.
+
+---
+
+## Screenshot file path limitation
+
+`browser_screenshot` with a `filename` parameter can only save files inside the
+**current working directory** of the active project. It cannot write directly to
+`C:\Projects\product-documentation`.
+
+**Workaround:** Save to the current project directory first, then copy with PowerShell:
+
+```powershell
+Copy-Item ".\screenshot.png" `
+          "C:\Projects\product-documentation\images\docs\{product}\{slug}\screenshot.png" -Force
+```
+
+Screenshot storage path in the docs repo:
+```
+C:\Projects\product-documentation\images\docs\{product}\{article-slug}\{filename}.png
+```
+
+Referenced in MDX as:
+```
+/images/docs/{product}/{article-slug}/{filename}.png
+```
+
+**Folder rule:** every article has its own subfolder matching the article path.
+Article `account-settings/my-profile/overview.mdx` → images at
+`images/docs/account-settings/my-profile/overview/`.
+Never save images to the product root folder.
+
+---
+
+## Known portal quirks
+
+Update this section when you discover new quirks during testing.
+
+- **Login is SSO only** — no username/password option on the login page
+- **Portal URL structure:** `https://portal.gcore.com/{product}/...` — some products
+  use different sub-paths; confirm by navigating in the browser
+- **If `mcp__playwright__*` tools are unavailable** at session start: restart Claude Desktop.
+  Do not attempt portal verification without Playwright — it is mandatory.
+- **Playwright availability check:** if ToolSearch returns no matches for playwright,
+  stop and tell the user before starting any audit work
+
+---
+
+## Testing protocol (for full-audit skill)
+
+When executing an article step-by-step:
+
+1. Open the portal and navigate to the section the article describes
+2. Follow the article's steps in order, as a real user would
+3. At each step, use `browser_snapshot` to read actual current UI labels
+4. Use `browser_screenshot` to capture screens that have a corresponding screenshot
+5. Record every divergence in FINDING format:
+
+```
+FINDING: [category]
+Location: Step N / screenshot name
+Article says: "..."
+Portal shows: "..."
+Action needed: rename / reorder / add step / update screenshot / remove
+```
+
+Categories:
+- Wrong UI element names
+- Changed navigation path
+- Step order changed
+- Missing steps (new mandatory step not in article)
+- Outdated screenshots
+- Missing sections (new feature not documented)
+- Wrong field names
+- Deprecated options
+
+**Do not fix anything during testing. Collect findings first, apply fixes after.**
+
+If the task cannot be completed (feature gated, account limitation, region unavailable):
+note the blocker, describe how far you got, mark specific findings as unverified.

--- a/.agents/references/mcp-tools/setup.md
+++ b/.agents/references/mcp-tools/setup.md
@@ -1,0 +1,197 @@
+# MCP Tools — Setup Check
+
+Read this file at the start of any task that requires Jira, Confluence, or Playwright.
+
+Before using an MCP tool, verify it is available by attempting a minimal call.
+If a tool is unavailable, stop the task and give the user the exact setup instructions below.
+Do not proceed without the required tool — do not work around it or skip portal verification.
+
+---
+
+## Playwright
+
+### How to check
+Attempt to call `mcp__playwright__browser_navigate`. If the tool is not found — tell the user:
+
+---
+
+> **Playwright MCP is not configured for this project.**
+>
+> To fix this, create a file called `.mcp.json` in the root of the
+> `product-documentation` folder with this content:
+>
+> ```json
+> {
+>   "mcpServers": {
+>     "Playwright": {
+>       "command": "npx",
+>       "args": ["@playwright/mcp@latest"],
+>       "env": {}
+>     }
+>   }
+> }
+> ```
+>
+> **Requirements:**
+> - Node.js must be installed. Check: open a terminal and run `node --version`.
+>   If not installed, download from https://nodejs.org (LTS version).
+>
+> **After creating the file:** restart Claude Desktop, then try again.
+
+---
+
+## Confluence
+
+### How to check
+Attempt to call `mcp__confluence__search` or `mcp__confluence__get_page`.
+If the tool is not found — tell the user:
+
+---
+
+> **Confluence MCP is not configured.**
+>
+> To fix this, you need:
+>
+> **Step 1 — Get a personal access token:**
+> 1. Go to https://wiki.gcore.lu
+> 2. Click your profile avatar → **Profile**
+> 3. Navigate to **Personal Access Tokens**
+> 4. Click **Create token**, give it a name, set expiry
+> 5. Copy the token — it is shown only once
+>
+> **Step 2 — Add to Claude Desktop config:**
+>
+> Open `%APPDATA%\Claude\claude_desktop_config.json` and add inside `"mcpServers"`:
+>
+> ```json
+> "confluence": {
+>   "command": "node",
+>   "args": ["C:/Projects/anton-wiki/wiki/dist/server.js"],
+>   "env": {
+>     "CONFLUENCE_URL": "http://wiki.gcore.lu",
+>     "CONFLUENCE_PERSONAL_TOKEN": "<paste your token here>"
+>   }
+> }
+> ```
+>
+> **Note:** The server file must exist at `C:/Projects/anton-wiki/wiki/dist/server.js`.
+> If it is missing, ask your team for the `anton-wiki` project and run `npm install` inside it.
+>
+> **After editing the file:** restart Claude Desktop, then try again.
+
+---
+
+## Jira
+
+### How to check
+Attempt to call `mcp__jira__get_issue` with any ticket ID (e.g. `DOC-1`).
+If the tool is not found — tell the user:
+
+---
+
+> **Jira MCP is not configured.**
+>
+> To fix this, you need:
+>
+> **Step 1 — Install the Jira MCP server:**
+>
+> Open a terminal and run:
+> ```powershell
+> pip install jira-mcp-server
+> ```
+> If `pip` is not available, install Python first: https://www.python.org/downloads/
+>
+> **Step 2 — Get a personal access token:**
+> 1. Go to https://jira.gcore.lu
+> 2. Click your profile avatar (top right) → **Profile**
+> 3. Navigate to **Personal Access Tokens**
+> 4. Click **Create token**, give it a name
+> 5. Copy the token — it is shown only once
+>
+> **Step 3 — Add to Claude Desktop config:**
+>
+> Open `%APPDATA%\Claude\claude_desktop_config.json` and add inside `"mcpServers"`:
+>
+> ```json
+> "jira": {
+>   "command": "python",
+>   "args": ["-c", "from jira_mcp_server.server import main; main()"],
+>   "env": {
+>     "JIRA_MCP_URL": "https://jira.gcore.lu",
+>     "JIRA_MCP_TOKEN": "<paste your token here>",
+>     "JIRA_MCP_VERIFY_SSL": "false"
+>   }
+> }
+> ```
+>
+> **After editing the file:** restart Claude Desktop, then try again.
+
+---
+
+## Where is `claude_desktop_config.json`?
+
+On Windows, the file is at:
+```
+C:\Users\<your-username>\AppData\Roaming\Claude\claude_desktop_config.json
+```
+
+Quick way to open it: press `Win + R`, paste this, press Enter:
+```
+%APPDATA%\Claude\claude_desktop_config.json
+```
+
+The file must be valid JSON. If Claude Desktop fails to start after editing,
+check for missing commas or extra brackets using https://jsonlint.com
+
+---
+
+## After any setup change
+
+Always restart Claude Code after editing `claude_desktop_config.json` or `.mcp.json`.
+Changes do not take effect until restart.
+
+## Critical: MCP tools must be connected before starting a session
+
+MCP tool schemas are loaded once at the start of a conversation.
+If a tool connects mid-session, its tools are **not available** in the current conversation.
+
+**If a tool shows "Failed to connect" at session start:**
+1. Exit the session
+2. Fix the connection issue (install browsers, check PATH, restart)
+3. Verify with `claude mcp list` — all required tools show ✓ Connected
+4. Start a new session
+
+**For Playwright specifically:** run `npx playwright install` once to install browsers
+before starting any session that requires portal testing.
+
+---
+
+## Mintlify local preview
+
+Not an MCP tool — a CLI for previewing the documentation site locally before pushing.
+
+### Check if installed
+
+```powershell
+mintlify --version
+```
+
+### Install if missing
+
+Requires Node.js (https://nodejs.org, LTS version):
+
+```powershell
+npm i -g mintlify
+```
+
+### Run
+
+From the repository root (`C:\Projects\product-documentation`):
+
+```powershell
+mintlify dev
+```
+
+Port is chosen automatically (default 3000, increments if taken).
+Run in a separate terminal window — does not need to be running for other tasks.
+The URL appears in that terminal once ready.

--- a/.agents/references/mdx-rules.md
+++ b/.agents/references/mdx-rules.md
@@ -1,0 +1,316 @@
+# MDX Rules — Gcore Product Documentation
+
+Technical rules for MDX files in this repository.
+All rules are Mintlify-specific and have been verified against real articles.
+Load this file when a skill tells you to. Do not load it proactively.
+
+---
+
+## MethodSwitch component
+
+`MethodSwitch` is a custom component that renders tabbed content (Customer Portal,
+REST API, Terraform, CLI) in a single MDX file. It is the only approved way to cover
+multiple methods in one article — never create separate files.
+
+### Import line
+
+Always import with the full `.jsx` extension:
+
+```mdx
+import { MethodSwitch, MethodSection } from "/snippets/method-switch.jsx";
+```
+
+**Missing `.jsx` renders the entire article as a blank page with no error.**
+The MDX compiler (`@mdx-js/mdx`) does NOT catch this — the blank page appears
+only in the Mintlify runtime. Always verify the import when an article renders empty.
+
+### Structure
+
+`<MethodSwitch>` wraps both sections. `label` belongs on `<MethodSection>`, not on `<MethodSwitch>`.
+
+**Correct:**
+```jsx
+<MethodSwitch>
+  <MethodSection id="portal" label="Customer Portal">
+  ...
+  </MethodSection>
+  <MethodSection id="api" label="REST API">
+  ...
+  </MethodSection>
+</MethodSwitch>
+```
+
+**Wrong — self-closing MethodSwitch with MethodSection outside:**
+```jsx
+<MethodSwitch methods={[...]} />
+
+<MethodSection id="portal">
+...
+</MethodSection>
+```
+
+### Tab IDs and labels
+
+| `id` | `label` | Status |
+|------|---------|--------|
+| `portal` | `Customer Portal` | Active |
+| `api` | `REST API` | Active |
+| `terraform` | `Terraform` | Planned |
+| `cli` | `CLI` | Planned |
+
+- `portal` always comes first — it is the default tab
+- Do not add `terraform` or `cli` tabs until the content exists
+
+### No content before `<MethodSwitch>`
+
+All article content — including intro paragraphs — must be INSIDE a `<MethodSection>`.
+Nothing goes between the import line and `<MethodSwitch>`.
+
+### Content rules inside `<MethodSection>`
+
+`<MethodSection>` is a passthrough component. When nested inside `<MethodSwitch>`,
+MDX compiles its children in **expression mode**, not flow mode. Plain markdown
+paragraphs become text strings — blank lines are stripped and content runs together.
+
+**Rules for all content inside `<MethodSection>`:**
+
+**1. Numbered steps — use `1.` (not `1\.`):**
+```
+1. Go to **Networking** > **Security Groups**.
+2. Find the required security group and click its name.
+```
+Sub-items indent 3 spaces:
+```
+1. Open the creation form:
+   - In the Cloud menu, click **Create**.
+   - On the VM creation page, go to **Networking**.
+```
+
+**2. Prose paragraphs between steps — wrap in `<p>` tags:**
+```mdx
+<p>Both options can be combined. If neither is specified, the rule applies to all IP addresses.</p>
+```
+Do NOT leave prose paragraphs unwrapped — they merge with adjacent content and render
+as one unbroken block.
+
+**3. Bullet-only lists — use `-` at column 0:** `<ul>/<li>` is block-level and renders correctly without wrapping.
+
+**4. JSX components (`<Info>`, `<Frame>`, `<Warning>`, `<Note>`):** always block-level, no special treatment needed.
+
+### Closing tag indent after a list
+
+When a markdown list item immediately precedes `</MethodSection>` or `<MethodSection>`,
+that tag must have **zero indentation**. Any indentation causes MDX to treat the tag
+as list-item continuation content — the tag becomes invisible to the parser.
+
+**Wrong (tag indented after list):**
+```markdown
+- Last bullet item.
+
+  </MethodSection>
+  <MethodSection id="api" label="REST API">
+```
+
+**Correct (tag at column 0):**
+```markdown
+- Last bullet item.
+
+</MethodSection>
+<MethodSection id="api" label="REST API">
+```
+
+Symptoms when violated: numbered steps appear merged into the preceding paragraph;
+JSX structure appears broken in the active section.
+
+### No `####` headings inside `<MethodSection>`
+
+`MethodSwitch` hides TOC entries only for `h2[id]` and `h3[id]`. Any `####` (h4)
+heading inside an inactive `<MethodSection>` is **not hidden** and leaks into the
+active tab's TOC.
+
+**Wrong:**
+```markdown
+#### Sharing a pool across multiple listeners
+```
+
+**Correct — use bold text instead:**
+```markdown
+**Sharing a pool across multiple listeners**
+```
+
+### Prose before `<Accordion>` loses spacing
+
+When a prose paragraph immediately precedes an `<Accordion>` inside `<MethodSection>`,
+Mintlify does not apply `margin-bottom` to the paragraph — the accordion visually
+"glues" to the text above it.
+
+**Fix — wrap the paragraph in an explicit `<p>` tag:**
+
+**Wrong:**
+```markdown
+Each step below explains what the call does.
+
+<Accordion title="Show all steps">
+```
+
+**Correct:**
+```markdown
+<p>Each step below explains what the call does.</p>
+
+<Accordion title="Show all steps">
+```
+
+Applies to every prose paragraph that immediately precedes `<Accordion>` inside any
+`<MethodSection>`. Does not affect content outside JSX.
+
+---
+
+## Frontmatter
+
+Every article must have these fields in the frontmatter block:
+
+```yaml
+---
+title: Create a Virtual Machine
+sidebarTitle: Create an instance
+ai-navigation: Create Linux or Windows Virtual Machines in Gcore Cloud via Customer Portal or via REST API.
+---
+```
+
+### Field rules
+
+| Field | Required | Notes |
+|-------|----------|-------|
+| `title` | Always | Full title shown in browser tab and page heading |
+| `sidebarTitle` | Optional | Shorter label for the left sidebar navigation |
+| `ai-navigation` | Required for tabbed articles | See rules below |
+| `description` | **NEVER USE** | Mintlify renders it as visible text on the page |
+
+### `ai-navigation` rules
+
+This field is read by AI agents scanning the sitemap. It must be a single plain English
+sentence describing what the article covers.
+
+**Required:**
+- One sentence, ending with a period
+- Starts with an action verb: Create, Configure, Manage, Enable, etc.
+- Mentions all methods covered: "via Customer Portal or via REST API"
+- Max 160 characters
+- No "you", "your", "this article", "learn how to"
+
+**Strictly forbidden — these break the YAML parser and crash the Mintlify build:**
+- Curly braces: `{task_id}` or `{variable}` — even inside apparent text
+- Slashes: `/cloud/v1/tasks` — no URL paths
+- Colons: any `:` inside the value — YAML treats it as a key separator
+- Hash: `#` — YAML treats it as a comment start
+- Backticks, square brackets, pipe characters
+
+The CI `sanitize-ai-navigation` workflow auto-replaces `:` and `#` with ` -`,
+but the result may look wrong. Avoid these characters from the start.
+
+**Safe:** commas, periods, hyphens, parentheses, semicolons, capitalized product names,
+descriptive terms without symbols ("task ID", "project ID")
+
+**Good examples:**
+```yaml
+ai-navigation: Create Linux or Windows Virtual Machines in Gcore Cloud via Customer Portal by configuring image, flavor, volumes, network, and firewall, or via REST API using the Instances API.
+ai-navigation: Create, use, or delete permanent API tokens with configurable expiration dates and role-based access control.
+```
+
+**Bad examples (will break build):**
+```yaml
+ai-navigation: Poll GET /cloud/v1/tasks/{task_id} until state is FINISHED.
+ai-navigation: Configure the Authorization: APIKey header.
+```
+
+---
+
+## MDX parsing gotchas
+
+### `{identifier}` inside backtick inline code spans
+
+MDX parses `{identifier}` inside single-backtick spans as JSX expressions. If the
+identifier is a valid JavaScript name (`task_id`, `project_id`, `LB_VIP`), the parser throws.
+
+**Wrong (breaks MDX):**
+```
+Poll `GET /cloud/v1/tasks/{task_id}` every 5 seconds.
+```
+
+**Correct — use HTML `<code>` tag with `&nbsp;` inside:**
+```
+Poll <code>GET&nbsp;/cloud/v1/tasks/{task_id}</code> every 5 seconds.
+```
+
+`{...}` inside triple-backtick fenced code blocks is always safe.
+Characters that are not valid JS identifiers (e.g. `{|}~`) are also safe inside backtick spans.
+
+### UTF-8 BOM at the start of a file
+
+Files must not start with a UTF-8 BOM (`\xEF\xBB\xBF`). A BOM before the `---`
+frontmatter delimiter breaks the YAML parser and produces a generic "parsing error"
+with no line number.
+
+**Check:**
+```powershell
+python -c "d=open('article.mdx','rb').read(); print('BOM' if d.startswith(b'\xef\xbb\xbf') else 'OK')"
+```
+
+**Strip:**
+```python
+data = open('article.mdx', 'rb').read()
+if data.startswith(b'\xef\xbb\xbf'):
+    open('article.mdx', 'wb').write(data[3:])
+```
+
+---
+
+## Internal links
+
+All internal links must be root-relative:
+
+**Correct:**
+```mdx
+See the [VM guide](/cloud/virtual-instances/create-an-instance).
+```
+
+**Wrong — full URL:**
+```mdx
+See the [VM guide](https://docs.gcore.com/cloud/virtual-instances/create-an-instance).
+```
+
+**Wrong — old path that no longer exists:**
+```mdx
+See the [VM guide](/cloud/api/virtual-instances/create-an-instance).
+```
+
+The `/cloud/api/` directory no longer exists. All merged articles live at
+`/cloud/{section}/{article}`.
+
+Anchor links work as usual:
+```mdx
+[SSH key setup](/cloud/virtual-instances/create-an-instance#step-1-add-an-ssh-key)
+```
+
+---
+
+## Validation
+
+Validate MDX locally before committing. The compiler gives exact error line and column numbers,
+unlike the generic "parsing error" shown in the browser.
+
+```powershell
+# Install once (run from any temp dir)
+cd C:\Temp; npm install @mdx-js/mdx
+
+# Validate an article
+node -e "
+const {compile}=require('@mdx-js/mdx');
+const fs=require('fs');
+const c=fs.readFileSync('path/to/article.mdx','utf8');
+compile(c).then(()=>console.log('OK')).catch(e=>console.error('ERROR:',e.message));
+"
+```
+
+**Note:** the compiler does NOT catch the missing `.jsx` extension in the MethodSwitch
+import — that error appears only in the Mintlify runtime.

--- a/.agents/references/procedures.md
+++ b/.agents/references/procedures.md
@@ -1,0 +1,175 @@
+# Procedures — Writing Step-by-Step Instructions
+
+Rules for writing numbered steps in how-to articles and tutorials.
+Load this file when a skill tells you to write or review procedural content.
+
+---
+
+## Step format
+
+```mdx
+1. Navigate to **Settings** > **API Keys**.
+
+2. Click **Create New Key**.
+
+3. In the dialog:
+   - Enter a **Name** for the key
+   - Select the **Permissions**
+   - Click **Create**
+
+4. Copy the key and store it securely.
+```
+
+Blank line between every numbered item. Sub-items indent 3 spaces under their parent.
+
+---
+
+## Order within a step
+
+### Location before action
+
+State where the reader must go before telling them what to do.
+
+| Bad | Good |
+|-----|------|
+| "Select **Add record** in the **DNS** section." | "In the **DNS** section, select **Add record**." |
+| "Click **Save** on the settings page." | "On the settings page, click **Save**." |
+
+### Purpose before action
+
+State why the reader is doing something before the action itself — when the purpose
+is not already obvious from context.
+
+| Bad | Good |
+|-----|------|
+| "Select **Delete** to remove the rule." | "To remove the rule, select **Delete**." |
+| "Click **Verify** to confirm the certificate." | "To confirm the certificate, click **Verify**." |
+
+Do not apply this rule mechanically to every step — only when the purpose adds
+meaningful context. "To save, click **Save**" is tautological and should be
+just "Click **Save**."
+
+---
+
+## Optional steps
+
+Prefix optional steps with exactly `(Optional)` as the first word:
+
+```
+(Optional) Enter a description for the key.
+```
+
+Not "Optional:", not "(optional)", not "Optionally, ...". The exact prefix is `(Optional)`.
+
+---
+
+## Login steps
+
+Write "log in to" as three words. Never "log into".
+
+**Wrong:** "Log into the Gcore Customer Portal."
+**Correct:** "Log in to the [Gcore Customer Portal](https://portal.gcore.com)."
+
+Consolidate login and navigation into a single step when they are always done together:
+
+**Over-split:**
+```
+1. Log in to the Customer Portal.
+2. Go to Cloud > Virtual Machines.
+```
+
+**Correct:**
+```
+1. Log in to the [Gcore Customer Portal](https://portal.gcore.com) and go to
+   **Cloud** > **Virtual Machines**.
+```
+
+---
+
+## Single-step procedures
+
+Do not create a numbered list for a single step. Fold the action into the
+introductory sentence instead.
+
+**Wrong:**
+```
+To reset your password:
+
+1. Click **Forgot password** on the login page.
+```
+
+**Correct:**
+```
+To reset your password, click **Forgot password** on the login page.
+```
+
+---
+
+## Sub-step hierarchy
+
+For nested steps, use letters then Roman numerals:
+
+```
+1. Configure the listener:
+   a. Set **Protocol** to HTTPS.
+   b. Set **Port** to 443.
+   c. Add a certificate:
+      i. Click **Add certificate**.
+      ii. Select the certificate from the list.
+```
+
+Do not go deeper than three levels (number → letter → Roman numeral). If a procedure
+requires a fourth level, restructure it into separate top-level steps.
+
+---
+
+## Numbered vs. bullet lists
+
+Use numbered lists only when order matters and skipping a step would break the flow.
+If steps can be done in any order, use bullet points.
+
+| Use numbers | Use bullets |
+|-------------|-------------|
+| Configuring a resource in sequence | Listing supported formats |
+| Installation steps | Feature capabilities |
+| Troubleshooting steps that build on each other | Prerequisites already met |
+
+---
+
+## Notes and warnings in procedures
+
+Use MDX components for callouts within steps. Place them after the step text
+they relate to — not before.
+
+```mdx
+<Note>
+Supplementary context that is not critical to completing the step.
+</Note>
+
+<Warning>
+Information the reader must know to avoid data loss or breakage.
+</Warning>
+
+<Tip>
+Best practice or shortcut the reader might find useful.
+</Tip>
+
+<Info>
+Prerequisites, access requirements, or environment setup.
+</Info>
+```
+
+Callout rules:
+- One callout per step maximum
+- No "you" or "your" inside callouts — same rule as prose
+- Keep callouts to 1–2 sentences. If more is needed, it belongs in the step text.
+
+---
+
+## What not to do
+
+- Do not start step text with a gerund: "Selecting **Save**" → "Select **Save**"
+- Do not number steps that are not sequential — use bullets
+- Do not add "Please" in instructions
+- Do not use directional language: not "click the button on the right" — reference by name
+- Do not document keyboard shortcuts in procedures

--- a/.agents/references/review-process.md
+++ b/.agents/references/review-process.md
@@ -1,0 +1,154 @@
+# Review Process
+
+Six-step process for reviewing any documentation article.
+Load this file when a skill tells you to run the review process.
+
+Follow steps sequentially. Do not batch-read all steps upfront.
+Complete and fix each step fully before moving to the next.
+
+---
+
+## Step 1 — Structure
+
+Run grep checks, fix all matches, then do manual scan.
+
+```powershell
+# Forbidden heading openers
+grep -n "^## What \|^## How \|^## Why \|^## When " article.mdx
+
+# Forbidden sections
+grep -n "^## Next steps\|^## Prerequisites\|^## Requirements\|^## Related documentation\|^## See also\|^## What" article.mdx
+
+# Meta-preamble openers
+grep -n "^This guide covers\|^This article\|^In this \|^This tutorial\|^This guide walks\|^This guide shows" article.mdx
+```
+
+**Manual checks:**
+- Every `##` and `###` heading is followed by a prose sentence before any code/table/list
+- No two consecutive headings without text between them
+- Opening paragraph does not describe the document — it states what the reader achieves
+- No separate `## Prerequisites` section — requirements are in the opening paragraph
+
+---
+
+## Step 2 — Formatting
+
+```powershell
+# Bold used outside UI elements (verify each match)
+grep -n "\*\*[^*]+\*\*" article.mdx
+
+# Unspaced em-dashes
+grep -n "[^ ]—\|—[^ ]" article.mdx
+```
+
+**Manual checks:**
+- Each bold match: is it a UI button, field name, or section name? If not — remove bold
+- After any table or code block introducing 3+ new terms: verify an orienting sentence follows
+- All tab groups (`<Tabs>`) have the same set of tabs throughout the article
+- Screenshots appear AFTER the step text, not before or in the middle
+
+---
+
+## Step 3 — Links
+
+```powershell
+# Link text longer than ~2 words (15+ characters between brackets)
+grep -n "\[[^\]]\{15,\}\](" article.mdx
+
+# Standalone link sentences (banned patterns)
+grep -n "For more details\|^See \[\|Learn more in\|Refer to \[\|For more information" article.mdx
+
+# All URLs — list for duplicate check
+grep -n "](https\?://" article.mdx
+```
+
+**Manual checks:**
+- For each URL appearing more than once: all occurrences after the first must be plain text
+- No sentence whose only purpose is to contain a link
+
+---
+
+## Step 4 — Voice
+
+```powershell
+# Forbidden words
+grep -in "\bjust\b\|\bsimply\b\|\bobviously\b\|\bclearly\b\|\bensure\b\|\bbe sure\b\|\bmake sure\b\|\betc\b\|\bplatform\b\|\bsuch as\b" article.mdx
+
+# "you" and "your" in prose
+grep -in "\byou\b\|\byour\b" article.mdx
+```
+
+**Manual checks:**
+- Fix all "you/your" in authored prose — skip code blocks and terminal output verbatim
+- Fix all "you/your" inside `<Info>`, `<Note>`, `<Warning>`, `<Tip>` blocks as well
+- Read adjacent sentence pairs — join cause-effect or contrast pairs with a connector
+- Verify consistent voice throughout (tutorial or reference — not mixed)
+
+---
+
+## Step 5 — Content accuracy
+
+```powershell
+# Find all internal links
+grep -n "\](/[^)]+)" article.mdx
+
+# Find all image references
+grep -n "src=\"\|!\[" article.mdx
+```
+
+**Verify each internal link:**
+1. Extract the path from the link
+2. Check if file exists at `{repo_root}/{path}.mdx` or `{repo_root}/{path}/index.mdx`
+3. If not found → flag as broken
+
+**Verify each image:**
+1. Extract the path from src or `![]()` syntax
+2. Check file exists at `C:\Projects\product-documentation\{path}`
+3. If not found → flag as broken
+4. Do not change an image path without confirming the file exists at the new path
+
+**Content checks:**
+- Technical information matches the OpenAPI spec or live portal
+- Code examples are syntactically correct
+- Each fact appears only once — no duplicate content across sections
+
+---
+
+## Step 6 — Final read
+
+Read the full article once as a medium-technical reader encountering it for the first time.
+
+Fix anything that:
+- Causes a pause or requires re-reading
+- Sounds mechanical or machine-generated
+- Contains a sentence that could appear in three different articles (too generic)
+- Has a section that exists only to host a link
+
+**Anti-patterns caught in review:**
+- Opening sentence is a template ("The Gcore API provides programmatic access...")
+- Section heading followed by one thin sentence — either expand or merge
+- Closing sentence points to the next article ("With these basics in place, the next step is...")
+- JSON block directly after `</Tabs>` without a label
+- Numbered list that is not truly sequential (use bullets instead)
+
+---
+
+## Report format
+
+After completing all six steps:
+
+```
+Review complete: [article path]
+
+Issues fixed:
+- [N] structure issues
+- [N] formatting issues
+- [N] link issues
+- [N] voice issues
+- [N] content accuracy issues
+
+Remaining (needs human decision):
+- [issue] at [location] — [why it needs human decision]
+
+Status: ready / needs human review
+```

--- a/.agents/references/style-guide.md
+++ b/.agents/references/style-guide.md
@@ -1,0 +1,656 @@
+# Style Guide — Gcore Product Documentation
+
+Canonical writing and formatting rules for all documentation work.
+Load this file when a skill tells you to. Do not load it proactively.
+
+---
+
+## Target audience
+
+The reader is a **medium-technical Gcore customer**: a developer or DevOps engineer
+who knows cloud infrastructure (VMs, networks, APIs) but may not know the specific
+Gcore product being documented.
+
+- Knows: cloud concepts, CLI tools, APIs, JSON/YAML, basic scripting
+- May not know: the specific Gcore service, its terminology, its configuration format
+- Goal: get something working as fast as possible, without reading more than necessary
+
+**Rules:**
+- Define every product-specific term on first use. One sentence: "A provider is a plugin that..." not "The provider connects to..."
+- Do not open with jargon. If the first sentence requires prior knowledge, rewrite it.
+- Show value before mechanics. The reader needs to understand *why* before *how*.
+
+**Self-check:** Read the article's first three sentences aloud. If a medium-technical
+reader would stop and ask "what is X?" without finding an answer — rewrite before continuing.
+
+---
+
+## Voice and tone
+
+### No meta-preamble openers
+
+Never open with a sentence that describes the document itself.
+
+**Banned openers:**
+- `This guide covers...`
+- `This article explains...`
+- `In this document, you will learn...`
+- `This tutorial walks you through...`
+- `This section describes...`
+
+Start with the subject matter directly.
+
+| Bad | Good |
+|-----|------|
+| "This guide covers installing Terraform and configuring the Gcore provider." | "Terraform manages infrastructure as code through configuration files — a [Gcore account](...) and a [permanent API token](...) are the only requirements." |
+| "This article explains how import works." | "Terraform import reads an existing resource's state from the API and writes it to the state file." |
+
+### No "you" or "your" in authored prose
+
+Rephrase to imperative (without subject) or neutral third person.
+This applies everywhere — body text, `<Info>`, `<Note>`, `<Warning>`, `<Tip>` blocks.
+
+| Bad | Good |
+|-----|------|
+| "You need a permanent API token." | "A permanent API token is required." |
+| "Your configuration file should include..." | "The configuration file must include..." |
+| "When you run terraform plan..." | "When running terraform plan..." |
+| "It is not linked to your Gcore account." | "It is not linked to the Gcore account." |
+
+**Exception:** terminal output verbatim (e.g. "Your infrastructure matches the configuration") — do not alter.
+
+### Voice — who is the subject
+
+Use the right subject for each situation:
+
+| Situation | Voice | Example |
+|-----------|-------|---------|
+| Gcore does something automatically | 1st person plural | "We support SRT and WebVTT formats." |
+| Explaining a technology or feature | 3rd person | "5G technology improves industrial automation." |
+| Gcore as a product providing something | 3rd person | "Gcore provides the following disk types." |
+| Instruction for the reader | Imperative (no subject) | "Navigate to the DNS section." |
+
+**"We" for Gcore:** use it, but not in every sentence. Vary with 3rd person to avoid repetition.
+
+### Contractions
+
+Common contractions are allowed — they make documentation sound like a real person wrote it.
+
+Allowed: it's, don't, can't, won't, doesn't, they're, we've, there's
+
+Avoid contractions that include "you" or "I" (you're, you'll, I'm, I'd) — these conflict with the no "you/your" rule.
+
+### Be direct
+
+- Active voice — avoid passive where possible
+- Imperative mood for instructions — no "you should", just the action
+- Avoid passive constructions: "The configuration must be updated" → "Update the configuration"
+
+**Good:** "Click **Save** to apply changes."
+**Good:** "Navigate to **DNS** > **Records**."
+**Good:** "Gcore configures X automatically."
+**Good:** "We support SRT and WebVTT formats."
+**Bad:** "The Save button should be clicked to apply changes."
+
+### Consistent voice within an article
+
+Every article must maintain one voice throughout:
+- **Tutorial voice** (guides, how-to): direct, action-oriented, explains what happens and what to do next
+- **Reference voice** (API docs, resource indexes): concise, neutral, states facts without narration
+
+Do not mix. A tutorial section that drifts into reference tone must be rewritten.
+
+---
+
+## Sentence structure
+
+### Causal connectors
+
+Two adjacent sentences that share a cause-effect or contrast relationship must be
+joined with a connector, not separated by a full stop.
+
+| Relationship | Connector | Example |
+|---|---|---|
+| Cause | because, as, since | "Pin the version because v0 and v2 use incompatible formats." |
+| Contrast | while, whereas | "New projects start with v2, while existing projects stay on v0." |
+| Result | so, which means | "It syncs automatically, so new resources become available faster." |
+| Condition | when, if | "When the project grows, split config into multiple files." |
+
+**Bad:** "Specify the version to avoid upgrades. v0 and v2 have different formats."
+**Good:** "Specify the version to avoid upgrades, because v0 and v2 use different, incompatible formats."
+
+### Paragraph flow and transitions
+
+The opening sentence of each paragraph must establish its relationship to the previous one.
+
+| Type | Signal |
+|------|--------|
+| Narrowing | "For [specific case],..." / "When [condition],..." |
+| Causal | "As a result,..." / "This means..." |
+| Continuation | Start with "It" or "This" referring back explicitly |
+| Contrast | "Unlike v0,..." / "In contrast,..." |
+
+### Stop when the point is made
+
+If a sentence already makes a complete point, stop. Do not append "— specifically in X, Y, and Z"
+unless the enumeration is genuinely necessary for the reader to act correctly.
+
+When "everywhere" or "in all cases" is used, a list that follows is usually redundant.
+
+### Avoid redundant reassurance
+
+State a reassurance once — at the moment it is most useful. Repeating "no infrastructure
+will be created" three times in one page patronizes the reader.
+
+### Do not over-explain the obvious
+
+A medium-technical reader knows how to click a button, type a value, open a terminal,
+and read a prompt. Do not explain actions that the interface or terminal output already describes.
+
+**Forbidden:**
+- Showing a terminal prompt that says `Enter a value: yes` then writing "Type `yes` when prompted"
+- Explaining what a button does after the reader just clicked it
+- "Click **Save** to save your changes" — saving is implied by clicking Save
+
+### No redundancy or tautology
+
+Do not restate information the reader already has from a heading, table, code block, or the previous sentence.
+
+| Bad | Why |
+|-----|-----|
+| "follow the migration guide for step-by-step instructions" | a guide already implies step-by-step |
+| "different schemas and are not interchangeable" | "not interchangeable" is implied by "different schemas" |
+| prose repeating what a table just said | paragraph must add context the table does not contain |
+
+---
+
+## Paragraph writing formulas
+
+Use these formulas for writing concise, non-repetitive paragraphs.
+These are structure rules, not example text.
+
+### Formula A: Two semantic steps (one paragraph = 2 sentences max)
+
+**Sentence 1 (WHAT):**
+```
+{Vendor} {enables|includes|supports} {Feature} {by default|automatically} {in|on|for} {Scope}.
+```
+
+**Sentence 2 (WHY):**
+```
+It {mechanism}, {benefit}.
+```
+
+**Rules:**
+- Feature name appears ONCE (sentence 1), then only "It" or "This"
+- "automatic/by default" appears ONCE, NOT in sentence 2
+- No filler in sentence 2: "significantly", "advanced", "optimization", "performance benefits"
+- After sentence 2: STOP. No sentence 3.
+
+### Formula B: Mechanism → Effect
+
+Structure: `It {mechanism} → {effect}.`
+
+One mechanism, one effect. Not: "reduces A and B and C".
+
+### Formula C: Third idea = new paragraph
+
+If a third semantic step is needed ("when to use"), it is a NEW paragraph:
+```
+Paragraph 1: Formula A (2 sentences)
+
+Paragraph 2: This matters most for {workload_type}.
+```
+
+### Formula D: Confidence based on source
+
+- Fact exists in source material → `It {does X}.`
+- Fact not in source material → Do NOT write. Or: `It can {do X} on supported configurations.`
+
+**Forbidden without source:** "typically", "always", "significantly", "in most cases"
+
+### Formula E: No root-word pairs in one paragraph
+
+These pairs are **forbidden** in the same paragraph:
+
+| Word 1 | Word 2 | Fix |
+|--------|--------|-----|
+| optimize | optimization | use "improve" instead of one |
+| reduce | reduction | use "lower" or "decrease" instead |
+| configure | configuration | use "set up" or "settings" instead |
+| automatic | automatically | keep only one |
+| perform | performance | rewrite sentence |
+
+### Self-check before finishing a paragraph
+
+- [ ] 2 sentences maximum
+- [ ] Feature mentioned once, then "It"
+- [ ] No root-word pairs
+- [ ] No filler words
+- [ ] 30–50 words
+
+If any check fails — DELETE and rewrite. Do not "slightly adjust".
+
+---
+
+## Structure and headings
+
+### Headings
+
+- **Sentence case:** "Create a virtual machine" — not "Create a Virtual Machine"
+- **Length:** 5–8 words maximum
+- **Levels:** H2 for main sections, H3 for subsections
+- **Form:** declarative or imperative only
+
+**Forbidden heading patterns:**
+
+| Forbidden | Use instead |
+|-----------|-------------|
+| `## What changes in v2` | `## Changes in v2` |
+| `## How import works` | `## Import process` |
+| `## When to use import` | `## Use cases` |
+| `## What is a provider?` | `## Provider overview` |
+| `## Why use Terraform?` | `## Terraform overview` |
+
+Any heading starting with **What, How, Why, When** is forbidden.
+
+**No infinitives in headings.** Use action verbs, not "To + verb":
+
+| Bad | Good |
+|-----|------|
+| `## To create a project` | `## Create and configure projects` |
+| `## To enable the feature` | `## Enable the feature` |
+
+Exception: FAQ articles where the title is a question.
+
+**Step headings** use "Step N." format with a period after the number:
+```
+## Step 1. Clone the repository
+## Step 2. Configure the provider
+```
+
+**Headings are noun phrases, not instructions.**
+A heading describes a topic — it does not tell the reader to do something.
+
+| Bad | Good |
+|-----|------|
+| `## Find the endpoint URL` | `## Endpoint URL` |
+| `## Send a request` | `## Chat completions` |
+| `## Secure the endpoint` | `## Endpoint authentication` |
+| `## List available models` | `## Available models` |
+
+**No consecutive headings.**
+A heading must not be immediately followed by another heading. Write at least
+1–2 sentences of text before the next heading.
+
+### Every heading needs an intro sentence
+
+After every `##` and `###` heading, the next line must be a prose sentence.
+A code block, table, or list appearing immediately after a heading is a violation.
+
+**Bad:**
+```
+### Authentication
+
+| | v0 | v2 |
+```
+
+**Good:**
+```
+### Authentication
+
+Both versions use the same token value, but the attribute name and environment variable changed.
+
+| | v0 | v2 |
+```
+
+### Forbidden sections
+
+These headings must never appear:
+
+| Forbidden | Why |
+|-----------|-----|
+| `## Next steps` | Sidebar already shows structure; use inline cross-links |
+| `## Prerequisites` | Integrate into the opening paragraph |
+| `## Requirements` | Same as Prerequisites |
+| `## Related documentation` | No link dumps; link inline where topic is relevant |
+| `## See also` | Same as Related documentation |
+| `## What's next` | Same as Next steps |
+
+### Opening paragraph rules
+
+- No meta-preamble (see Voice section)
+- Start with the subject matter: what the product does, or what the reader achieves
+- Prerequisites go in the opening paragraph as plain text, not a separate section
+- Every article opens with its own unique sentence — never a template sentence that could appear in three different articles
+
+---
+
+## Links
+
+### Link once per destination per article
+
+If a URL has already appeared as a link, all subsequent mentions are **plain text**.
+The first occurrence is the canonical link.
+
+### Link text: 1–2 words maximum
+
+The link text must be the noun or short verb phrase that names the destination.
+Never use a full clause, sentence fragment, or description.
+
+| Bad | Good |
+|-----|------|
+| `[install Terraform and configure the provider first](...)` | `[install the provider](...)` |
+| `[v2 documentation on Terraform Registry](...)` | `[v2 documentation](...)` |
+| `[follow the migration guide for step-by-step instructions](...)` | `[migration guide](...)` |
+
+### Banned link sentence patterns
+
+These create empty sentences. Merge the link into the previous sentence instead.
+
+- `For more details, see [X]`
+- `See [X] for more information`
+- `Learn more in [X]`
+- `For details, see [X]`
+- `Refer to [X] for`
+- Any standalone sentence whose only purpose is to host a link
+
+**Bad:**
+```
+For more details, see [API tokens](/account-settings/api-tokens).
+```
+
+**Good:**
+```
+Generate a [permanent token](/account-settings/api-tokens) in account settings.
+```
+
+### Links must carry meaning
+
+No separate sentence constructed to host a link.
+Embed the link into an existing content sentence as a natural part of the text.
+
+**Forbidden:** "The full parameter list is in the [API reference](...)." — this sentence carries no information beyond the link. If no natural sentence exists for the link, remove the link entirely.
+
+### Gcore Customer Portal naming
+
+| Context | Use |
+|---------|-----|
+| First mention in article | `[Gcore Customer Portal](https://portal.gcore.com)` |
+| All subsequent mentions | plain text: "the Customer Portal" (no link, no "Gcore" prefix) |
+
+---
+
+## Formatting
+
+### Bold
+
+Bold is **only** for:
+- Clickable UI elements: Click **Save**
+- UI field names: In the **Name** field, enter...
+- Section names the reader must find on a page: the **Import** section
+
+**Never use bold for:**
+- Technical terms or concepts being introduced
+- Table row labels or column labels
+- Emphasis on important words mid-sentence
+
+**Exception:** version labels directly before paired code blocks (`**v0:**` / `**v2:**`)
+may use bold to visually separate the two blocks.
+
+If a concept needs emphasis, rewrite the sentence so the concept carries weight through
+structure. Use a definition pattern: "A provider is a plugin that..." not "The **provider** is a plugin that..."
+
+### Em-dash spacing
+
+Always use a **spaced** em-dash: ` — ` (space before and after).
+Never use an unspaced em-dash `—`.
+
+| Wrong | Correct |
+|-------|---------|
+| `configuration files—a Gcore account` | `configuration files — a Gcore account` |
+| `API calls—it defines` | `API calls — it defines` |
+
+### Code
+
+- Inline code: backticks — `api_key`, `terraform plan`
+- Code blocks: fenced with language tag — ` ```bash `, ` ```json `, ` ```powershell `
+- File names referenced inline: backticks — `providers.tf`
+- Include expected terminal output when it helps verify a step succeeded
+
+### Consistent tab sets
+
+All tab groups (`<Tabs>`) in an article must have the same set of tabs.
+If one section has Python SDK + Go SDK + curl, every other section must have
+Python SDK + Go SDK + curl. No mixing tab sets within an article.
+
+### Cognitive load density
+
+After any table or code block that introduces 3+ new terms, add at least one orienting
+sentence before the next code block or table.
+
+**Signs of excessive density:**
+- Three or more config attribute names in one sentence
+- A paragraph requiring the reader to hold more than two new concepts simultaneously
+- A table immediately followed by a code block followed by another table with no prose break
+
+### Tables
+
+- Use for structured comparisons, not for information that reads naturally as prose
+- Keep column headers short
+- Row labels in the first column: plain text, no bold
+- Every table needs a real intro sentence — not one that just restates what the table shows
+
+---
+
+## Procedures
+
+For full step-writing rules — format, ordering, Optional prefix, login steps,
+sub-step hierarchy, notes and warnings — see `.agents/references/procedures.md`.
+
+### No stub sections
+
+A section heading followed by one thin sentence is a stub. If a section cannot be
+explained in at least 2–3 meaningful sentences, expand it or fold it into a neighbouring section.
+
+---
+
+## Images and screenshots
+
+### When to include
+
+- Complex UI workflows where the path is non-obvious
+- Settings that are hard to describe in prose
+- Verification steps ("after clicking Apply, the status changes to Active")
+
+### When to skip
+
+- Simple single-click actions described in one sentence
+- Frequently changing UI elements
+
+### Screenshot placement
+
+Screenshots go **after** the step text that describes them — never before, never
+in the middle of a step. The reader reads what to do, then sees what it looks like.
+
+**Wrong:**
+```
+<Frame>![Create instance form](screenshot.png)</Frame>
+
+1. In the **Name** field, enter a name for the instance.
+```
+
+**Correct:**
+```
+1. In the **Name** field, enter a name for the instance.
+
+<Frame>![Create instance form with Name field highlighted](screenshot.png)</Frame>
+```
+- Anything the prose already makes unambiguous
+
+### Screenshot requirements
+
+- **Format:** PNG
+- **Alt text:** required, under 125 characters, sentence case, describes what is shown
+- **Alt text bad:** "Screenshot of the DNS page"
+- **Alt text good:** "DNS records list with the Add record button highlighted"
+
+Full screenshot capture rules (browser settings, crop, zoom, sidebar collapse) are in
+`.agents/references/mcp-tools/playwright.md`.
+
+---
+
+## Terminology and naming
+
+### Gcore naming
+
+| Context | Use |
+|---------|-----|
+| First mention of portal | Gcore Customer Portal |
+| Subsequent mentions | the Customer Portal |
+| Company as subject | Gcore (not "the platform", "the system", "we") |
+| API | Gcore API |
+
+### Forbidden words
+
+| Forbidden | Why | Use instead |
+|-----------|-----|-------------|
+| platform | Vague | Gcore, Gcore Customer Portal, or specific service name |
+| ensure, be sure, make sure | Not an action | verify, check, confirm |
+| simply, just | Filler, condescending | remove entirely |
+| obviously, clearly | Condescending | remove entirely |
+| etc., and so on | Vague | complete the list explicitly |
+| leverage, utilize | Corporate jargon | use |
+| seamlessly, robust, scalable | Marketing filler | say what it actually does |
+| programmatic access | Vague | what specifically: creates VMs, configures networks |
+| for example (inline) | Breaks sentence flow | restructure the sentence or use a dash |
+| such as | Implies incomplete list | complete the list or restructure |
+
+### Common terms
+
+| Use this | Not this |
+|----------|----------|
+| click | click on |
+| select | choose |
+| enter | type in |
+| navigate to | go to |
+| API key | api key, API Key |
+| email address | email, e-mail |
+
+### Inclusive language
+
+Replace outdated terms. There are 19+ occurrences of these in the existing docs
+and new articles should use the preferred terms from the start.
+
+| Avoid | Use instead | Notes |
+|-------|------------|-------|
+| whitelist | allowlist | Always replaceable |
+| blacklist | blocklist | Always replaceable |
+| master (Kubernetes) | control plane | "master node" → "control plane node" |
+| master (database) | primary | "master/slave replication" → "primary/replica" |
+| slave (database) | replica | |
+
+**Exception — do not change:**
+- "master playlist" in HLS/video streaming context — this is the official term from the HLS specification and changing it would be technically incorrect
+
+### Spelling (US English)
+
+| Use (US) | Not (UK) |
+|----------|----------|
+| behavior | behaviour |
+| color | colour |
+| center | centre |
+| organize | organise |
+
+**Exception:** API identifiers, tag names, and system-generated content that use UK
+spelling must be preserved exactly as they appear in the system.
+
+### Avoid mechanical phrasing
+
+Read each sentence aloud. If it sounds machine-generated, rewrite it.
+
+| Mechanical | Natural |
+|---|---|
+| "all commands run in a terminal window" | "all interaction happens through a terminal window" |
+| "no graphical interface exists" | "there is no application to launch" |
+| "the installation process completes" | "once installed" |
+
+Avoid noun-verb repetition within two adjacent sentences (e.g., "install" → "installation").
+
+---
+
+## Multi-article updates
+
+### No copy-paste between articles
+
+Each article has its own context and purpose. Adapt content to each article's context.
+
+- **create-* article:** focus on what happens during creation
+- **manage-* article:** focus on runtime behavior and limitations
+
+### Cross-reference instead of duplicate
+
+If detailed explanation exists in one article, link to it from others. Do not duplicate the explanation.
+
+### No "Next steps" sections
+
+No `## Next steps` at the end of articles. The sidebar navigation already shows the
+full content structure. Use inline cross-links within the article text where the connection is meaningful.
+
+---
+
+## Numbers
+
+- Spell out whole numbers zero through nine in body text: "three regions", "nine nodes"
+- Use digits for 10 and above: "10 instances", "128 nodes"
+- Always use digits for: measurements, limits, port numbers, version numbers, API values
+- Always include a space between a number and its unit: "128 GB", "10 Gbps", "30 s"
+- Unit symbols do not take a plural: "10 MB", not "10 MBs"
+- Use a comma for numbers with four or more digits: "1,000 requests", "10,000 records"
+
+---
+
+## Capitalization
+
+### Product and feature names — Title Case
+
+Gcore product names and named features always use Title Case, everywhere:
+
+| Title Case (correct) | Lowercase (wrong) |
+|----------------------|-------------------|
+| Bare Metal | bare metal |
+| Virtual Machines | virtual machines |
+| Cloud | cloud |
+| Video Streaming | video streaming |
+| Reserved IP | reserved IP |
+| Origin Shielding | origin shielding |
+| Object Storage | object storage |
+
+Match the exact capitalization from the Gcore Customer Portal UI and official product pages.
+
+### General capabilities and settings — sentence case
+
+Generic descriptions, page titles, and settings use sentence case:
+
+| Sentence case (correct) | Title Case (wrong) |
+|-------------------------|-------------------|
+| Create a virtual machine | Create a Virtual Machine |
+| Configure logging | Configure Logging |
+| Manage your account | Manage Your Account |
+
+### When in doubt
+
+If a term appears capitalized in the Gcore Customer Portal, capitalize it in docs.
+If it is a general technical concept, use lowercase.
+
+---
+
+## No section exists only for a link
+
+The following patterns are forbidden:
+- "The full parameter list is in the [API reference](...)."
+- "Full task management endpoints are in the [API reference](...)."
+- "Complete steps are in the [migration guide](...)."
+
+These sentences carry no information beyond the link. Embed the link in a content
+sentence, or remove it entirely if no natural content sentence exists.

--- a/.agents/skills/api-use-case/SKILL.md
+++ b/.agents/skills/api-use-case/SKILL.md
@@ -1,0 +1,381 @@
+---
+name: api-use-case
+description: Add a REST API tab to an existing Customer Portal article using the
+OpenAPI spec already in the repository. Load when asked to add API coverage to a
+portal-only article, or to create the REST API section of a tabbed article.
+---
+
+Read an existing Customer Portal article, find the matching API endpoints in the
+OpenAPI spec, and write a complete `<MethodSection id="api">` section.
+
+## Scope — read exactly these files
+
+1. This SKILL.md
+2. The existing article specified by the user
+3. `/api-reference/services_documented/{product}_api.yaml` — the relevant OpenAPI spec
+4. `.agents/references/mdx-rules.md` — MethodSwitch structure rules
+5. `.agents/references/style-guide.md` — writing rules for the API section prose
+6. `.agents/references/procedures.md` — step format and ordering rules
+
+Do not read other articles unless the existing article cross-links to them and
+the link is directly relevant to mapping a Portal step to an API call.
+
+---
+
+## Inputs
+
+| Input | Required | Notes |
+|-------|----------|-------|
+| Path to existing Portal article | Yes | The article that will receive the API tab |
+| Real API testing | No | Ask the user — see Phase 2 |
+
+---
+
+## Phase 1 — Read the Portal article
+
+Read the full article. Understand:
+
+1. **What resources are created and in what order** — e.g. network → subnet → instance → floating IP
+2. **Dependencies between steps** — e.g. subnet needs `network_id` from step 2
+3. **The overall flow type:**
+   - Steps feed into each other → **sequential** → use Structure A (Quickstart + Step-by-step)
+   - Steps are independent operations → **independent** → use Structure B (standalone sections)
+
+**Rule:** "Create" / "Deploy" articles are almost always sequential (Structure A).
+"Manage" / "Configure" articles are almost always independent (Structure B).
+Test: "Can the user do Step 3 without Steps 1 and 2?" If yes → Structure B.
+
+4. **Identify the product** from the file path — determines which OpenAPI YAML to load.
+
+---
+
+## Phase 2 — API testing (ask the user)
+
+Before writing, ask:
+
+> The API section can be based on the OpenAPI spec alone, or I can also run
+> the actual API calls against the live environment to verify real responses,
+> catch undocumented errors, and confirm field behavior.
+>
+> - **Yes, test with real API** — more accurate, takes longer
+> - **No, use the spec only** — faster, mark uncertain steps as `{TODO: verify}`
+
+Wait for the answer before proceeding.
+
+**If yes → real testing:**
+- API credentials are in `C:\Projects\docops-agent2\access.md`
+- Use Luxembourg-3 (`region_id: 148`) for general VM and networking
+- Use Frankfurt-2 (`region_id: 180`) for DBaaS and Kubernetes
+- Run each API call end-to-end in the terminal using `curl` against `https://api.gcore.com`
+- Record real responses — exact fields, structure, error messages
+- Only after the full flow runs end-to-end — move to Phase 3
+- Do NOT delete test resources until the user approves the final article
+
+**If no → spec only:**
+- Mark steps that cannot be verified from the spec as `{TODO: verify in live environment}`
+- These will need a follow-up `full-audit` run to verify
+
+---
+
+## Phase 3 — Find the API endpoints
+
+Open the OpenAPI YAML for the product:
+```
+/api-reference/services_documented/{product}_api.yaml
+```
+
+For each Portal step, find the equivalent API operation:
+
+```powershell
+# Search for an endpoint by path pattern
+Select-String -Path "api-reference\services_documented\cloud_api.yaml" `
+              -Pattern "/cloud/v\d+/instances"
+```
+
+**Mapping rules:**
+- Always use the latest non-deprecated API version (`v2` over `v1` when both exist)
+- Verify field names from the YAML spec — never write field names from memory
+- Note gotchas discovered: wrong methods, missing required fields, non-obvious validation
+
+**Known gotchas to check before writing** (add new ones as you discover them):
+- `GET /cloud/v1/instances/{project_id}/{region_id}/available_flavors` is a POST requiring volume data — use `GET /cloud/v1/flavors/{project_id}/{region_id}` to list flavors
+- Instance `name` field is blocked on reseller accounts — standard accounts support it normally; use `name` in article examples
+- `addresses` field uses network name as key (e.g. `"pub_net"`), not a fixed string — iterate over all keys
+
+---
+
+## Phase 4 — Write the API section
+
+### Structure A — Sequential creation flow
+
+Use when Portal steps must execute in order and outputs feed into later steps.
+
+**Opening sentence** (required, before `<Info>` block):
+One sentence describing what this section enables. Rules:
+- Do NOT start with "The steps below..."
+- Do NOT explain what the product is (that belongs in an overview article)
+- DO describe the user action and outcome
+
+Good: `"Create a subnet inside an existing network and customize its DHCP and DNS settings."`
+Good: `"Keep services reachable even when infrastructure changes by assigning a floating IP."`
+Bad: `"The steps below create a subnet and configure DNS."` ← starts with "The steps below"
+
+**`<Info>` block** (required):
+```mdx
+<Info>
+A permanent [API token](/account-settings/api-tokens) is required, along with a
+[project ID](https://api.gcore.com/docs/cloud#tag/Projects/operation/ProjectsListV1.get)
+and a [region ID](https://api.gcore.com/docs/cloud#tag/Regions/operation/RegionListV1.get).
+</Info>
+```
+If the flow requires an existing resource (e.g. a network), add it:
+`"...and the ID of an existing [network](/cloud/networking/create-and-manage-a-network)."`
+
+**Environment variables block:**
+```mdx
+Open a terminal and set these environment variables before running the examples:
+
+```bash
+export GCORE_API_KEY="{YOUR_API_KEY}"
+export GCORE_CLOUD_PROJECT_ID="{YOUR_PROJECT_ID}"
+export GCORE_CLOUD_REGION_ID="{YOUR_REGION_ID}"
+```
+```
+
+**Quickstart section:**
+```mdx
+## Quickstart
+
+{One sentence: what the scripts do. Not "Complete scripts for the full flow."}
+
+<Tabs>
+  <Tab title="Python SDK">
+    ```python
+    # Step 1. {action}
+    # Step 2. {action}
+    ```
+  </Tab>
+  <Tab title="Go SDK">
+    ```go
+    // Step 1. {action}
+    // Step 2. {action}
+    ```
+  </Tab>
+</Tabs>
+```
+
+Quickstart rules:
+- Python SDK and Go SDK tabs only — **no curl tab in Quickstart**
+- Every logical step: `# Step 1.` — never combine (`# Step 3+4`)
+- Script runs as-is after setting three env vars — no other substitutions needed
+- **Never hardcode region-specific IDs** — select by characteristics:
+  ```python
+  # IDs are region-specific; selects 2 vCPU / 4 GB RAM
+  flavor = next(f for f in flavors if f.vcpus == 2 and f.ram == 4096)
+  ```
+- Print useful output at each step (resource name, ID, SSH command)
+
+**Step-by-step section:**
+```mdx
+## Step-by-step
+
+<p>Each step below explains what the call does, which parameters matter,
+and what the response looks like.</p>
+
+<Accordion title="Show all steps">
+
+### Step 1. {Verb + object}
+
+{One sentence: why this step matters in the flow.}
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `param` | Yes | What it does and how to get it |
+
+<Tabs>
+  <Tab title="Python SDK">```python ... ```</Tab>
+  <Tab title="Go SDK">```go ... ```</Tab>
+  <Tab title="curl">
+    ```bash
+    curl -X POST "https://api.gcore.com/..." \
+      -H "Authorization: APIKey $GCORE_API_KEY" \
+      -d '{...}'
+    ```
+
+    Response:
+    ```json
+    {"tasks": ["abc-123"]}
+    ```
+  </Tab>
+</Tabs>
+
+The API returns:
+
+```json
+{"tasks": ["abc-123"]}   // save as TASK_ID
+```
+
+</Accordion>
+```
+
+**Step anatomy rules:**
+1. One prose sentence: why this step matters — not "In this step, you will..."
+2. Parameters table: non-obvious required fields only
+3. Code tabs: Python SDK → Go SDK → curl (curl always last)
+4. Response JSON: always labeled with `The API returns:` — never a bare JSON block after `</Tabs>`
+5. Inline API reference link: embed in a meaningful sentence, not standalone
+
+**Polling pattern** — when an endpoint returns `{"tasks": [...]}`:
+```mdx
+Run <code>GET&nbsp;/cloud/v1/tasks/{task_id}</code> every 5 seconds until
+`state` is `FINISHED`, then read the resource ID from `created_resources`.
+
+While provisioning:
+```json
+{"state": "RUNNING", "created_resources": {}}
+```
+
+When complete:
+```json
+{"state": "FINISHED", "created_resources": {"instances": ["abc-123"]}}
+```
+```
+
+**Optional standalone sections** (after the accordion, as separate `##` headings):
+- `## Add an SSH key`, `## Filter images by OS`, `## Attach to a private network`
+- `## Clean up` — always standalone, never inside the accordion
+
+**Forbidden sections:** `## Prerequisites`, `## Next steps`, `## What's next`, `## Requirements`
+
+---
+
+### Structure B — Independent operations
+
+Use when operations are unrelated and can be done in any order (manage/configure articles).
+
+```mdx
+{Opening sentence}
+
+<Info>...</Info>
+
+```bash
+export GCORE_API_KEY="{YOUR_API_KEY}"
+...
+```
+
+## {Operation name}
+
+{One sentence.}
+
+<Tabs>
+  <Tab title="Python SDK">```python ... ```</Tab>
+  <Tab title="Go SDK">```go ... ```</Tab>
+  <Tab title="curl">```bash ... ```</Tab>
+</Tabs>
+
+The API returns:
+```json
+{...}
+```
+
+## {Another operation name}
+```
+
+No Quickstart section for Structure B — operations are unrelated and a single
+script would be artificial.
+
+---
+
+## Phase 5 — Wrap in MethodSwitch
+
+If the article currently has no MethodSwitch, wrap the existing portal content:
+
+```mdx
+import { MethodSwitch, MethodSection } from "/snippets/method-switch.jsx";
+
+<MethodSwitch>
+  <MethodSection id="portal" label="Customer Portal">
+
+  {existing portal content — do not change it}
+
+  </MethodSection>
+  <MethodSection id="api" label="REST API">
+
+  {new API section written in Phase 4}
+
+  </MethodSection>
+</MethodSwitch>
+```
+
+If MethodSwitch already exists, add the `<MethodSection id="api">` after the portal section.
+
+**Do not modify the portal section** — it is out of scope for this skill.
+
+---
+
+## Phase 6 — Update frontmatter
+
+Update `ai-navigation` to mention both methods:
+
+```yaml
+ai-navigation: Create Linux Virtual Machines in Gcore Cloud via Customer Portal
+by configuring image, flavor, and network, or via REST API using the Instances API.
+```
+
+Rules: one sentence, starts with action verb, mentions both methods, max 160 chars,
+no curly braces, no URL paths, no colons followed by space.
+
+---
+
+## Phase 7 — Review
+
+Run these checks before showing the result:
+
+**Structure:**
+```
+grep "^## What \|^## How \|^## Why \|^## When "
+grep "^## Next steps\|^## Prerequisites\|^## Requirements\|^## See also"
+grep "^This guide covers\|^This article\|^In this \|^The steps below"
+```
+Scan every `##` and `###` — verify a prose sentence follows before any code block or table.
+
+**Formatting:**
+- Bold only for UI elements — not for emphasis
+- Em-dashes spaced: ` — ` not `—`
+- Response JSON never appears directly after `</Tabs>` without a label
+- Quickstart scripts have no combined step labels (`# Step 3+4`)
+- Flavor and image IDs not hardcoded — selected dynamically
+
+**Links:**
+- Link text 1–2 words maximum
+- Each URL linked only once — subsequent mentions plain text
+- No standalone "For more details, see..." sentences
+
+**Voice:**
+- No "you" or "your" in prose
+- No forbidden words: just, simply, obviously, ensure, platform
+
+**MDX:**
+- Import has `.jsx` extension
+- `<MethodSwitch>` wraps both sections
+- Closing `</MethodSection>` tags at column 0 after lists
+- No `{identifier}` in inline backtick spans
+
+---
+
+## Output
+
+Show the complete updated article. Then:
+
+```
+Article: [path]
+API structure: [A — sequential / B — independent]
+Steps covered: [N]
+Real API tested: [yes / no — N steps marked TODO]
+
+TODO items:
+- {TODO: verify ...} at Step N — [what to check]
+```
+
+When the user confirms the result looks good — load `.agents/skills/pr/SKILL.md`
+to create the branch, commit, and open a draft PR.

--- a/.agents/skills/cookbook/SKILL.md
+++ b/.agents/skills/cookbook/SKILL.md
@@ -1,0 +1,305 @@
+---
+name: cookbook
+description: Compile an end-to-end scenario guide that combines steps from
+multiple Gcore products into a single unified article. Load when given a
+real-world scenario topic that spans more than one product or section.
+---
+
+Take a scenario topic, find all relevant source articles across the repository,
+determine the correct sequence, and write a cookbook article that guides the
+reader from start to finished result.
+
+## Scope — read exactly these files
+
+1. This SKILL.md
+2. `.agents/references/content-types.md` — cookbook structure and template
+3. `.agents/references/style-guide.md` — writing rules
+4. `.agents/references/mdx-rules.md` — frontmatter and MDX rules
+5. Source articles found during Phase 2 (read only the relevant sections)
+6. `.agents/references/mcp-tools/playwright.md` — only if user agrees to end-to-end testing
+
+Do not read every article in the repo. Read only articles confirmed relevant
+during the search phase.
+
+---
+
+## Inputs
+
+| Input | Required | Notes |
+|-------|----------|-------|
+| Scenario topic | Yes | What the reader wants to achieve end-to-end |
+| Target audience | No | Infer from topic if not specified |
+| Products involved | No | Infer from topic, confirm during Phase 1 |
+
+**Example topics:**
+- "Set up video streaming with CDN delivery and DDoS protection"
+- "Deploy a Kubernetes application with load balancing and object storage"
+- "Configure a multi-region CDN with custom SSL and origin shield"
+
+---
+
+## Phase 1 — Understand the scenario
+
+Before searching for articles, build a clear picture of what the cookbook covers.
+
+Answer these questions:
+
+**Who is the reader?**
+A developer or DevOps engineer who already knows the individual products and
+wants to connect them into a working system. Not a beginner — do not explain
+basic product concepts inline, link to overview articles instead.
+
+**What will the reader have when done?**
+State this as a concrete outcome, not a list of steps. Example:
+- "A live video stream delivered via CDN with automatic DDoS mitigation"
+- "A Kubernetes cluster with persistent storage and a public load balancer"
+
+**Which Gcore products are involved?**
+List each product. For each one — does it have existing documentation in this repo?
+```powershell
+ls {product}/ --directory
+```
+
+**What are the dependencies between products?**
+Some products must be set up before others because they produce outputs the next
+step needs. Map these before writing:
+
+```
+Example: video streaming + CDN
+  1. Streaming — must come first, produces the origin URL
+  2. CDN — needs the origin URL from step 1 to configure the resource
+  3. DDoS Protection — can be added after CDN is working
+
+Example: K8s + load balancer + object storage
+  1. Network — load balancer needs a subnet
+  2. Kubernetes cluster — needs the network
+  3. Load balancer — connects to the cluster
+  4. Object storage — independent, can be done in parallel with K8s
+```
+
+If the dependencies are unclear — determine them by reading the "what you need
+before starting" context in the relevant product articles.
+
+---
+
+## Phase 2 — Find source articles
+
+Search for articles covering each product in the scenario:
+
+```powershell
+# Find articles in a product folder
+ls {product}/ -Recurse -Filter "*.mdx" | Select-Object Name, FullName
+
+# Search by keyword across products
+grep -r "load balancer" --include="*.mdx" -l
+```
+
+For each product in the scenario, find:
+- The main how-to article (create / get started)
+- Any prerequisite articles (e.g. "create a network" before "create a load balancer")
+
+Read only the **first paragraph and headings** of each candidate article to confirm
+it covers the right topic. Do not read full articles yet.
+
+Build a source map:
+
+```
+Step 1: Create a streaming live stream
+  Source: /streaming/live-streams/create-a-live-stream.mdx
+
+Step 2: Configure CDN resource for streaming
+  Source: /cdn/getting-started/create-cdn-resource.mdx
+
+Step 3: Enable DDoS protection
+  Source: /ddos-protection/...
+```
+
+If a required step has no article in the repo — note it as a gap:
+`{TODO: no existing article for X — needs to be written separately}`
+
+---
+
+## Phase 3 — Determine file path and title
+
+**File path:**
+```
+/{primary-product}/use-cases/{scenario-slug}.mdx
+```
+or if the scenario spans equally across products:
+```
+/use-cases/{scenario-slug}.mdx   (if this folder exists)
+```
+
+Use the product where the reader spends the most time as the primary product.
+
+**Title:** the outcome the reader achieves, not a list of products.
+- Good: "Stream live video with CDN delivery and DDoS protection"
+- Bad: "Streaming + CDN + DDoS Protection setup guide"
+
+**sidebarTitle:** short version of the title (5 words max):
+- "Live streaming with CDN and DDoS"
+
+---
+
+## Phase 4 — End-to-end testing (ask the user)
+
+If the scenario involves portal UI steps — ask:
+
+> I can walk through this entire scenario in the Gcore Customer Portal to
+> verify that the steps work in the correct order and that all required
+> settings actually exist.
+>
+> - **Yes, test end-to-end** — I will verify each step produces the expected
+>   output before the next step uses it
+> - **No, write from existing articles** — I will document the sequence based
+>   on what the source articles say, and mark unverified connections as TODO
+
+Wait for the answer.
+
+**If yes:**
+- Follow the Playwright protocol in `.agents/references/mcp-tools/playwright.md`
+- Execute the scenario from start to finish
+- Specifically verify handoff points: does step N actually produce what step N+1 needs?
+- Note any differences between what source articles describe and what the portal shows
+
+**If no:**
+- Write from source articles
+- Mark every cross-product handoff that was not verified:
+  `{TODO: verify that the output of step N is the correct input for step N+1}`
+
+---
+
+## Phase 5 — Write the cookbook
+
+Use the cookbook template from `.agents/references/content-types.md`.
+
+### Opening paragraph
+
+State who this is for and what they will have when done.
+Do not open with "This guide covers..." or a list of products.
+
+Good:
+> A live video stream requires three Gcore services working in sequence:
+> Streaming provides the ingest endpoint and transcoding, CDN distributes
+> the content to viewers, and DDoS Protection absorbs volumetric attacks
+> before they reach the origin. This cookbook connects all three into a
+> working pipeline.
+
+### Prerequisites
+
+Integrate into the opening paragraph as plain text — not a separate section.
+State only non-obvious requirements: an active account, a specific plan tier,
+a resource that must exist before starting.
+
+### Steps
+
+Each step follows this pattern:
+
+```mdx
+## Step N. {Verb + object — what happens in this step}
+
+{One paragraph: why this step is needed at this point in the sequence.
+What does it produce that the next step needs?}
+
+{2–5 key actions the reader must take — brief, imperative.}
+
+For the full procedure, see [{article name}]({path}).
+
+{Optional: note the specific output to copy for the next step.}
+> After completing this step, copy the **Origin URL** — you will need it in Step 2.
+```
+
+**Rules for each step:**
+- Brief instructions only — do not duplicate the full how-to article
+- Always link to the source article with 1–2 word link text
+- Explain the dependency explicitly: "because Step 3 needs the X from Step 2"
+- If a step produces an output the reader must copy — call it out explicitly
+
+### Cross-product handoffs
+
+These are the most important part of a cookbook — the connections that the
+individual how-to articles do not cover. Make them explicit:
+
+```mdx
+## Step 2. Create a CDN resource
+
+CDN needs an origin URL — the address where your content lives before delivery.
+Use the playback URL from the streaming live stream created in Step 1.
+
+1. In the Customer Portal, go to **CDN** > **CDN Resources** > **Create**.
+2. In the **Origin** field, paste the streaming playback URL from Step 1.
+...
+
+For the full procedure, see [create a CDN resource](/cdn/getting-started/create-cdn-resource).
+```
+
+### Expected outcome section
+
+End with a concrete description of what the reader should see when done.
+Not a checklist — a paragraph describing the working system.
+
+```mdx
+## Expected outcome
+
+{Describe the working system: what is running, how it behaves, how to verify it.}
+
+If anything is not working as described, check:
+- {common issue 1 and where to find help}
+- {common issue 2 and where to find help}
+```
+
+---
+
+## Phase 6 — Validate
+
+**MDX:**
+- [ ] Frontmatter complete: `title`, `sidebarTitle`, `ai-navigation`
+- [ ] No `description` field
+- [ ] No `{identifier}` in inline backtick spans
+
+**Structure:**
+- [ ] No `## Prerequisites` section — requirements in opening paragraph
+- [ ] No `## Next steps` section — use inline links
+- [ ] Every `##` heading followed by a prose sentence
+- [ ] Headings in sentence case
+
+**Content:**
+- [ ] Each step links to its source article
+- [ ] Every cross-product handoff explicitly documented
+- [ ] `## Expected outcome` section present
+- [ ] All `{TODO:}` items listed
+
+**`ai-navigation`:**
+One sentence, action verb, all products mentioned, max 160 chars,
+no curly braces, no URL paths:
+```yaml
+ai-navigation: Stream live video through Gcore CDN with DDoS protection by
+configuring a live stream origin, a CDN resource, and a DDoS protection profile.
+```
+
+---
+
+## Output
+
+Show the complete article. Then:
+
+```
+File: [path]
+Source articles used: [N]
+  - [path 1]
+  - [path 2]
+
+Cross-product handoffs documented: [N]
+
+TODO items:
+- {TODO: ...}
+
+Gaps (steps with no source article):
+- [step] — no existing article found
+
+Recommended next step:
+- No TODOs → ready for review, create PR
+- Has TODOs → verify handoffs, then create PR
+```
+
+Do not commit without explicit user confirmation.

--- a/.agents/skills/feature-draft/SKILL.md
+++ b/.agents/skills/feature-draft/SKILL.md
@@ -1,0 +1,330 @@
+---
+name: feature-draft
+description: For product teams and contributors — take a feature description,
+research the context, find or create the right article, write a draft, and
+open a PR for writer review. Load when a contributor provides context about
+a new feature or product change and wants a documentation draft.
+---
+
+Take context from a contributor about a new feature or product change, research
+it, find the right place in the documentation, write a draft, and open a draft PR
+for a technical writer to review.
+
+## Scope — read exactly these files
+
+1. This SKILL.md
+2. `.agents/references/mcp-tools/setup.md` — verify required MCPs are available
+3. `.agents/references/mcp-tools/jira.md` — if a Jira ticket is provided
+4. `.agents/references/mcp-tools/confluence.md` — if Confluence links are present
+5. `.agents/references/mcp-tools/playwright.md` — only if user agrees to portal testing
+6. `.agents/references/content-types.md` — to determine article type and structure
+7. `.agents/references/style-guide.md` — writing rules for the draft
+8. `.agents/references/procedures.md` — step format and ordering rules
+9. `.agents/references/mdx-rules.md` — MDX and frontmatter rules
+9. One existing article of the same type as a style reference
+
+---
+
+## Inputs
+
+Accepts any combination of:
+
+| Input | Notes |
+|-------|-------|
+| Jira ticket ID or URL | Best source — has acceptance criteria and linked dev ticket |
+| Confluence page URL | Internal spec, release notes, architecture doc |
+| Free-text description | What the feature does, what changed, who it affects |
+| Screenshots or attachments | UI screenshots of the new feature |
+
+At least one input is required. If none is provided — ask the contributor
+to describe what changed and who it affects.
+
+---
+
+## Phase 1 — Gather context
+
+Collect everything available before writing anything.
+
+**From Jira** (if ticket provided):
+- Fetch the main ticket: summary, description, status, labels
+- Fetch the linked dev ticket: acceptance criteria, stakeholders, Confluence links
+- Read all comments — important clarifications often appear there
+- Check ticket status — if Done or Cancelled, ask the contributor if this is already live
+
+**From Confluence** (if URL provided or linked from Jira):
+- Fetch the page: feature description, API changes, known limitations
+- Never copy Confluence text verbatim — use it to understand the feature
+
+**From free-text description:**
+- Note what is clearly stated vs what needs verification
+- Ask one clarifying question if critical information is missing
+  (e.g. "Is this change visible in the Customer Portal, the API, or both?")
+
+**Build a mental model:**
+- What does the feature do?
+- Who uses it and when?
+- What changed compared to before?
+- Is it visible in the Customer Portal, the API, or both?
+- Is it already live or still upcoming?
+
+If the feature is not yet live — note this clearly and mark the draft as
+`{TODO: verify in portal before publishing}`.
+
+---
+
+## Phase 2 — Quick documentability check
+
+Before searching for an article, verify this is worth documenting:
+
+**Skip documentation if:**
+- The change is purely internal (admin API, internal tool, backend refactoring)
+- The change is a product bug fix with no customer-visible behavior change
+- The change affects only internal Gcore teams (check stakeholders in dev ticket)
+- The Jira ticket is already Done and the docs were updated at the time
+
+**Proceed if:**
+- The feature is visible to customers in the portal or public API
+- The change affects what customers can do, configure, or plan for
+- The contributor is confident this needs documenting
+
+If unsure — ask: "Does a customer need to know about this to use the product
+correctly, or to plan their setup?" If yes → document.
+
+---
+
+## Phase 3 — Find or determine the article
+
+Search the repository for an existing article about this feature:
+
+```powershell
+grep -r "feature or product name" --include="*.mdx" -l
+```
+
+Read the first few lines of any matches to confirm they are relevant.
+
+**If an existing article is found:**
+- This is an UPDATE — the draft will modify the existing article
+- Note which sections are affected by the change
+- Confirm with content-types.md that the article type still matches
+
+**If no article is found:**
+- This is a NEW article
+- Determine the correct product folder and file path:
+  ```
+  /{product}/{section}/{article-name}.mdx
+  ```
+- Determine the article type using `.agents/references/content-types.md`
+
+---
+
+## Phase 4 — Portal testing (ask the contributor)
+
+If the feature is accessible in the portal — ask:
+
+> I can open the Gcore Customer Portal and navigate through the new feature
+> to document the exact steps and capture screenshots.
+>
+> - **Yes, test in the portal** — more accurate, I will document what I actually see
+> - **No, write from the description** — faster, I will mark steps that need
+>   verification as TODO
+
+Wait for the answer.
+
+**If yes:**
+- Follow the Playwright protocol in `.agents/references/mcp-tools/playwright.md`
+- Navigate to the feature in the portal
+- Document the UI flow from direct observation — not from the description alone
+- Capture screenshots following the standards in `.agents/references/mcp-tools/playwright.md`
+
+**If no:**
+- Write from the provided context
+- Mark every UI step that could not be verified:
+  `{TODO: verify in portal — confirm button name and navigation path}`
+
+---
+
+## Phase 5 — Write the draft
+
+### Before writing
+
+Read one existing article of the same type from the same product folder.
+Use it as a style reference — depth of explanation, step format, tone.
+
+### Article structure
+
+Use the template from `.agents/references/content-types.md` for the determined type.
+
+For most how-to articles:
+- Portal section: numbered steps, bold UI element names, screenshots
+- API section: mark as `{TODO: API section — add if REST API coverage is needed}`
+  unless the contributor specifically provided API details
+
+### Writing rules
+
+Follow `.agents/references/style-guide.md`. Key rules for contributors:
+
+- **Opening sentence:** state what the reader will accomplish — not "This guide covers..."
+- **Steps:** use imperative ("Click **Save**") — not "You should click Save"
+- **Bold:** only for UI element names and button labels — not for emphasis
+- **No forbidden sections:** no `## Prerequisites`, `## Next steps`, `## See also`
+- **One sentence per paragraph action** — result on the next line if needed
+
+### Marking uncertainty
+
+Use `{TODO:}` for anything that could not be verified:
+
+```
+{TODO: verify navigation path — confirm exact menu location}
+{TODO: screenshot needed — capture the creation form}
+{TODO: verify field name — spec says "retention_period", confirm in UI}
+{TODO: API section — add REST API coverage if needed}
+```
+
+Collect all TODOs — they become the PR description checklist.
+
+### Frontmatter
+
+```yaml
+---
+title: [Full descriptive title]
+sidebarTitle: [Short sidebar label]
+ai-navigation: [One sentence, action verb, max 160 chars, no {braces} or /slashes/]
+---
+```
+
+Write `ai-navigation` last. Rules: one sentence, starts with action verb,
+describes all methods covered, no curly braces, no URL paths, no colons followed by space.
+
+---
+
+## Phase 6 — Verify agent-added claims
+
+Find everything in the draft that you wrote from your own reasoning — not from
+what the contributor provided or what is in Jira/Confluence.
+
+**The rule:** if the contributor gave you the spec directly — trust it. If Jira
+or Confluence has the value — trust it. Verification targets only what you added
+yourself through inference or "logical deduction".
+
+**Signs of agent-added content:**
+- A number or limit you assumed: "typically 30 seconds", "standard limit is 100"
+- A behavioral claim you deduced from general knowledge: "since it's cloud-based,
+  it automatically scales"
+- A step you added because "it seemed necessary"
+- Anything you wrote that the contributor did not explicitly tell you
+
+**What does NOT need verification:**
+- Specs and values the contributor provided directly in their input
+- Values found in the Jira ticket, parent ticket, or Confluence
+- Details confirmed through Playwright testing in Phase 4
+
+**For each agent-added claim, check in order:**
+
+1. **Main Jira ticket** — stated in description or acceptance criteria?
+2. **Parent ticket** — epic or parent story (fetch if not yet loaded)
+3. **Sibling tickets** — other issues under the same parent
+4. **Confluence pages** — linked from tickets or searchable by feature name
+
+Use `.agents/references/mcp-tools/jira.md` and `.agents/references/mcp-tools/confluence.md`.
+
+**Decision:**
+
+| Situation | Action |
+|-----------|--------|
+| Came from contributor or source material | Keep — no verification needed |
+| Confirmed in Jira or Confluence | Keep |
+| Your own reasoning, not in any source | `{TODO: verify — added by agent, not in source}` |
+
+**Self-check:** for every technical claim, ask "Where did I get this?"
+If the answer is "it seemed logical" — mark it.
+
+---
+
+## Phase 7 — Style check
+
+Quick validation before creating the PR:
+
+**MDX:**
+- [ ] Import has `.jsx` extension if MethodSwitch is used
+- [ ] No `{identifier}` in inline backtick spans
+- [ ] Prose inside `<MethodSection>` wrapped in `<p>` tags
+
+**Frontmatter:**
+- [ ] `title` and `ai-navigation` present
+- [ ] No `description` field
+
+**Style:**
+- [ ] No forbidden openers: "This guide...", "This article..."
+- [ ] No forbidden sections: `## Prerequisites`, `## Next steps`
+- [ ] Headings in sentence case
+- [ ] No "you" or "your" in prose
+- [ ] No forbidden words: just, simply, ensure, platform
+
+---
+
+## Phase 8 — Create draft PR
+
+### Git
+
+```powershell
+cd C:\Projects\product-documentation
+git checkout main
+git pull origin main
+git checkout -b feature-draft/{ticket-id-or-slug}
+```
+
+Stage only the files you created or modified:
+```powershell
+git add {article-path}
+git add {screenshot-paths}
+git commit -m "[{Product}] Draft: {feature name}"
+git push -u origin feature-draft/{ticket-id-or-slug}
+```
+
+### PR
+
+Create as a **draft PR** — it is not ready for review until a technical writer
+has verified the content.
+
+**Title format:** `[Product] Draft: {feature name}`
+Examples:
+- `[Cloud] Draft: GPU cluster auto-scaling`
+- `[CDN] Draft: Origin shield configuration`
+
+**PR body:**
+```markdown
+## What this documents
+
+{1-2 sentences: what feature or change this documents, and the source (Jira ticket link if available)}
+
+## Contributor notes
+
+{Any context the writer should know — what was tested, what was assumed, known gaps}
+
+## TODO before publishing
+
+{List of all {TODO:} items from the draft}
+- [ ] {TODO item 1}
+- [ ] {TODO item 2}
+- [ ] Verify portal steps with Playwright (if not already done)
+- [ ] Add API section if REST API coverage is needed
+- [ ] Technical writer review and approval
+```
+
+---
+
+## Output
+
+```
+Draft created: [article path]
+Action: [new article / updated existing article]
+Portal tested: [yes / no — N steps marked TODO]
+
+PR: [URL]
+Branch: feature-draft/{name}
+
+TODO items for the writer:
+- [list from draft]
+
+Next step: assign the PR to a technical writer for review
+```

--- a/.agents/skills/full-audit/SKILL.md
+++ b/.agents/skills/full-audit/SKILL.md
@@ -1,0 +1,274 @@
+---
+name: full-audit
+description: Test an existing article step by step against the live portal,
+find all discrepancies, and update the article. Load when asked to audit,
+verify, or update an outdated article by testing it in real conditions.
+---
+
+Walk through an existing article as a real user would, execute every step
+in the live portal using Playwright, record all discrepancies, then fix the
+article. Do not skip portal verification — articles updated without testing
+mislead customers.
+
+## Scope — read exactly these files
+
+1. This SKILL.md
+2. The article file specified by the user
+3. `.agents/references/mcp-tools/setup.md` — verify Playwright MCP is available
+4. `.agents/references/mcp-tools/playwright.md` — Playwright protocol and screenshot standards
+5. `.agents/references/review-process.md` — Phase 4 review process and grep commands
+6. `.agents/references/style-guide.md` — only during Phase 4 review
+7. `.agents/references/mdx-rules.md` — only if making structural edits to MethodSwitch
+
+Do not read other articles. Do not read the API section of the article —
+it is out of scope for this skill.
+
+---
+
+## Inputs
+
+| Input | Required | Notes |
+|-------|----------|-------|
+| Article path | Yes | The MDX file to audit |
+| Jira ticket | No | Defines what must be fixed — but does NOT limit audit scope |
+
+**Important:** if a Jira ticket is provided, it is an additional input to Phase 3,
+not a replacement for Phases 1–2. The audit scope is always the full article —
+every step, every UI element, every screenshot.
+
+---
+
+## Before starting — report blockers first
+
+Before creating a branch or making any changes, check Phase 2 feasibility:
+
+- Is the feature accessible with the test account?
+- Are there destructive actions (delete, wipe) that cannot be safely tested?
+- Is the feature behind a paywall or regional restriction?
+
+If any blocker exists — **stop and tell the user before doing any work.**
+Describe exactly what cannot be tested and ask how to proceed.
+Do not silently proceed and bury the problem in the changelog.
+
+---
+
+## Phase 1 — Read the article
+
+1. Read the full article MDX file
+2. Understand the **goal**: what task does the article walk the user through?
+3. Extract all steps: what to do, in what order, via which UI elements
+4. List every screenshot reference (`<Frame>` blocks) — you will verify each one
+5. Note the `<MethodSection id="portal">` — this is the only section being audited
+
+Use this as your roadmap in Phase 2. The article may have errors in the details,
+but it is correct enough to understand the intent and navigate the portal.
+
+---
+
+## Phase 2 — Portal execution (mandatory)
+
+**Do not just read the portal. Actually perform the task.**
+
+First, verify Playwright MCP is available. If not — follow `.agents/references/mcp-tools/setup.md` and stop.
+
+Log in to the portal following the SSO flow in `.agents/references/mcp-tools/playwright.md`.
+If Windows Hello authentication is required — ask the user to confirm it, then continue.
+
+### Execution protocol
+
+1. Open the portal and navigate to the section the article describes
+2. Follow the article's steps in order, as a real user would
+3. At each step, use `browser_snapshot` to read actual current UI labels
+4. Use `browser_screenshot` to capture screens that have a corresponding screenshot in the article
+5. Continue until the task is fully completed or until a genuine blocker is hit
+
+**Do not fix anything during Phase 2. Only collect findings.**
+
+### What to look for
+
+| Category | Example |
+|----------|---------|
+| Wrong UI element names | Article: "Click **Add Instance**" — Portal: "**Create Instance**" |
+| Changed navigation path | Article: **Cloud** > **Instances** — Portal: **Cloud** > **Virtual Machines** |
+| Step order changed | Article describes A then B — Portal now shows B then A |
+| Missing steps | Portal has a new mandatory step the article does not mention |
+| Outdated screenshots | Screenshot shows old layout, old button positions, old field names |
+| Missing sections | Portal shows a new tab or option the article does not document |
+| Wrong field names | Article names form fields incorrectly |
+| Deprecated options | Article documents an option that no longer exists |
+
+### Finding format
+
+Record each discrepancy:
+
+```
+FINDING: [category from table above]
+Location: Step N / screenshot [filename]
+Article says: "..."
+Portal shows: "..."
+Action needed: rename / reorder / add step / update screenshot / remove
+```
+
+### If the task cannot be completed
+
+Note the blocker, describe how far you got, mark specific findings as unverified:
+```
+BLOCKED at Step N: [reason — feature gated, account limitation, region unavailable]
+Findings before blocker: [list]
+Unverified: Steps N through M
+```
+
+---
+
+## Phase 3 — Fix the article
+
+Apply fixes based on Phase 2 findings. Fix in this order:
+
+1. **Navigation paths and step order** — structural changes first
+2. **UI element names and field names** — rename throughout the article
+3. **Missing steps** — add new required steps with prose
+4. **Missing sections** — add new sections for undocumented features
+5. **Screenshots** — replace outdated ones last (after prose is correct)
+
+If a Jira ticket was provided — apply those specific changes as part of this phase,
+in addition to all findings from Phase 2.
+
+### Replacing screenshots
+
+1. Navigate to the exact screen using Playwright
+2. Follow all screenshot standards from `.agents/references/mcp-tools/playwright.md`:
+   - Collapse the sidebar before every screenshot
+   - Zoom and crop to the relevant area
+   - Light mode, English UI, no personal data visible
+3. Save screenshot to the current working directory first, then copy:
+   ```powershell
+   Copy-Item ".\screenshot.png" `
+     "C:\Projects\product-documentation\images\docs\{product}\{slug}\{filename}.png" -Force
+   ```
+4. **Always rename when replacing** — reusing the same filename causes CDN caching issues
+5. **Delete the old file:** `git rm old-filename.png`
+6. Update the `<Frame>` block reference and alt text in the article
+
+Screenshot folder rule: `images/docs/{product}/{article-slug}/{filename}.png`
+Every article has its own subfolder — never save to the product root folder.
+
+### Adding new steps
+
+```mdx
+1. Navigate to **Section** > **Subsection**.
+2. Click **Button Name**.
+
+<Frame>
+  ![Description of what is shown](/images/docs/{product}/{slug}/{filename}.png)
+</Frame>
+```
+
+For numbered steps inside `<MethodSection>`, use `1.` (not `1\.`) and wrap
+standalone prose in `<p>` tags. See `.agents/references/mdx-rules.md`.
+
+### Do not touch
+
+- `<MethodSection id="api">` — API sections are maintained separately
+- Article filename and slug — broken URLs are worse than outdated content
+- `docs.json` — only edit if a new sidebar section is required; confirm with user first
+- `ai-navigation` frontmatter — only update if the article's topic fundamentally changed
+
+---
+
+## Phase 4 — Style review (mandatory)
+
+Run after every article update. Do not skip.
+
+Run the full 6-step process from `.agents/references/review-process.md`.
+Use the grep commands in that file for each step.
+
+---
+
+## Git workflow
+
+```powershell
+cd C:\Projects\product-documentation
+git checkout main
+git pull origin main
+git checkout -b update-{product}-{article-slug}
+```
+
+**Rules:**
+- Always pull before branching — never branch from a stale local main
+- Never reuse an existing branch — delete it and recreate from updated main
+- Stage files by name only — never `git add .` or `git add -A`
+- Never commit without explicit user approval
+- Branch naming: `update-{product}-{article-slug}` — both product and slug, not just product
+
+---
+
+## Changelog file
+
+After completing Phase 3 (before the style review), create a changelog file.
+This file stays in `C:\Projects\update_outdated_articles\changelogs\` — do NOT
+commit it to the product-documentation repo.
+
+Filename: `{product}--{article-slug}.md`
+
+```markdown
+# {article path relative to product-documentation}
+
+**Audited:** {date}
+
+## Changes
+
+- {change description}
+
+## Screenshots replaced
+
+- {filename} — {reason}
+
+## Not updated
+
+- {item} — {reason it could not be updated}
+```
+
+Update this file if Phase 4 introduces additional edits.
+
+---
+
+## Self-documentation rule
+
+If during the audit you encounter something not covered by these instructions —
+a portal quirk, an extra required step, a workaround that worked — add it to
+`.agents/references/mcp-tools/playwright.md` under "Known portal quirks" immediately.
+Do not wait until the end of the session. Future audits should not have to
+rediscover the same thing.
+
+---
+
+## Output
+
+After completing all four phases:
+
+```
+Article: [path]
+Product: [product area]
+
+Findings:
+- [N] UI element names updated
+- [N] navigation paths corrected
+- [N] steps added / reordered
+- [N] screenshots replaced
+- [N] new sections added
+
+Status: updated / no changes needed / needs manual review
+
+Branch: update-{product}-{article-slug}
+```
+
+If the article cannot be fully verified:
+```
+Status: PARTIALLY UPDATED
+Unverified: [list of steps that could not be tested]
+Recommendation: [what is needed to complete the audit]
+```
+
+When the user confirms the result looks good — load `.agents/skills/pr/SKILL.md`
+to create the branch, commit, and open a draft PR.
+```

--- a/.agents/skills/jira-context/SKILL.md
+++ b/.agents/skills/jira-context/SKILL.md
@@ -1,0 +1,261 @@
+---
+name: jira-context
+description: Analyze a Jira ticket and produce a structured brief of what needs
+to be documented. Load when given a Jira ticket ID or URL and asked to understand
+what work is needed.
+---
+
+Fetch a Jira ticket, determine whether documentation work is needed, classify
+the type of change, find the affected article, and produce a clear brief.
+
+## Scope — read exactly these files
+
+1. This SKILL.md
+2. `.agents/references/mcp-tools/setup.md` — verify Jira MCP is available first
+3. `.agents/references/mcp-tools/jira.md` — Jira operations and status reference
+4. `.agents/references/mcp-tools/confluence.md` — only if Jira ticket links to Confluence pages
+
+Do not read article files during this skill. This skill produces a brief —
+it does not make changes to documentation.
+
+---
+
+## Phase 1 — Verify MCP and fetch ticket
+
+**Step 1.** Check that Jira MCP is available. If not — follow the instructions
+in `.agents/references/mcp-tools/setup.md` and stop.
+
+**Step 2.** Validate the ticket key format: must start with `DOC-` followed by numbers.
+If the format is wrong — tell the user and stop.
+
+**Step 3.** Fetch the ticket:
+- Summary, description, status, reporter, assignee, labels
+- All comments — read every one, blockers often appear here
+- All linked issues — fetch the linked dev ticket if present
+
+**Step 4.** Fetch the linked dev ticket (if exists):
+- Description and acceptance criteria — most detailed technical spec
+- Stakeholders field — critical for classification
+- Any linked Confluence pages — fetch if present
+
+---
+
+## Phase 2 — Status check
+
+Check the ticket status against this table:
+
+| Status | Can work? |
+|--------|-----------|
+| Backlog | YES |
+| To Do | YES |
+| Reopened | YES |
+| In Progress | NO — someone else is working |
+| In Review | NO — already submitted for review |
+| Blocked | NO — on hold |
+| BLOCKED- Need Info | NO — waiting for SME answer |
+| In SEO review | NO — treat as In Review |
+| Done | NO — already completed |
+| Cancelled | NO |
+
+**If status is not in the YES list — stop immediately.**
+
+Report to the user:
+```
+Ticket: [TICKET-ID]
+Status: [status]
+Cannot start: [reason]
+```
+
+**Also scan all comments** for blocking signals before proceeding:
+- "wait for..." / "waiting for..."
+- "not ready" / "on hold"
+- "feature not released" / "not in production"
+- "blocked by..." / "depends on..."
+
+If any blocking signal found — stop and report to the user.
+
+---
+
+## Phase 3 — Classify the ticket
+
+Classification determines whether documentation work is allowed.
+**Do not write or search for articles until classification is complete.**
+
+### The primary test: Customer Decision & Planning
+
+Ask: does knowing about this change help a customer do any of the following?
+
+- [ ] Choose between product options or configurations
+- [ ] Plan their architecture, resources, or costs
+- [ ] Set correct expectations about system behavior
+- [ ] Compare Gcore capabilities with alternatives
+- [ ] Make operational decisions (monitoring, scaling, troubleshooting)
+
+If **any box is checked** → likely PUBLIC_PRODUCT_DOC. Continue to category check.
+If **none checked** → likely NOT_DOCUMENTABLE or INTERNAL_DOC. Verify with the rules below.
+
+### Categories
+
+**PUBLIC_PRODUCT_DOC** — document this
+- New feature or change in the Customer Portal
+- New public API endpoint customers can use
+- Changed UI workflow, renamed element, new field
+- New pricing tier, limit, or quota
+- Automatic feature that affects performance, reliability, or planning decisions
+- Documentation error (typo, wrong command, outdated screenshot) — always update
+
+**PUBLIC_TROUBLESHOOTING** — document this
+- Error message customers encounter and can troubleshoot
+- Common mistake and how to fix it
+- Workaround for a known limitation
+
+**BUG_FIX** — cancel, do not document
+- Ticket title contains `[BUG]` AND describes fixing broken product behavior
+- Exception: if the bug is a documentation error (wrong text, broken link) → treat as PUBLIC_PRODUCT_DOC
+
+**INTERNAL_DOC** — cancel, do not document
+- Admin APIs (`/admin/v1/...`)
+- Internal billing processes
+- Features for internal teams (Team DX, DevOps, Support)
+- Stakeholders in dev ticket are internal-only
+
+**NOT_DOCUMENTABLE** — cancel, do not document
+- Code refactoring, library update, infrastructure migration
+- `api-reference/` YAML file changes — those are owned by backend developers
+- Zero customer-facing effect
+
+**INCIDENT_POSTMORTEM** — draft only, needs human approval
+- Major service outage or security incident
+
+### Hard rules (always apply)
+
+**Rule 1:** If `[BUG]` is in the title AND it describes fixing broken *product* behavior → BUG_FIX → cancel. No exceptions.
+
+**Rule 2:** If the only stakeholders in the dev ticket are internal teams → INTERNAL_DOC or NOT_DOCUMENTABLE → cancel.
+
+**Rule 3:** If the ticket asks to modify files in `api-reference/` → NOT_DOCUMENTABLE → cancel. Backend team owns those files. Exception: if the ticket asks to write a *how-to guide* about using an API (in a regular `.mdx` file) → PUBLIC_PRODUCT_DOC.
+
+**Rule 4:** "Automatic" or "behind the scenes" does NOT mean not documentable. If the feature affects what the customer gets — document it.
+
+**Rule 5:** If no existing article exists AND the ticket has fewer than 3 sentences of useful customer-facing information AND stakeholders are internal → NOT_DOCUMENTABLE.
+
+### Red flags (verify carefully before proceeding)
+
+| Signal | Likely category |
+|--------|----------------|
+| `[BUG]` in title | BUG_FIX |
+| `/admin/`, "internal", "admin API" | INTERNAL_DOC |
+| "refactor", "merge", "consolidate" | NOT_DOCUMENTABLE |
+| "library update", "lib", "dependency" | NOT_DOCUMENTABLE |
+| "Team DX", "DevOps team", "Backend team" in stakeholders | INTERNAL_DOC |
+| `api-reference/`, "OpenAPI", "swagger", "YAML spec" | NOT_DOCUMENTABLE |
+| "GitLab to GitHub", "migrate repo", "publish internally" | NOT_DOCUMENTABLE |
+
+### Green flags (proceed)
+
+| Signal | Category |
+|--------|----------|
+| "new feature", "new in portal" | PUBLIC_PRODUCT_DOC |
+| "customer", "user" as audience | PUBLIC_PRODUCT_DOC |
+| "how to", "guide", "tutorial" | PUBLIC_PRODUCT_DOC |
+| "error message", "troubleshooting" | PUBLIC_TROUBLESHOOTING |
+| "now supports", "started to support" | PUBLIC_PRODUCT_DOC |
+| "pricing", "limits", "quotas" | PUBLIC_PRODUCT_DOC |
+| "automatically enabled" + affects performance | PUBLIC_PRODUCT_DOC |
+
+### If category requires cancel
+
+Output exactly this — nothing more:
+
+```
+Ticket: [TICKET-ID]
+Category: [category]
+Decision: CANCEL
+Reason: [1-2 sentences]
+```
+
+Do NOT summarize the ticket. Do NOT rephrase the information. Do NOT create
+"alternative" internal documentation. CANCEL means CANCEL.
+
+---
+
+## Phase 4 — Find the affected article
+
+Only reached if category is PUBLIC_PRODUCT_DOC or PUBLIC_TROUBLESHOOTING.
+
+Search the repository for the relevant article:
+
+```powershell
+# By product or feature name
+grep -r "feature name" --include="*.mdx" -l
+
+# By UI section path
+grep -r "Cloud > Networking" --include="*.mdx" -l
+```
+
+Determine the action needed:
+
+| Situation | Action |
+|-----------|--------|
+| Existing article found, needs update | UPDATE |
+| No existing article, sufficient info to write | NEW |
+| No existing article, info too sparse | BLOCKED |
+
+**For NEW action — verify before proceeding:**
+- Does the ticket describe a clear customer use case?
+- Are there enough technical details to write accurately?
+- If info is sparse (< 3 useful sentences) → BLOCKED, ask user for more context
+
+---
+
+## Phase 5 — Assess complexity
+
+For UPDATE actions only. Determines which skill to use next.
+
+Score the update based on these signals:
+
+| Signal | Score |
+|--------|-------|
+| 2–3 articles affected | +2 |
+| 4+ articles affected | +3 |
+| Screenshots need updating | +2 |
+| New feature added or removed | +2 |
+| Cross-links between articles needed | +1 |
+| Migration or upgrade involved | +2 |
+| Typo, grammar, broken link | -3 |
+
+**Score 0–2 → SIMPLE** — a targeted text change in one location
+**Score 3+ → COMPLEX** — involves multiple locations, restructuring, or screenshots
+
+---
+
+## Output
+
+Produce this brief — always, regardless of next action:
+
+```
+## Jira context: [TICKET-ID]
+
+### Classification
+- Category: [category]
+- Decision: [PROCEED / CANCEL / BLOCKED]
+
+### What changed
+[1 paragraph: what the product change is, who it affects]
+
+### Affected documentation
+- Article: [path, or "none found"]
+- Action: [UPDATE / NEW / CANCEL / BLOCKED]
+- Complexity: [SIMPLE / COMPLEX] (for UPDATE only)
+
+### Scope of work
+[Bullet list: what specifically needs to be added, changed, or removed]
+
+### Suggested next skill
+[One of the following:]
+- Simple text update → load skill update-page
+- Complex update (multiple locations, screenshots) → load skill update-page
+- New article needed → load skill write-from-scratch
+- Blocked — needs more context → ask user for [specific missing info]
+- Cancel → no documentation work needed
+```

--- a/.agents/skills/pr/SKILL.md
+++ b/.agents/skills/pr/SKILL.md
@@ -1,0 +1,297 @@
+---
+name: pr
+description: Create a GitHub pull request after documentation changes are complete.
+Load when a skill finishes its work and the user confirms they want to open a PR.
+---
+
+Create a draft PR for changes made in the current session.
+Always create as draft — the writer reviews the deploy preview before requesting review.
+
+## Scope — read exactly these files
+
+1. This SKILL.md
+
+Do not read any other files. All context needed comes from the calling skill's output.
+
+---
+
+## Step 0 — Check prerequisites
+
+Before doing anything else, verify that the required tools are available.
+
+### Check `gh` CLI
+
+```powershell
+gh auth status
+```
+
+If the command fails or says "not logged in":
+
+> **GitHub CLI is not authenticated.**
+>
+> To fix this, choose one of:
+>
+> **Option A — Interactive login (recommended):**
+> ```powershell
+> gh auth login
+> ```
+> Follow the prompts. Select HTTPS or SSH, then authenticate via browser.
+>
+> **Option B — Personal access token:**
+> 1. Go to https://github.com/settings/tokens
+> 2. Generate a token with `repo` scope
+> 3. Set it as an environment variable:
+>    ```powershell
+>    $env:GH_TOKEN = "your-token-here"
+>    ```
+>    Or add it permanently via Windows environment variables.
+>
+> After authenticating, run `gh auth status` again to confirm.
+
+### Check git push access
+
+```powershell
+git ls-remote origin
+```
+
+If this fails:
+
+> **Git cannot connect to the remote repository.**
+>
+> To fix this:
+>
+> **If using SSH (recommended):**
+> 1. Check if you have an SSH key: `ls ~/.ssh/id_*.pub`
+> 2. If not, generate one: `ssh-keygen -t ed25519 -C "your@email.com"`
+> 3. Add the public key to GitHub: https://github.com/settings/keys
+> 4. Test: `ssh -T git@github.com`
+>
+> **If using HTTPS:**
+> 1. Git will prompt for credentials on push
+> 2. Use a personal access token as the password (not your GitHub password)
+>    Generate at: https://github.com/settings/tokens (scope: `repo`)
+
+**Do not proceed until both checks pass.**
+
+---
+
+## Inputs (from the calling skill)
+
+Before creating the PR, confirm you have:
+
+- List of files changed or created
+- What was done (summary of changes)
+- Any `{TODO:}` items that remain in the draft
+- The product area (from the file path)
+
+---
+
+## Step 1 — Local preview (recommended before pushing)
+
+Running the local preview lets the user verify the article renders correctly
+before creating a PR. Run it now, then continue with the steps below — do not
+wait for it to finish loading.
+
+### Check if Mintlify is installed
+
+```powershell
+mintlify --version
+```
+
+If the command is not found:
+
+> **Mintlify CLI is not installed.**
+>
+> Install it once with npm (Node.js required):
+> ```powershell
+> npm i -g mintlify
+> ```
+> Node.js download: https://nodejs.org (LTS version)
+>
+> After installing, run `mintlify --version` to confirm.
+
+### Start the local preview
+
+Run from the repository root (where `docs.json` lives) **in the background** —
+do not wait for output, continue immediately with Step 1:
+
+```powershell
+# Start in a separate window so it doesn't block
+Start-Process powershell -ArgumentList "-NoExit", "-Command", `
+  "Set-Location 'C:\Projects\product-documentation'; mintlify dev"
+```
+
+Mintlify chooses the port automatically (default 3000, increments if taken).
+The URL appears in the terminal window that opened. Tell the user:
+
+> Local preview is starting. The URL will appear in the new terminal window
+> (usually http://localhost:3000). Navigate to the article you just edited
+> to check how it renders. Continue — we'll create the PR in parallel.
+
+---
+
+## Step 2 — Determine the product name
+
+Infer the product display name from the file path. Use this table:
+
+| Folder | Display name |
+|--------|-------------|
+| `cloud/` | Cloud |
+| `cdn/` | CDN |
+| `dns/` | DNS |
+| `waap/` | WAAP |
+| `streaming/` | Streaming |
+| `storage/` | Storage |
+| `fastedge/` | FastEdge |
+| `ddos-protection/` | DDoS Protection |
+| `edge-ai/` | Edge AI |
+| `hosting/` | Hosting |
+| `account-settings/` | Account Settings |
+| `developer-tools/` | Developer Tools |
+| `reseller-support/` | Reseller Support |
+
+If the change spans multiple products, list the two most prominent: `[Cloud, CDN]`.
+
+---
+
+## Step 3 — Ensure main is up to date and create branch
+
+```powershell
+cd C:\Projects\product-documentation
+git checkout main
+git pull origin main
+git checkout -b {branch-name}
+```
+
+**Branch naming:**
+
+| What was done | Branch name |
+|---------------|-------------|
+| New article | `new-article/{product}-{slug}` |
+| Added API tab | `api-tab/{product}-{slug}` |
+| Updated article | `update/{product}-{slug}` |
+| Audited article | `audit/{product}-{slug}` |
+| Feature draft (contributor) | `feature-draft/{ticket-id-or-slug}` |
+
+Where `{slug}` is the article filename without `.mdx`.
+
+**If branch already exists** — do not reuse it. Delete and recreate:
+```powershell
+git branch -D {branch-name}
+git checkout -b {branch-name}
+```
+
+---
+
+## Step 4 — Stage and commit
+
+Stage only the files changed in this session — by name, never `git add .`:
+
+```powershell
+git add {file1} {file2} {screenshot-paths}
+```
+
+Before staging, run `git status` and verify the list. If unrelated files appear
+in the working tree — do not stage them. Ask the user if they should be included.
+
+Commit message format: `[Product] Short description`
+
+```powershell
+git commit -m "[Cloud] Add REST API tab to create-an-instance article"
+git commit -m "[CDN] Update origin group configuration steps"
+git commit -m "[Cloud] Draft: GPU cluster auto-scaling feature"
+```
+
+Rules:
+- Imperative mood: "Add", "Update", "Fix", "Draft" — not "Added", "Updated"
+- Under 72 characters
+- No period at the end
+
+---
+
+## Step 5 — Push
+
+```powershell
+git push -u origin {branch-name}
+```
+
+**After pushing**, two CI workflows may auto-commit to your branch:
+- `sanitize-ai-navigation` — fixes `:` or `#` in `ai-navigation` frontmatter
+- `normalize-images` — renames images and updates MDX paths
+
+Wait ~30 seconds, then run `git pull` before any follow-up commits.
+If you commit without pulling, the push will be rejected with "non-fast-forward".
+
+---
+
+## Step 6 — Create the PR
+
+```powershell
+gh pr create --base main --draft --title "[{Product}] {short description}" --body-file /tmp/pr-body.md
+```
+
+Always `--draft`. Always `--base main`.
+
+**PR title** follows the same format as the commit message:
+- Content changes: `[Product] Short description`
+- Contributor draft: `[Product] Draft: Feature name`
+
+**PR body** — write to a temp file first, then use `--body-file`:
+
+```markdown
+## What changed
+
+{1-3 sentences: what was done and why. Link to Jira ticket if available.}
+
+## Files changed
+
+- `{file path}` — {what was done to it}
+
+## TODO before publishing
+
+{List every {TODO:} item from the draft, as checkboxes.
+If no TODOs — write "No TODOs. Ready for review."}
+
+- [ ] {TODO item 1}
+- [ ] {TODO item 2}
+- [ ] Writer review and approval
+```
+
+Write the body with the Write tool, then clean up:
+```powershell
+# After gh pr create runs:
+Remove-Item /tmp/pr-body.md
+```
+
+---
+
+## Step 7 — Report
+
+```
+PR created: {URL}
+Branch: {branch-name}
+Status: Draft
+
+Files staged:
+- {file 1}
+- {file 2}
+
+{If TODOs exist:}
+TODOs in draft ({N} items):
+- {TODO 1}
+- {TODO 2}
+
+Next step: review the deploy preview, then mark as ready for review.
+```
+
+---
+
+## If `gh` is not available
+
+If the `gh` CLI is not installed or not authenticated, provide:
+
+1. The PR title and body as text for copy-paste
+2. The URL to open a PR manually:
+   ```
+   https://github.com/G-Core/product-documentation/compare/main...{branch-name}
+   ```

--- a/.agents/skills/update-page/SKILL.md
+++ b/.agents/skills/update-page/SKILL.md
@@ -1,0 +1,187 @@
+---
+name: update-page
+description: Update an existing article when product or UI changes are provided.
+Load when the user describes changes to a product, feature, or portal UI and wants
+the documentation updated to reflect them.
+---
+
+Update existing articles based on provided context about product or UI changes.
+
+## Scope — read exactly these files
+
+1. This SKILL.md
+2. The article file(s) identified during Phase 1
+3. `.agents/references/style-guide.md` — when rewriting prose or restructuring
+4. `.agents/references/mdx-rules.md` — when editing MethodSwitch structure or frontmatter
+5. `.agents/references/mcp-tools/playwright.md` — only if user agrees to Playwright testing
+
+Do not read other articles for context unless they are directly linked from the
+article being updated.
+
+---
+
+## Inputs
+
+| Input | Required | Notes |
+|-------|----------|-------|
+| Description of what changed | Yes | Product change, UI rename, new option, changed flow |
+| Article path | No | If not provided, agent searches for it |
+| Screenshots | No | If provided, use them directly — no Playwright needed |
+| Jira ticket / Confluence link | No | Additional context if available |
+
+---
+
+## Phase 1 — Find affected articles
+
+If the article path is given — skip to Phase 2.
+
+If not, search the repository:
+
+```powershell
+# Search by product or feature name
+grep -r "keyword" --include="*.mdx" -l
+
+# Search by UI element name that changed
+grep -r "old button name" --include="*.mdx" -l
+```
+
+Read the first sentence of each match to confirm it is relevant before proceeding.
+Multiple articles may be affected — process each one separately.
+
+**Do not update articles you are not sure are affected.** If unsure, list them
+and ask the user which ones to update.
+
+---
+
+## Phase 2 — Understand the article
+
+Before making any change, read the full article:
+
+- What is the article's goal? What task does it walk the reader through?
+- How is it structured? (Tabbed / portal-only / API-only)
+- Where exactly do the provided changes fit?
+- What surrounding content might need adjustment for the change to read naturally?
+
+Do not start editing until you can answer these questions.
+
+---
+
+## Phase 3 — Playwright decision
+
+**If screenshots were provided** → skip this phase, use the provided screenshots.
+
+**If the changes involve UI elements** (button names, navigation paths, form fields,
+new UI screens) **and no screenshots were provided** → ask the user:
+
+> The changes you described affect the portal UI.
+> Should I open the portal and capture updated screenshots?
+>
+> - **Yes** — I will navigate to the relevant section, verify the current UI,
+>   and take new screenshots.
+> - **No** — I will update the text only. You can add screenshots separately.
+
+Wait for the answer before proceeding.
+
+- If **yes** → follow the protocol in `.agents/references/mcp-tools/playwright.md`
+- If **no** → continue to Phase 4 with text-only changes
+
+**If the changes are text-only** (new limits, new field descriptions, changed behavior,
+new API parameters) → skip this phase entirely.
+
+---
+
+## Phase 4 — Apply changes
+
+### What to change
+
+Apply only what was described in the input. Do not fix unrelated issues you notice
+along the way — note them separately at the end.
+
+For each change:
+
+1. Find the exact location in the article
+2. Read the surrounding paragraph or section — understand the tone and structure
+3. Write the change so it fits naturally into that context
+
+### How to make changes organically
+
+Mechanical replacement ("find X, replace with Y") is rarely enough. The goal is
+that the reader cannot tell which sentences were changed.
+
+**If renaming a UI element:**
+- Replace in all occurrences throughout the article
+- Check if any surrounding sentences now read awkwardly — rewrite if needed
+- Check alt text on screenshots that show the renamed element
+
+**If adding a new option or field:**
+- Find where similar options are described
+- Add the new one in the same style and structure
+- If it changes the step count — renumber steps
+
+**If a flow changed (steps reordered, step added, step removed):**
+- Rewrite the affected section — do not patch individual sentences
+- Ensure the intro sentence for the section still matches what follows
+- Check if `ai-navigation` frontmatter still accurately describes the article
+
+**If restructuring a section:**
+- Read the full section before and after in your head — does it flow?
+- Verify headings are still in logical order
+- Check all internal anchor links — renaming a heading breaks them
+
+### Do not touch
+
+- `<MethodSection id="api">` — API sections are maintained separately
+- Article filename and slug — broken URLs are worse than outdated content
+- `docs.json` navigation — only if a new top-level section is added, and only
+  after confirming with the user
+
+---
+
+## Phase 5 — Validate
+
+After making changes, check:
+
+**MDX:**
+- [ ] No unescaped `{identifier}` in inline code spans (use `<code>` with `&nbsp;`)
+- [ ] If MethodSwitch was touched: closing tags at column 0 after lists
+- [ ] If MethodSwitch was touched: prose inside `<MethodSection>` wrapped in `<p>` tags
+- [ ] No `####` headings inside `<MethodSection>`
+
+**Frontmatter:**
+- [ ] `ai-navigation` still accurately describes the article after changes
+  (update it if the article's scope changed)
+- [ ] No `description` field present
+
+**Style:**
+- [ ] New prose follows sentence case headings
+- [ ] No forbidden sections added (`## Next steps`, `## Prerequisites`, etc.)
+- [ ] Bold used only for UI element names
+- [ ] No forbidden words: just, simply, ensure, platform, obviously
+
+**Links:**
+- [ ] Any renamed heading has no broken anchor links pointing to it
+- [ ] Internal links still root-relative
+
+---
+
+## Output
+
+After completing all phases, report:
+
+```
+Article: [path]
+
+Changes made:
+- [description of change 1]
+- [description of change 2]
+
+Screenshots: [replaced N / text-only update / N new screenshots added]
+
+Unrelated issues noticed (not changed):
+- [issue] at [location] — recommend fixing separately
+```
+
+If multiple articles were updated — one report block per article.
+
+When the user confirms the result looks good — load `.agents/skills/pr/SKILL.md`
+to create the branch, commit, and open a draft PR.

--- a/.agents/skills/write-from-scratch/SKILL.md
+++ b/.agents/skills/write-from-scratch/SKILL.md
@@ -1,0 +1,317 @@
+---
+name: write-from-scratch
+description: Write a new documentation article from scratch based on a provided
+source — Jira brief, Confluence page, or direct description. Load when asked to
+create a new article that does not yet exist in the repository.
+---
+
+Write a new article from source material, following the correct structure for
+the article type and the project style guide.
+
+## Scope — read exactly these files
+
+1. This SKILL.md
+2. `.agents/references/content-types.md` — article type decision and templates
+3. `.agents/references/style-guide.md` — writing rules
+4. `.agents/references/procedures.md` — step format, Optional prefix, location/purpose before action
+5. `.agents/references/mdx-rules.md` — MDX and frontmatter rules
+5. One or two existing articles of the same type (found during Phase 3)
+6. Source material: Jira brief, Confluence page, or user input
+7. `.agents/references/mcp-tools/confluence.md` — only if fetching from Confluence
+8. `.agents/references/mcp-tools/jira.md` — only if fetching from Jira directly
+
+Do not read more than two reference articles. Do not read articles from other
+product areas unless directly relevant.
+
+---
+
+## Inputs
+
+| Input | Required | Notes |
+|-------|----------|-------|
+| Topic or feature description | Yes | What the article is about |
+| Source material | One of these | Jira brief, Confluence URL, or free-text description |
+| Article type | No | If not specified, determine from content-types.md |
+| Product area | No | If not specified, infer from topic |
+
+If coming from `jira-context` skill — the brief from that skill is your source material.
+Do not re-fetch the Jira ticket.
+
+---
+
+## Phase 1 — Gather source material
+
+Collect everything needed to write accurately. Do not write from memory or assumptions.
+
+**If a jira-context brief was provided:**
+Use it directly. The brief already contains what changed, which article, and scope of work.
+
+**If a Jira ticket ID is provided directly:**
+Fetch the ticket. Extract: summary, description, acceptance criteria, linked dev ticket.
+Follow the instructions in `.agents/references/mcp-tools/jira.md`.
+
+**If a Confluence URL is provided:**
+Fetch the page. Look for: feature description, API fields, known limitations, screenshots.
+Follow the instructions in `.agents/references/mcp-tools/confluence.md`.
+Never copy Confluence text verbatim — use it to understand the feature, write in your own words.
+
+**If free-text description is provided:**
+Use it as the primary source. Note what is known vs what needs verification.
+
+**For API content — check the OpenAPI spec:**
+Find the relevant YAML file in `/api-reference/services_documented/{product}_api.yaml`.
+Verify field names, parameter types, and endpoint paths against the spec — not against
+Confluence or memory.
+
+**Mark gaps:** If important details are missing (exact field names, UI navigation path,
+behavior in edge cases), note them as `{TODO: verify X}` inline in the draft.
+Do not invent technical details.
+
+---
+
+## Phase 2 — Determine article type
+
+Read `.agents/references/content-types.md` and answer two questions:
+
+**1. Does the feature have both Customer Portal UI and REST API coverage?**
+- Both → Tabbed article
+- Portal only → Portal-only article
+- API only → API-only article
+
+**2. For articles with an API section — do the steps require sequential execution?**
+- Yes (outputs feed into next steps) → Structure A: Quickstart + Step-by-step
+- No (independent operations) → Structure B: standalone sections
+
+**Rule of thumb:**
+- "Create" / "Deploy" articles → almost always sequential (Structure A)
+- "Manage" / "Configure" articles → almost always independent (Structure B)
+- Test: "Can the user do Step 3 without Steps 1 and 2?" If yes → Structure B
+
+If unsure — ask the user before writing.
+
+---
+
+## Phase 3 — Find the file path and a reference article
+
+**Determine the file path:**
+```
+/{product}/{section}/{article-name}.mdx
+```
+
+- Product: matches the top-level folder (`cloud`, `cdn`, `dns`, `waap`, etc.)
+- Section: matches the subfolder within the product
+- Filename: lowercase, hyphens, verb-noun pattern — `create-an-instance.mdx`,
+  `configure-firewall-rules.mdx`
+
+**Find one reference article:**
+Look for an existing article of the same type in the same product folder:
+```powershell
+ls {product}/{section}/*.mdx
+```
+
+Read it fully. Use it to understand:
+- The depth of explanation typical for this product
+- How UI steps are formatted
+- How code examples are presented
+- The tone and level of assumed knowledge
+
+---
+
+## Phase 4 — Write the article
+
+Use the template from `.agents/references/content-types.md` for the article type
+determined in Phase 2.
+
+### Opening sentence
+
+The first sentence must state what the reader will accomplish and why it matters.
+Never open with "This guide covers...", "This article explains...", or any description
+of the document itself.
+
+**Bad:** "This guide covers creating a virtual machine using the Gcore Cloud API."
+**Good:** "Deploy a Linux virtual machine using the Gcore Cloud REST API — create
+SSH keys, select a flavor and image, and assign a floating IP address."
+
+### Writing each section
+
+Before writing a section:
+1. Know what the section's goal is — what does the reader need after reading it?
+2. Write the intro sentence for that section first
+3. Then the content
+
+Follow the paragraph formulas in `style-guide.md`:
+- Maximum 2 sentences per paragraph (Formulas A and B)
+- No root-word pairs in the same paragraph
+- No filler words: just, simply, ensure, platform
+
+### Portal steps
+
+For `<MethodSection id="portal">`:
+- Numbered steps using `1.` (not `1\.`)
+- Bold for UI element names: Click **Create**, In the **Name** field
+- Wrap standalone prose paragraphs in `<p>` tags
+- No `####` headings — use **bold text** for sub-labels
+- Screenshot placeholders where needed: `{TODO: screenshot — [what it shows]}`
+
+### API steps
+
+For `<MethodSection id="api">` or standalone API articles:
+
+**Opening sentence** (required, before the `<Info>` block):
+Describe what this section enables. Not "The steps below...".
+Good: "Create a subnet inside an existing network and customize its DHCP settings."
+
+**`<Info>` block** (required):
+```mdx
+<Info>
+A permanent [API token](/account-settings/api-tokens) is required, along with a
+[project ID](...) and a [region ID](...).
+</Info>
+```
+
+**Tab order:** always Python SDK → Go SDK → curl (curl always last).
+**In Quickstart:** Python SDK and Go SDK only — no curl tab.
+
+**Step anatomy** (for Structure A sequential steps):
+1. One sentence: why this step matters in the flow
+2. Key parameters table (non-obvious required fields only)
+3. Code tabs: Python SDK → Go SDK → curl
+4. `The API returns:` label, then the response JSON
+5. Inline link to API reference on a meaningful noun
+
+**Quickstart scripts:**
+- Comment every step: `# Step 1.` / `// Step 1.` — never combine (`# Step 3+4`)
+- Must run as-is after setting three env vars — no other substitutions
+- Never hardcode region-specific IDs — select by characteristics:
+  ```python
+  # IDs are region-specific; selects 2 vCPU / 4 GB RAM
+  flavor = next(f for f in flavors if f.vcpus == 2 and f.ram == 4096)
+  ```
+
+### Marking uncertainty
+
+When technical details cannot be verified from source material:
+```
+{TODO: verify — [what needs to be checked and where]}
+```
+
+Use for: exact UI navigation paths, field names not in the spec, behavior in
+edge cases, screenshot content.
+
+Do not publish speculation as fact.
+
+---
+
+## Phase 5 — Verify agent-added claims
+
+Before writing frontmatter, find everything you wrote that did NOT come directly
+from the provided source material.
+
+**The rule:** if the contributor or source gave you the information — trust it and
+use it, even if it is not yet in Jira or Confluence. Verification only targets
+what you added through your own reasoning.
+
+**What counts as agent-added:**
+- A number or limit you inferred: "the timeout is probably 30 seconds" or "standard
+  limit is 100" — when the source didn't state it
+- A behavioral claim you deduced: "since it uses REST, it returns JSON" or "this
+  will automatically scale"
+- A step you added because "it seems logical this would be needed"
+- Any phrase starting with "typically", "usually", "generally", "by default" when
+  the source did not say this
+
+**What does NOT need verification:**
+- Numbers, limits, and specs explicitly stated by the contributor in their input
+- Values taken directly from the Jira ticket description or Confluence page
+- Technical details confirmed by real API testing in Phase 1
+- Values copied from the OpenAPI YAML spec
+
+**For each agent-added claim, check in order:**
+
+1. **Main Jira ticket** — is it stated in description or acceptance criteria?
+2. **Parent ticket** — does the parent epic specify this?
+3. **Sibling tickets** — other issues linked to the same parent
+4. **Confluence pages** — linked from any ticket or searchable by feature name
+
+Use `.agents/references/mcp-tools/jira.md` and `.agents/references/mcp-tools/confluence.md`.
+
+**Decision:**
+
+| Situation | Action |
+|-----------|--------|
+| Claim came from contributor or source | Keep it — no verification needed |
+| Claim confirmed in Jira or Confluence | Keep it |
+| Claim is your own reasoning, not found anywhere | `{TODO: verify — added by agent, not confirmed in source}` |
+| Sources disagree | Use most authoritative (Confluence spec > ticket description), note the discrepancy |
+
+When in doubt, ask yourself: **"Where did I get this from?"**
+If the answer is "I reasoned it" or "it seemed logical" — mark it as TODO.
+
+---
+
+## Phase 6 — Frontmatter
+
+Every article requires these fields:
+
+```yaml
+---
+title: [Full title — shown in browser tab]
+sidebarTitle: [Short sidebar label]
+ai-navigation: [One sentence, starts with action verb, max 160 chars, no {braces} or /slashes/]
+---
+```
+
+Write `ai-navigation` last — after the article is complete, it is easier to
+summarize accurately.
+
+Check the rules in `.agents/references/mdx-rules.md` — curly braces and colons in
+`ai-navigation` break the Mintlify build.
+
+---
+
+## Phase 7 — Validate before showing
+
+**MDX:**
+- [ ] Import line includes `.jsx` extension: `from "/snippets/method-switch.jsx"`
+- [ ] `<MethodSwitch>` wraps both sections, `label` is on `<MethodSection>`
+- [ ] All prose inside `<MethodSection>` wrapped in `<p>` tags or proper list syntax
+- [ ] No `{identifier}` in inline backtick spans — use `<code>` with `&nbsp;`
+- [ ] No `####` headings inside `<MethodSection>`
+- [ ] Closing `</MethodSection>` tags at column 0 (not indented after a list)
+
+**Frontmatter:**
+- [ ] `title` present
+- [ ] `ai-navigation` present, no forbidden characters
+- [ ] No `description` field
+
+**Style:**
+- [ ] Opening sentence does not describe the document
+- [ ] No forbidden sections: `## Prerequisites`, `## Next steps`, `## See also`
+- [ ] Every `##` heading followed by a prose sentence before code or table
+- [ ] Headings in sentence case
+- [ ] Bold only for UI element names
+- [ ] No forbidden words: just, simply, ensure, platform, obviously
+
+---
+
+## Phase 8 — Output
+
+Show the complete article content. Then:
+
+```
+File: [path]
+Article type: [type from content-types.md]
+Structure: [A — sequential / B — independent / N/A]
+
+TODO items requiring verification:
+- {TODO: ...} at Step N — [what to check]
+- {TODO: ...} in [section] — [what to check]
+
+Recommended next step:
+- No TODOs → ready for review, create PR with skill pr
+- Has portal TODOs → run skill full-audit to verify UI steps
+- Has API TODOs → verify against API spec or test manually
+```
+
+When the user confirms the result looks good — load `.agents/skills/pr/SKILL.md`
+to create the branch, commit, and open a draft PR.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,185 @@
+# AGENTS.md — Gcore Product Documentation
+
+This file is loaded automatically. Read it fully, then stop and wait for a task.
+Do not explore the repository until you have a task and have loaded the matching skill.
+
+## What this repo is
+
+Mintlify documentation site for Gcore cloud products. Content is MDX files in
+product folders. Articles that cover multiple tools (Customer Portal, REST API,
+Terraform, CLI) live as a single MDX file using the `MethodSwitch` component —
+not as separate files. OpenAPI specs for all products are in the repo and used
+as the source of truth for API documentation.
+
+## Folder structure
+
+```
+/{product}/{section}/article.mdx       Main content (cloud, cdn, dns, waap, …)
+/{product}.mdx                         Product landing/navigation page
+/api-reference/services_documented/    OpenAPI YAML specs, one per product
+/snippets/                             Shared JSX and MDX components
+/.agents/skills/                       Skills — load on demand, one per task
+/.agents/references/                   Reference files — load only when a skill says to
+```
+
+## Three rules that apply to every task
+
+**1. Never create separate files for Portal / API / Terraform.**
+All methods for the same feature live in one `.mdx` file using `MethodSwitch`.
+If you are adding API coverage to an existing Portal article, add a tab — do
+not create a new file.
+
+**2. Never use `description` in frontmatter.**
+Mintlify renders `description` as visible page text. Use `ai-navigation` instead.
+`ai-navigation` is one sentence, max 160 characters, starts with an action verb,
+mentions all methods covered.
+
+`ai-navigation` is not just a label — it is read by a GitHub Action that generates
+`llms.txt` files for every product. These files are how AI agents (including Claude)
+discover what documentation exists. A missing or broken `ai-navigation` means the
+article is invisible to AI-powered search and navigation tools.
+
+Forbidden characters in `ai-navigation`: `:` (colon) and `#` (hash). The CI
+workflow auto-replaces them with ` -`, but the result may look wrong. Avoid them.
+
+**3. Internal links are always root-relative.**
+Use `/cloud/virtual-instances/create-an-instance`, never a full
+`https://docs.gcore.com/…` URL and never a relative `../` path.
+
+## Available MCP tools
+
+These are configured in this environment. Skills that need them will say so.
+
+| MCP | Purpose |
+|-----|---------|
+| Jira | Fetch tickets, acceptance criteria, linked issues |
+| Confluence | Internal product specs, release notes |
+| Playwright | Browser testing at https://portal.gcore.com |
+
+**Before using any MCP tool:** verify it is available. If not — read
+`.agents/references/mcp-tools/setup.md` and give the user the exact setup
+instructions from that file. Do not attempt to work around a missing tool.
+
+## Task → Skill
+
+Identify the task from the user's request. Load exactly one skill file.
+Read nothing else until the skill tells you to.
+
+| Task | Load this skill |
+|------|----------------|
+| Product or UI changed — find affected articles and update them | `.agents/skills/update-page/SKILL.md` |
+| Write a new article from scratch | `.agents/skills/write-from-scratch/SKILL.md` |
+| Analyze a Jira ticket — what needs documenting | `.agents/skills/jira-context/SKILL.md` |
+| Add REST API tab to an existing Portal article | `.agents/skills/api-use-case/SKILL.md` |
+| Test an article step by step and fix it | `.agents/skills/full-audit/SKILL.md` |
+| Product team: new feature → draft PR | `.agents/skills/feature-draft/SKILL.md` |
+| Compile a multi-topic end-to-end guide | `.agents/skills/cookbook/SKILL.md` |
+| Create a PR after work is done | `.agents/skills/pr/SKILL.md` |
+
+## Common mistakes
+
+These errors are specific to this repository. They cause silent failures or broken
+builds that are hard to debug. Know them before touching any file.
+
+**1. MethodSwitch import missing `.jsx` — blank page, no error**
+```mdx
+Wrong:  import { MethodSwitch, MethodSection } from "/snippets/method-switch"
+Correct: import { MethodSwitch, MethodSection } from "/snippets/method-switch.jsx"
+```
+The MDX compiler reports OK. The blank page appears only in the Mintlify runtime.
+
+**2. `description` in frontmatter — renders as visible page text**
+```yaml
+Wrong:  description: How to create a VM   ← appears on the page
+Correct: ai-navigation: Create a VM ...   ← invisible to users, read by AI
+```
+
+**3. `{identifier}` in inline backtick code spans — MDX parse error**
+```mdx
+Wrong:  Poll `GET /tasks/{task_id}` every 5 seconds.
+Correct: Poll <code>GET&nbsp;/tasks/{task_id}</code> every 5 seconds.
+```
+Safe inside triple-backtick fenced blocks. Only breaks in single-backtick inline spans.
+
+**4. `</MethodSection>` indented after a list — tag becomes invisible to parser**
+```mdx
+Wrong:
+- Last item.
+
+  </MethodSection>   ← indented = MDX treats as list continuation
+
+Correct:
+- Last item.
+
+</MethodSection>     ← column 0
+```
+
+**5. Prose not wrapped in `<p>` inside `<MethodSection>` — content merges into one block**
+```mdx
+Wrong:  <MethodSection>Some intro text. Then a step.</MethodSection>
+Correct: <MethodSection><p>Some intro text.</p>1. Then a step.</MethodSection>
+```
+Plain paragraphs inside `<MethodSection>` compile to text strings — blank lines are stripped.
+
+**6. `####` heading inside `<MethodSection>` — appears in the wrong tab's TOC**
+```mdx
+Wrong:  #### Subsection title   ← leaks into active tab's TOC
+Correct: **Subsection title**   ← bold text, no TOC entry
+```
+
+**7. `ai-navigation` with `{...}`, `/paths/`, `:` or `#` — breaks build**
+```yaml
+Wrong:  ai-navigation: Poll GET /tasks/{task_id} until state: FINISHED
+Wrong:  ai-navigation: See #overview for details
+Correct: ai-navigation: Create and manage virtual machines via the Gcore Cloud API.
+```
+Allowed: commas, periods, hyphens, parentheses. Forbidden: `{` `}` `/` `:` `#`.
+
+**8. Image file without extension — does not display in browser**
+```mdx
+Wrong:  ![Alt text](/images/docs/cloud/create-vm/step-3)
+Correct: ![Alt text](/images/docs/cloud/create-vm/step-3.png)
+```
+Always verify the file exists at the path before referencing it.
+
+**9. `git add .` or `git add -A` — stages unrelated files from other sessions**
+Always stage files by name: `git add cloud/virtual-instances/create-an-instance.mdx`
+
+**10. Branching from stale local main — silently includes other branches' commits**
+```powershell
+Always run before branching:
+git checkout main
+git pull origin main   ← required, not optional
+git checkout -b update-{product}-{slug}
+```
+
+---
+
+## CI workflows — what runs automatically
+
+Two GitHub Actions run automatically when you push a branch or open a PR.
+Know about them to avoid confusion.
+
+**`sanitize-ai-navigation`** — runs on every push to non-main branches:
+Scans all `.mdx` files and replaces `:` and `#` in `ai-navigation` values with ` -`.
+Auto-commits the fix directly to your branch. If this happens, run `git pull`
+before any follow-up commits to avoid conflicts.
+
+**`normalize-images`** — runs on every PR when images or MDX files change:
+Renames images to `{article-slug}-imageN.ext` and updates the paths in MDX files.
+Also regenerates `llms.txt` files. Auto-commits everything to your branch.
+Same rule: run `git pull` before follow-up commits.
+
+**Image naming convention** (the action enforces this, but follow it from the start):
+```
+images/docs/{product}/{article-slug}/{article-slug}-image1.png
+images/docs/{product}/{article-slug}/{article-slug}-image2.png
+```
+
+---
+
+## Hard stop
+
+Load one skill per task. Do not read other skill files. Do not read articles to
+"understand context." Do not read references unless the skill explicitly says to.
+When in doubt about what to do next, ask the user — do not explore.


### PR DESCRIPTION
Adds AGENTS.md orchestrator and .agents/ directory with 8 skills, 5 references, and MCP tool guides for Jira, Confluence, and Playwright. Enables AI agents to write, audit, review, and publish documentation.