### PR TITLE
docs(api-reference): rewrite overview page per style guide

### DIFF
--- a/api-reference/overview.mdx
+++ b/api-reference/overview.mdx
@@ -19,28 +19,29 @@ Gcore's API covers the full operational lifecycle — not just read operations, 
 
 Each Gcore product has its own path prefix on the shared base `https://api.gcore.com`:
 
-| Service | Base URL |
-|---------|----------|
-| Identity & Access Management (IAM) | `https://api.gcore.com/iam` |
-| Content Delivery Network (CDN) | `https://api.gcore.com/cdn` |
-| Managed DNS | `https://api.gcore.com/dns` |
-| Cloud, GPU Cloud & AI Inference | `https://api.gcore.com/cloud` |
-| Object Storage | `https://api.gcore.com/storage` |
-| FastEdge (Edge Functions) | `https://api.gcore.com/fastedge` |
-| Video Streaming | `https://api.gcore.com/streaming` |
-| DDoS | `https://api.gcore.com/security/iaas` |
-| WAAP | `https://api.gcore.com/waap` |
+| Service | Base URL | Reseller API |
+|---------|----------|--------------|
+| Identity & Access Management (IAM) | `https://api.gcore.com/iam` | [IAM reseller](/api-reference/iam-resellers) |
+| Content Delivery Network (CDN) | `https://api.gcore.com/cdn` | [CDN reseller](/api-reference/cdn-resellers) |
+| Managed DNS | `https://api.gcore.com/dns` | — |
+| Cloud, GPU Cloud & AI Inference | `https://api.gcore.com/cloud` | [Cloud reseller](/api-reference/cloud-resellers) |
+| Object Storage | `https://api.gcore.com/storage` | — |
+| FastEdge (Edge Functions) | `https://api.gcore.com/fastedge` | [FastEdge reseller](/api-reference/fastedge-resellers) |
+| Video Streaming | `https://api.gcore.com/streaming` | — |
+| DDoS | `https://api.gcore.com/security/iaas` | — |
+| WAAP | `https://api.gcore.com/waap` | — |
+| Billing | — | [Billing reseller](/api-reference/billing) |
 
 ## Authentication
 
