### PR TITLE
fix: resolve two broken links 

### DIFF
--- a/cloud/networking/ip-address/configure-an-allowed-address-pair.mdx
+++ b/cloud/networking/ip-address/configure-an-allowed-address-pair.mdx
@@ -234,7 +234,7 @@ Up to 10 pairs are allowed per port.
     }
     ```
 
-    Poll <code>GET&nbsp;https://api.gcore.com/cloud/v1/tasks/{task_id}</code> every 5 seconds until `state` is `FINISHED`. The operation typically completes in under 10 seconds.
+    Poll `GET https://api.gcore.com/cloud/v1/tasks/{task_id}` every 5 seconds until `state` is `FINISHED`. The operation typically completes in under 10 seconds.
   </Tab>
 </Tabs>
 
@@ -334,7 +334,7 @@ To remove all allowed address pairs from a port, send the same `PUT` request wit
     }
     ```
 
-    Poll <code>GET&nbsp;https://api.gcore.com/cloud/v1/tasks/{task_id}</code> every 5 seconds until `state` is `FINISHED`.
+    Poll `GET https://api.gcore.com/cloud/v1/tasks/{task_id}` every 5 seconds until `state` is `FINISHED`.
   </Tab>
 </Tabs>
 

--- a/edge-ai/getting-started.mdx
+++ b/edge-ai/getting-started.mdx
@@ -18,7 +18,7 @@ Check out [our API docs](https://api.gcore.com/docs/cloud#tag/GPU-Cloud) if you 
 
 The second stage of AI is [model inference](https://gcore.com/learning/what-is-ai-inference/), where the model makes predictions based on user requests. In this stage, it's crucial that the AI model can respond promptly to users regardless of network delays, latency, and distance from data centers.
 
-**If you need inference** for open-source models or models you trained yourself, [our guide on deploying AI models](/edge-ai/everywhere-inference/ai-models/deploy-an-ai-model) explains how to set up [Everywhere Inference](https://gcore.com/everywhere-inference) via the Gcore Customer Portal.
+**If you need inference** for open-source models or models you trained yourself, [our guide on deploying AI models](/edge-ai/everywhere-inference/ai-models/deploy-from-catalog) explains how to set up [Everywhere Inference](https://gcore.com/everywhere-inference) via the Gcore Customer Portal.
 
 <Tip>
 **Tip**


### PR DESCRIPTION
- edge-ai/getting-started: update deploy-an-ai-model -> deploy-from-catalog (page renamed)
- configure-an-allowed-address-pair: replace <code> tags with backticks to prevent Mintlify scanning {task_id} placeholder URL