### PR TITLE
Doc 1399

### DIFF
--- a/account-settings/llms.txt
+++ b/account-settings/llms.txt
@@ -6,7 +6,7 @@
 
 ## My profile
 - [My profile settings](https://gcore.com/docs/account-settings/my-profile/overview.md): Configure personal user account settings including username, email, preferred language, two-factor authentication (2FA), password changes, and view login history with IP address, OS, browser, and success status tracking in the Customer Portal My profile page.
-- [Set up two-factor authentication](https://gcore.com/docs/account-settings/my-profile/two-factor-authentication.md): Enable two-factor authentication in Gcore Customer Portal using authenticator applications (Google Authenticator, Microsoft Authenticator, Authy) with QR code scanning and backup verification codes for account security.
+- [Set up two-factor authentication](https://gcore.com/docs/account-settings/my-profile/two-factor-authentication.md): Enable or disable two-factor authentication in Gcore Customer Portal using authenticator apps, backup verification codes, and email confirmation for disabling 2FA.
 - [Change or reset a password](https://gcore.com/docs/account-settings/my-profile/change-password.md): Change or reset account password in Gcore Customer Portal via Profile settings, or reset forgotten password via email verification link at auth.gcore.com/login/forgot-password.
 - [Missing password reset email](https://gcore.com/docs/account-settings/my-profile/password-reset-email.md): Troubleshoot missing password reset emails from support@gcore.com by checking spam folders and reinitiating the reset process at auth.gcore.com/login/forgot-password.
 

--- a/account-settings/my-profile/two-factor-authentication.mdx
+++ b/account-settings/my-profile/two-factor-authentication.mdx
@@ -1,7 +1,7 @@
 ---
 title: Set up two-factor authentication
 sidebarTitle: Two-factor authentication
-ai-navigation: Enable two-factor authentication in Gcore Customer Portal using authenticator applications (Google Authenticator, Microsoft Authenticator, Authy) with QR code scanning and backup verification codes for account security.
+ai-navigation: Enable or disable two-factor authentication in Gcore Customer Portal using authenticator apps, backup verification codes, and email confirmation for disabling 2FA.
 ---
 
 Two-factor authentication (2FA) provides an extra layer of security by requiring both a password and a single-use verification code at login, protecting accounts from unauthorized access.
@@ -51,6 +51,8 @@ Backup verification codes allow access to the account if the authenticator app b
 <Frame>![Two-Factor authentication section on My profile page](/images/docs/account-settings/my-profile/two-factor-authentication/2fa-security-section.png)</Frame>
 
 <Warning>
+**Warning**
+
 Each backup code can be used only once. When all codes have been used, generate a new set — clicking **Generate backup code** invalidates the previous codes.
 </Warning>
 
@@ -74,9 +76,23 @@ Copy, print, or download the five codes and store them securely before closing t
 
 ## Disable two-factor authentication
 
-Go to the [My profile](https://portal.gcore.com/accounts/settings/user-profile) page and in the **Two-Factor authentication** section, click **Disable 2FA**.
+1. Go to the [My profile](https://portal.gcore.com/accounts/settings/user-profile) page and in the **Two-Factor authentication** section, click **Disable 2FA**.
 
 <Frame>![Disable 2FA button on My profile page](/images/docs/account-settings/my-profile/two-factor-authentication/disable-2fa-section.png)</Frame>
+
+2. In the confirmation dialog that opens, review the message and click **Confirm**.
+
+   A confirmation link will be sent to the email address associated with the account. The link is masked in the dialog for security.
+
+3. Open the email and click the confirmation link.
+
+Two-factor authentication is now disabled. The portal redirects to the My profile page where 2FA is shown as inactive.
+
+<Warning>
+**Warning**
+
+The confirmation link is single-use and expires after a short period. If the link has expired or was already used, an error page appears — return to the My profile page and click **Disable 2FA** again to request a new link.
+</Warning>
 
 ## View users with enabled two-factor authentication
 

--- a/account-settings/my-profile/two-factor-authentication.mdx
+++ b/account-settings/my-profile/two-factor-authentication.mdx
@@ -76,7 +76,7 @@ Copy, print, or download the five codes and store them securely before closing t
 
 ## Disable two-factor authentication
 
-1. Go to the [My profile](https://portal.gcore.com/accounts/settings/user-profile) page and in the **Two-Factor authentication** section, click **Disable 2FA**.
+1. Go to the [**My profile**](https://portal.gcore.com/accounts/settings/user-profile) page and in the **Two-Factor authentication** section, click **Disable 2FA**.
 
 <Frame>![Disable 2FA button on My profile page](/images/docs/account-settings/my-profile/two-factor-authentication/disable-2fa-section.png)</Frame>
 
@@ -86,12 +86,12 @@ Copy, print, or download the five codes and store them securely before closing t
 
 3. Open the email and click the confirmation link.
 
-Two-factor authentication is now disabled. The portal redirects to the My profile page where 2FA is shown as inactive.
+Two-factor authentication is now disabled. The portal redirects to the **My profile** page where 2FA is shown as inactive.
 
 <Warning>
 **Warning**
 
-The confirmation link is single-use and expires after a short period. If the link has expired or was already used, an error page appears — return to the My profile page and click **Disable 2FA** again to request a new link.
+The confirmation link is single-use and expires after a short period. If the link has expired or was already used, an error page appears — return to the **My profile** page and click **Disable 2FA** again to request a new link.
 </Warning>
 
 ## View users with enabled two-factor authentication

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -10,7 +10,7 @@
 
 ## My profile
 - [My profile settings](https://gcore.com/docs/account-settings/my-profile/overview.md): Configure personal user account settings including username, email, preferred language, two-factor authentication (2FA), password changes, and view login history with IP address, OS, browser, and success status tracking in the Customer Portal My profile page.
-- [Set up two-factor authentication](https://gcore.com/docs/account-settings/my-profile/two-factor-authentication.md): Enable two-factor authentication in Gcore Customer Portal using authenticator applications (Google Authenticator, Microsoft Authenticator, Authy) with QR code scanning and backup verification codes for account security.
+- [Set up two-factor authentication](https://gcore.com/docs/account-settings/my-profile/two-factor-authentication.md): Enable or disable two-factor authentication in Gcore Customer Portal using authenticator apps, backup verification codes, and email confirmation for disabling 2FA.
 - [Change or reset a password](https://gcore.com/docs/account-settings/my-profile/change-password.md): Change or reset account password in Gcore Customer Portal via Profile settings, or reset forgotten password via email verification link at auth.gcore.com/login/forgot-password.
 - [Missing password reset email](https://gcore.com/docs/account-settings/my-profile/password-reset-email.md): Troubleshoot missing password reset emails from support@gcore.com by checking spam folders and reinitiating the reset process at auth.gcore.com/login/forgot-password.
 


### PR DESCRIPTION
## What changed
Documents the new email confirmation flow for disabling 2FA (DOC-1399 / IMP-429).
Previously, disabling 2FA required a single click. The new flow sends a single-use
confirmation link to the user's email — 2FA is only disabled after opening the link.
## Files changed
- `account-settings/my-profile/two-factor-authentication.mdx` — expanded the
  "Disable two-factor authentication" section from one sentence to a 3-step flow;
  added Warning block for expired/already-used token errors; updated ai-navigation.