### PR TITLE
fix broken link 

### DIFF
--- a/streaming/player/player-api-tutorial.mdx
+++ b/streaming/player/player-api-tutorial.mdx
@@ -470,7 +470,7 @@ Gcore Player supports integration with remote logging platforms like Sentry for 
 
 ### Views Statistics
 
-This player does not collect or send usage statistics from end user devices. Viewing statistics are available from CDN data. See the apidocs section [Get unique viewers via CDN](/api-reference/streaming/streaming-statistics/get-unique-viewers-via-cdn).
+This player does not collect or send usage statistics from end user devices. Viewing statistics are available from CDN data. See the apidocs section [Get unique viewers via CDN](/api-reference/streaming/statistics/get-unique-viewers-via-cdn).
 
 
 ### Missing the feature you need?


### PR DESCRIPTION
Path segment was streaming-statistics instead of statistics.