### PR TITLE
fix(tokens): update API token format from $ to _ separator

### DIFF
--- a/cdn/grafana/view-cdn-statistics-in-grafana.mdx
+++ b/cdn/grafana/view-cdn-statistics-in-grafana.mdx
@@ -87,7 +87,7 @@ You can get a token in your personal account. To do this, go to Profile > API to
 
 Insert the received API token in the API token field in the format: **APIKey** `{the received API token}`.
 
-For example: `APIKey 7711$eyJ0eXAiOiJKV`
+For example: `APIKey 7711_eyJ0eXAiOiJKV`
 
 
 <Frame>![Insert the received API token](/images/docs/cdn/grafana-terraform/view-cdn-statistics-in-grafana/api_token_1.png)</Frame>

--- a/cdn/logs/log-viewer-view-and-download-cdn-resource-logs.mdx
+++ b/cdn/logs/log-viewer-view-and-download-cdn-resource-logs.mdx
@@ -131,7 +131,7 @@ We open a tool for working with an API and do as follows:
 
 2\. We specify the request method: `GET`.
 
-3\. We add the `Authorization` header and its value. We want to log in with a [permanent token](/account-settings/api-tokens), so we specify our token "APIKey 7711$eyJ0eXAiOiJKV".
+3\. We add the `Authorization` header and its value. We want to log in with a [permanent token](/account-settings/api-tokens), so we specify our token "APIKey 7711_eyJ0eXAiOiJKV".
 
 4\. We enter the request parameters:
 


### PR DESCRIPTION
Replaces the deprecated 7711$eyJ... token format with the new 7711_eyJ... format in all documentation examples.

Resolves: DOC-1395