### PR TITLE
feat(hooks): add agent hooks for Claude Code and Cursor

### DIFF
--- a/.claude/hooks/pre-edit-mdx.ps1
+++ b/.claude/hooks/pre-edit-mdx.ps1
@@ -1,0 +1,31 @@
+# Runs before every Edit or Write tool call.
+# If the file is .mdx, injects procedures.md and mdx-rules.md into context.
+# The agent cannot skip these rules — they are physically present before the edit.
+
+$inputJson = [Console]::In.ReadToEnd() | ConvertFrom-Json
+$filePath = $inputJson.tool_input.file_path
+
+if ($filePath -notmatch '\.mdx$') { exit 0 }
+
+$refDir = Join-Path $env:CLAUDE_PROJECT_DIR ".agents" "references"
+$procedures = Join-Path $refDir "procedures.md"
+$mdxRules   = Join-Path $refDir "mdx-rules.md"
+
+Write-Output "=== RULES FOR MDX EDIT: $filePath ==="
+Write-Output ""
+
+if (Test-Path $procedures) {
+    Write-Output "--- procedures.md ---"
+    Get-Content $procedures -Raw
+    Write-Output ""
+}
+
+if (Test-Path $mdxRules) {
+    Write-Output "--- mdx-rules.md ---"
+    Get-Content $mdxRules -Raw
+    Write-Output ""
+}
+
+Write-Output "=== Apply these rules to the edit. ==="
+
+exit 0

--- a/.claude/hooks/pre-screenshot.ps1
+++ b/.claude/hooks/pre-screenshot.ps1
@@ -1,0 +1,19 @@
+# Runs before any Playwright screenshot tool call.
+# Injects screenshot standards so the agent follows them before capturing.
+
+$inputJson = [Console]::In.ReadToEnd() | ConvertFrom-Json
+$toolName  = $inputJson.tool_name
+
+if ($toolName -notmatch 'screenshot') { exit 0 }
+
+$playwrightFile = Join-Path $env:CLAUDE_PROJECT_DIR ".agents" "references" "mcp-tools" "playwright.md"
+
+if (Test-Path $playwrightFile) {
+    Write-Output "=== SCREENSHOT STANDARDS ==="
+    Write-Output ""
+    Get-Content $playwrightFile -Raw
+    Write-Output ""
+    Write-Output "=== Follow these standards before taking the screenshot. ==="
+}
+
+exit 0

--- a/.claude/hooks/session-start.ps1
+++ b/.claude/hooks/session-start.ps1
@@ -1,0 +1,8 @@
+# Runs at session start. Injects AGENTS.md into context so the agent
+# always knows what skills are available before any task.
+
+$agentsFile = Join-Path $env:CLAUDE_PROJECT_DIR "AGENTS.md"
+
+if (Test-Path $agentsFile) {
+    Get-Content $agentsFile -Raw
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,37 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "powershell.exe",
+            "args": ["-NoProfile", "-File", ".claude/hooks/session-start.ps1"]
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "powershell.exe",
+            "args": ["-NoProfile", "-File", ".claude/hooks/pre-edit-mdx.ps1"]
+          }
+        ]
+      },
+      {
+        "matcher": "mcp__playwright__browser_screenshot",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "powershell.exe",
+            "args": ["-NoProfile", "-File", ".claude/hooks/pre-screenshot.ps1"]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.cursor/hooks.json
+++ b/.cursor/hooks.json
@@ -1,0 +1,22 @@
+{
+  "hooks": {
+    "sessionStart": [
+      {
+        "command": "powershell.exe",
+        "args": ["-NoProfile", "-File", ".claude/hooks/session-start.ps1"]
+      }
+    ],
+    "preToolUse": [
+      {
+        "matcher": "editFile|writeFile",
+        "command": "powershell.exe",
+        "args": ["-NoProfile", "-File", ".claude/hooks/pre-edit-mdx.ps1"]
+      },
+      {
+        "matcher": "browser_screenshot",
+        "command": "powershell.exe",
+        "args": ["-NoProfile", "-File", ".claude/hooks/pre-screenshot.ps1"]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -44,7 +44,8 @@ Thumbs.db
 
 # Private files
 _private/
-.cursor/
+.cursor/*
+!.cursor/hooks.json
 .playwright-mcp/
 
 scully.log
@@ -53,5 +54,4 @@ scullyStats.json
 /scully/**/*.js
 /scully/**/*.js.map
 /scully/**/*.d.ts
-.cursor/
 .playwright-mcp/


### PR DESCRIPTION
SessionStart: injects AGENTS.md so agent always sees available skills. PreToolUse on *.mdx edit: injects procedures.md + mdx-rules.md before every MDX edit — agent cannot skip these rules.
PreToolUse on screenshot: injects screenshot standards before captures. Cursor equivalent in .cursor/hooks.json uses same PowerShell scripts.