### PR TITLE
feat(skills): add .claude/skills/ pointing to .agents/skills/

### DIFF
--- a/.claude/skills/api-use-case/SKILL.md
+++ b/.claude/skills/api-use-case/SKILL.md
@@ -1,0 +1,1 @@
+@../../../.agents/skills/api-use-case/SKILL.md

--- a/.claude/skills/cookbook/SKILL.md
+++ b/.claude/skills/cookbook/SKILL.md
@@ -1,0 +1,1 @@
+@../../../.agents/skills/cookbook/SKILL.md

--- a/.claude/skills/feature-draft/SKILL.md
+++ b/.claude/skills/feature-draft/SKILL.md
@@ -1,0 +1,1 @@
+@../../../.agents/skills/feature-draft/SKILL.md

--- a/.claude/skills/full-audit/SKILL.md
+++ b/.claude/skills/full-audit/SKILL.md
@@ -1,0 +1,1 @@
+@../../../.agents/skills/full-audit/SKILL.md

--- a/.claude/skills/jira-context/SKILL.md
+++ b/.claude/skills/jira-context/SKILL.md
@@ -1,0 +1,1 @@
+@../../../.agents/skills/jira-context/SKILL.md

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -1,0 +1,1 @@
+@../../../.agents/skills/pr/SKILL.md

--- a/.claude/skills/update-page/SKILL.md
+++ b/.claude/skills/update-page/SKILL.md
@@ -1,0 +1,1 @@
+@../../../.agents/skills/update-page/SKILL.md

--- a/.claude/skills/write-from-scratch/SKILL.md
+++ b/.claude/skills/write-from-scratch/SKILL.md
@@ -1,0 +1,1 @@
+@../../../.agents/skills/write-from-scratch/SKILL.md


### PR DESCRIPTION
Each .claude/skills/<name>/SKILL.md imports the canonical skill file from .agents/skills/ via @-reference. Single source of truth stays in .agents/skills/, Claude Code discovers skills via .claude/skills/.