### PR TITLE
fix(agents): add language-independent skill routing

### DIFF
--- a/.cursor/rules/skill-routing.mdc
+++ b/.cursor/rules/skill-routing.mdc
@@ -1,0 +1,22 @@
+---
+description: Routes any documentation task to the correct skill file. Always active.
+alwaysApply: true
+---
+
+When the user gives you a task:
+
+1. Translate the request to English internally — no external call needed.
+2. Match it to a skill using the table below.
+3. Open the skill file with a Read tool call before writing any response.
+4. Follow the skill file exactly.
+
+| Task (any language) | Skill file |
+|---|---|
+| Check/audit/test/verify/update an existing article for accuracy | `.agents/skills/full-audit/SKILL.md` |
+| Apply product or UI changes to an existing article | `.agents/skills/update-page/SKILL.md` |
+| Write a new article from scratch | `.agents/skills/write-from-scratch/SKILL.md` |
+| Analyze a Jira ticket | `.agents/skills/jira-context/SKILL.md` |
+| Add REST API tab to a portal article | `.agents/skills/api-use-case/SKILL.md` |
+| Product team: document a new feature | `.agents/skills/feature-draft/SKILL.md` |
+| Compile a multi-product end-to-end guide | `.agents/skills/cookbook/SKILL.md` |
+| Create a pull request | `.agents/skills/pr/SKILL.md` |

--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ Thumbs.db
 _private/
 .cursor/*
 !.cursor/hooks.json
+!.cursor/rules/
 .playwright-mcp/
 
 scully.log

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,15 @@
 This file is loaded automatically. Read it fully, then stop and wait for a task.
 Do not explore the repository until you have a task and have loaded the matching skill.
 
+## How to handle any task
+
+The user may write in any language. Follow these steps every time:
+
+1. **Translate** the user's request to English internally (no external call needed — you speak all languages).
+2. **Match** the translated request against the Task → Skill table below.
+3. **Use the Read tool** to open the matching skill file. This is your first tool call — before writing any response, before asking any question.
+4. **Follow the skill file exactly.** It overrides everything else.
+
 ## What this repo is
 
 Mintlify documentation site for Gcore cloud products. Content is MDX files in


### PR DESCRIPTION
AGENTS.md now tells the agent to translate any language to English internally, then match to skill table, then Read the skill file. No external API call needed — agent handles translation natively.

.cursor/rules/skill-routing.mdc: alwaysApply Cursor equivalent with the same routing table and instructions.