### PR TITLE
fix(streaming): correct CDN navigation path from Security to Access tab

### DIFF
--- a/streaming/interaction-with-cdn/custom-cdn-resource.mdx
+++ b/streaming/interaction-with-cdn/custom-cdn-resource.mdx
@@ -101,7 +101,7 @@ Custom CDN resources unlock powerful security features through CDN access polici
 - Regulatory compliance for specific markets
 
 **How to configure:**
-1. Navigate to **CDN** > **CDN resources** > Select your resource > **Security**
+1. Navigate to **CDN** > **CDN resources** > Select your resource > **Access**
 2. Enable [Country access policy](https://gcore.com/docs/cdn/cdn-resource-options/security/control-access-to-the-content-with-country-referrer-ip-and-user-agents-policies#country-access-policy)
 3. Choose **Allow only** (whitelist) or **Block** (blacklist)
 4. Select countries from the list
@@ -155,7 +155,7 @@ Result: Content can only be embedded on these domains
 - Partner-specific content delivery
 
 **How to configure:**
-1. Navigate to **CDN** > **CDN resources** > Select your resource > **Security**
+1. Navigate to **CDN** > **CDN resources** > Select your resource > **Access**
 2. Enable [IP access policy](https://gcore.com/docs/cdn/cdn-resource-options/security/control-access-to-the-content-with-country-referrer-ip-and-user-agents-policies)
 3. Choose **Allow IP policy** or **Block IP policy**
 4. Add IP addresses or CIDR ranges
@@ -275,7 +275,7 @@ For detailed instructions, see: [Create a CDN resource](https://gcore.com/docs/c
 After creating the resource, configure security policies as needed:
 
 1. Go to **CDN** > **CDN resources** > Select your resource
-2. Navigate to **Security** tab
+2. Navigate to **Access** tab
 3. Configure:
    - [Country access policy](https://gcore.com/docs/cdn/cdn-resource-options/security/control-access-to-the-content-with-country-referrer-ip-and-user-agents-policies#country-access-policy) for geo-blocking
    - [Referrer access policy](https://gcore.com/docs/cdn/cdn-resource-options/security/control-access-to-the-content-with-country-referrer-ip-and-user-agents-policies#allow-referrer-policy) for embedding control


### PR DESCRIPTION
Country access policy, IP access policy, and the generic security section all incorrectly pointed users to the Security tab; the actual location is the Access tab.