-A [permanent API token](/account-settings/api-tokens#create-a-permanent-api-token) is required — generate one in **Customer Portal → [API tokens](https://portal.gcore.com/accounts/profile/api-tokens)**, then pass it as an `APIKey` value in the `Authorization` header:
+An [API token](/account-settings/api-tokens#create-a-permanent-api-token) is required — generate one in **Customer Portal → [API tokens](https://portal.gcore.com/accounts/profile/api-tokens)**, then pass it as an `APIKey` value in the `Authorization` header:
 
 ```http
 GET https://api.gcore.com/iam/clients/me
 Authorization: APIKey <YOUR_TOKEN>
 ```
 
-The `Authorization` header is case-insensitive. The same API token works across all Gcore product APIs. [Reseller endpoints](/reseller-support/api) use a separate Admin Portal token.
+The `Authorization` header is case-insensitive. The same API token works across all Gcore product APIs. [Reseller accounts](/reseller-support/api) authenticate with a separate Admin Portal token.
 
 ## Quick start
 

--- a/api-reference/overview.mdx
+++ b/api-reference/overview.mdx
@@ -42,8 +42,6 @@ Authorization: APIKey <YOUR_TOKEN>
 
 The `Authorization` header is case-insensitive. The same API token works across all Gcore product APIs. [Reseller endpoints](/reseller-support/api) use a separate Admin Portal token.
 
-<Warning>Gcore API keys include a dollar sign (`$`). When pasting a key directly into a terminal, escape it (`\$`) so the shell doesn't treat it as the start of an environment variable.</Warning>
-
 ## Quick start
 
 Verify the token by fetching account details:
@@ -54,7 +52,7 @@ curl -H "Authorization: APIKey $GCORE_TOKEN" "https://api.gcore.com/iam/clients/
 
 A `200 OK` response confirms the token is valid.
 
-## SDKs and IaC
+## SDKs and Terraform
 
 Three official clients cover the most common languages and infrastructure workflows:
 

--- a/api-reference/overview.mdx
+++ b/api-reference/overview.mdx
@@ -1,21 +1,23 @@
 ---
 title: Introduction
-description: Learn how to start building with Gcore’s REST APIs.
+description: Learn how to start building with Gcore's REST APIs.
 ---
 
 # Gcore API Overview
 
-Gcore is a global edge-cloud and security provider with **210+ Points of Presence on six continents**. Every product you see in the [Gcore Product Documentation](/home) is backed by a public, REST-style API so you can automate everything you do in the Customer Portal — or build entirely new experiences of your own.
+Every Gcore product is backed by a public REST API — the same API used by the Customer Portal and the official SDKs. All product APIs are available under the same base URL: `https://api.gcore.com`.
 
-## Why build on the API?
+## Use cases
 
-* **Automate** routine tasks such as CDN cache purges, DNS record updates, or VM provisioning.
-* **Integrate** Gcore services into CI/CD pipelines, Terraform workflows, Kubernetes Operators, or custom back-office tools.
-* **Monitor & react** to real-time metrics or events and keep your infrastructure in a desired state.
+Gcore's API covers the full operational lifecycle — not just read operations, but provisioning, configuration changes, and event-driven automation. Common use cases include:
 
-Whether you’re shipping a simple web app or operating a multi-region SaaS platform, Gcore’s APIs give you the same programmatic control used internally by our portal and SDKs.
+- Automating CDN cache purges, DNS record updates, and VM provisioning.
+- Integrating Gcore services into CI/CD pipelines, Terraform workflows, Kubernetes Operators, and custom back-office tools.
+- Reacting to real-time metrics and keeping infrastructure in a desired state without manual intervention.
 
 ## Base URLs by product
+
+Each Gcore product has its own path prefix on the shared base `https://api.gcore.com`:
 
 | Service | Base URL |
 |---------|----------|
@@ -31,46 +33,37 @@ Whether you’re shipping a simple web app or operating a multi-region SaaS plat
 
 ## Authentication
 
-1. Sign in to the **Customer Portal → [API tokens](https://portal.gcore.com/accounts/profile/api-tokens)**.
-2. Create a token (optionally set an expiry or rotate it later).
-3. Send the token as an *APIKey* in the `Authorization` header:
+A [permanent API token](/account-settings/api-tokens#create-a-permanent-api-token) is required — generate one in **Customer Portal → [API tokens](https://portal.gcore.com/accounts/profile/api-tokens)**, then pass it as an `APIKey` value in the `Authorization` header:
 
 ```http
 GET https://api.gcore.com/iam/clients/me
 Authorization: APIKey <YOUR_TOKEN>
 ```
 
-The header name is case-insensitive, so `Authorization`, `authorization`, and `AUTHORIZATION` all work identically. The same header works for every product API.
+The `Authorization` header is case-insensitive. The same API token works across all Gcore product APIs. [Reseller endpoints](/reseller-support/api) use a separate Admin Portal token.
 
-<Warning>Gcore API keys always contain a dollar sign (`$`). When you paste the key directly into a terminal,
-    escape the dollar sign (`\$`) so your shell doesn't treat it as the start of an environment variable.</Warning>
+<Warning>Gcore API keys include a dollar sign (`$`). When pasting a key directly into a terminal, escape it (`\$`) so the shell doesn't treat it as the start of an environment variable.</Warning>
 
-## Quick start (cURL)
+## Quick start
 
-Get detailed information about your account
+Verify the token by fetching account details:
 
 ```bash
 curl -H "Authorization: APIKey $GCORE_TOKEN" "https://api.gcore.com/iam/clients/me"
 ```
 
-The command should return `HTTP/1.1 200 OK`.
+A `200 OK` response confirms the token is valid.
 
-## Tooling & SDKs
+## SDKs and IaC
 
-| Tool | Install | Notes |
-|------|---------|-------|
-| **Python SDK** | `pip install gcore`<br/>[github.com/G-Core/gcore-python](https://github.com/G-Core/gcore-python) | Auto-generated from OpenAPI, sync and async support |
-| **Go SDK** | `go get github.com/G-Core/gcore-go`<br/>[github.com/G-Core/gcore-go](https://github.com/G-Core/gcore-go) | Idiomatic Go client with context support |
-| **Terraform Provider** | `terraform init` with<br/>`required_providers { gcore = { source = "G-Core/gcore" } }`<br/>[registry.terraform.io/providers/G-Core/gcore](https://registry.terraform.io/providers/G-Core/gcore) | Manage CDN, DNS, Cloud, WAAP, and more |
+Three official clients cover the most common languages and infrastructure workflows:
 
-## Support & feedback
+| Tool | Install |
+|------|---------|
+| Python SDK | `pip install gcore` — [github.com/G-Core/gcore-python](https://github.com/G-Core/gcore-python) |
+| Go SDK | `go get github.com/G-Core/gcore-go` — [github.com/G-Core/gcore-go](https://github.com/G-Core/gcore-go) |
+| Terraform Provider | `required_providers { gcore = { source = "G-Core/gcore" } }` — [registry.terraform.io](https://registry.terraform.io/providers/G-Core/gcore) |
 
-* **Production incidents:** check [status.gcore.com](https://status.gcore.com).
-* **Developer questions:** create a GitHub Discussion in the relevant SDK repo or email **support@gcore.com**.
-* **Feature requests / bugs:** check [Gcore Roadmap](https://roadmap.gcore.com/).
+## Support
 
-## Next steps
-
-1. [Create your first permanent token](/account-settings/api-tokens#create-a-permanent-api-token)
-2. Explore the existing SDKs and Terraform provider
-3. Jump straight to a [product reference](/api-reference/quick-access)
+For production incidents, check [status.gcore.com](https://status.gcore.com). Developer questions go to GitHub Discussions in the relevant SDK repo or to support@gcore.com. Feature requests and bugs are tracked on [Gcore Roadmap](https://roadmap.gcore.com/).


### PR DESCRIPTION
Fix style guide violations: remove forbidden headings (Why build, Next steps), remove bold on non-UI elements, remove 'you/your', remove 'such as', add intro sentences before lists and tables.

Also add organic inline link to reseller API endpoints in Authentication section, and apply editorial improvements: intro paragraph, use cases phrasing, split auth sentence, replace 'always contain' with 'include', rename SDKs section.