### PR TITLE
waap: billing behavior for disabled domains

### DIFF
--- a/waap/getting-started/billing.mdx
+++ b/waap/getting-started/billing.mdx
@@ -75,3 +75,13 @@ A credit card is not required to start.
 If no payment method is added and the included quota is reached, service consumption is stopped.
 
 If a credit card is added, service continues without interruption. Usage remains free until the included quota is reached. Any usage beyond the included quota is billed according to the selected plan.
+
+## Billing for disabled domains
+
+When a WAAP-protected domain is disabled, the following billing rules apply:
+
+- **Traffic is not processed.** No requests are inspected or counted while the domain is disabled.
+- **The domain is counted for the current billing month.** If you disable a domain mid-month, it counts as one Domain / Zone for that billing period.
+- **The domain is not counted in subsequent months.** Starting from the next billing month, a disabled domain no longer appears in your usage metrics.
+
+To avoid being billed for a domain in a given month, disable it before that billing month begins.

--- a/waap/getting-started/billing.mdx
+++ b/waap/getting-started/billing.mdx
@@ -84,4 +84,6 @@ When a WAAP-protected domain is disabled, the following billing rules apply:
 - **The domain is counted for the current billing month.** If you disable a domain mid-month, it counts as one Domain / Zone for that billing period.
 - **The domain is not counted in subsequent months.** Starting from the next billing month, a disabled domain no longer appears in your usage metrics.
 
+<Tip>
 To avoid being billed for a domain in a given month, disable it before that billing month begins.
+</Tip>


### PR DESCRIPTION
## Summary

- Adds a new "Billing for disabled domains" section to `waap/getting-started/billing.mdx`
- Clarifies that a disabled domain is still counted in the current billing month but not in subsequent months
- Clarifies that traffic is not processed while a domain is disabled

## Context

Agreed with Aleksandr Ivanov (PO) on 2026-06-22: the current behavior is intentional (anti-abuse), only documentation was missing.