### PR TITLE
[Streaming] Document active ingest region fields

### DIFF
--- a/streaming/live-streaming/primary-backup.mdx
+++ b/streaming/live-streaming/primary-backup.mdx
@@ -172,6 +172,8 @@ Reach out to your account manager for setup assistance.
   ![Geo distributed ingest points for PUSH](/images/docs/streaming-platform/faq/live-streaming-issues/ingest-points.png)
 </Frame>
 
+To identify the ingest region of an active live stream, use the stream API. Call <code>GET&nbsp;/streaming/streams/{stream_id}</code> and read `active_ingest_region_primary` for the primary ingest and `active_ingest_region_backup` for the backup ingest; each field returns a region code, or `null` when that ingest is inactive.
+
 ### PUSH Ingest Limits
 
 Pay attention to rules of ingest server behavior because of security reason:


### PR DESCRIPTION
## What changed

Added a Streaming docs note explaining how to identify the ingest region of an active live stream through the stream API response fields.

Related: VP-6563

## Files changed

- `streaming/live-streaming/primary-backup.mdx` — Adds an API note for `active_ingest_region_primary` and `active_ingest_region_backup`.

## TODO before publishing

No TODOs. Ready for review.

- [ ] Writer review and approval
