### PR TITLE
DOC-1669: add WAAP Reseller API reference

### DIFF
--- a/api-reference/services_docs_mintlify/waap_reseller_api.yaml
+++ b/api-reference/services_docs_mintlify/waap_reseller_api.yaml
@@ -1,0 +1,597 @@
+openapi: 3.1.0
+info:
+  description: This OpenAPI is an aggregated OpenAPI specification that unifies all Gcore products into a single file. It covers Cloud, CDN, DNS, WAAP, DDoS Protection, Object Storage, Streaming, and FastEdge services.
+  title: Gcore OpenAPI – WAAP Reseller API
+  version: '2026-06-30T10:55:00Z'
+servers:
+- url: https://api.gcore.com
+paths:
+  /v1/prebilling/total/{metric}:
+    get:
+      tags:
+      - Pre-billing
+      summary: Get aggregated billable consumption by metric
+      description: Retrieve an aggregated report on billable consumption by given
+        metric
+      operationId: get_consumption_total_v1_prebilling_total__metric__get
+      security:
+      - Bearer: []
+      parameters:
+      - name: metric
+        in: path
+        required: true
+        schema:
+          enum:
+          - domains
+          - volume
+          - requests
+          type: string
+          description: The metric to get billable consumption for
+          title: Metric
+        description: The metric to get billable consumption for
+      - name: client_ids
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: array
+            items:
+              type: integer
+          - type: 'null'
+          description: List of client IDs to filter the billable consumption by, if
+            specified
+          examples:
+          - - 1
+            - 2
+            - 3
+          title: Client Ids
+        description: List of client IDs to filter the billable consumption by, if
+          specified
+      - name: from
+        in: query
+        required: true
+        schema:
+          type: string
+          format: date
+          description: The report start date (inclusive) in ISO 8601 format
+          title: From
+        description: The report start date (inclusive) in ISO 8601 format
+      - name: to
+        in: query
+        required: true
+        schema:
+          type: string
+          format: date
+          description: The report end date (exclusive) in ISO 8601 format
+          title: To
+        description: The report end date (exclusive) in ISO 8601 format
+      - name: limit
+        in: query
+        required: false
+        schema:
+          type: integer
+          maximum: 100
+          minimum: 0
+          description: Number of items to return
+          default: 100
+          title: Limit
+        description: Number of items to return
+      - name: offset
+        in: query
+        required: false
+        schema:
+          type: integer
+          maximum: 100000
+          minimum: 0
+          description: Number of items to skip
+          default: 0
+          title: Offset
+        description: Number of items to skip
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedResponse_BillingReportItem_'
+        '400':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+              example:
+                type: http-bad-request
+                title: Bad Request
+                status: 400
+                detail: 'Invalid domain name: '''''''''
+          description: Bad Request
+        '403':
+          description: Unauthenticated
+          content:
+            application/problem+json:
+              example:
+                detail: Permission denied
+        '404':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+              example:
+                type: http-not-found
+                title: Not Found
+                status: 404
+                detail: The resource is not found
+          description: Not Found
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/APICompositeError'
+              example:
+                type: request-validation-failed
+                title: Request validation error.
+                status: 422
+                detail: One or more fields have validation errors.
+                errors:
+                - loc:
+                  - body
+                  - name
+                  detail: Input should be a valid string
+                - loc:
+                  - body
+                  - date
+                  detail: Field required
+                - loc:
+                  - query
+                  - limit
+                  detail: Field required
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+              example:
+                type: internal-server-error
+                title: Internal server error.
+                status: 500
+                detail: An unexpected condition was encountered which prevented the
+                  server from fulfilling the request.
+          description: Internal Server Error
+        '401':
+          description: Unauthorized
+          content:
+            application/problem+json:
+              example:
+                detail: Auth token is missing or invalid
+  /v1/prebilling/breakdown/{metric}:
+    get:
+      tags:
+      - Pre-billing
+      summary: Get billable consumption by metric per account
+      description: Retrieve a report on billable consumption by given metric with
+        per-account breakdown
+      operationId: get_consumption_breakdown_v1_prebilling_breakdown__metric__get
+      security:
+      - Bearer: []
+      parameters:
+      - name: metric
+        in: path
+        required: true
+        schema:
+          enum:
+          - domains
+          - volume
+          - requests
+          type: string
+          description: The metric to get billable consumption for
+          title: Metric
+        description: The metric to get billable consumption for
+      - name: client_ids
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: array
+            items:
+              type: integer
+          - type: 'null'
+          description: List of client IDs to filter the billable consumption by, if
+            specified
+          examples:
+          - - 1
+            - 2
+            - 3
+          title: Client Ids
+        description: List of client IDs to filter the billable consumption by, if
+          specified
+      - name: from
+        in: query
+        required: true
+        schema:
+          type: string
+          format: date
+          description: The report start date (inclusive) in ISO 8601 format
+          title: From
+        description: The report start date (inclusive) in ISO 8601 format
+      - name: to
+        in: query
+        required: true
+        schema:
+          type: string
+          format: date
+          description: The report end date (exclusive) in ISO 8601 format
+          title: To
+        description: The report end date (exclusive) in ISO 8601 format
+      - name: limit
+        in: query
+        required: false
+        schema:
+          type: integer
+          maximum: 100
+          minimum: 0
+          description: Number of items to return
+          default: 100
+          title: Limit
+        description: Number of items to return
+      - name: offset
+        in: query
+        required: false
+        schema:
+          type: integer
+          maximum: 100000
+          minimum: 0
+          description: Number of items to skip
+          default: 0
+          title: Offset
+        description: Number of items to skip
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StructuredPaginatedResponse_BreakdownBillingReport_'
+        '400':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+              example:
+                type: http-bad-request
+                title: Bad Request
+                status: 400
+                detail: 'Invalid domain name: '''''''''
+          description: Bad Request
+        '403':
+          description: Unauthenticated
+          content:
+            application/problem+json:
+              example:
+                detail: Permission denied
+        '404':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+              example:
+                type: http-not-found
+                title: Not Found
+                status: 404
+                detail: The resource is not found
+          description: Not Found
+        '422':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/APICompositeError'
+              example:
+                type: request-validation-failed
+                title: Request validation error.
+                status: 422
+                detail: One or more fields have validation errors.
+                errors:
+                - loc:
+                  - body
+                  - name
+                  detail: Input should be a valid string
+                - loc:
+                  - body
+                  - date
+                  detail: Field required
+                - loc:
+                  - query
+                  - limit
+                  detail: Field required
+          description: Unprocessable Entity
+        '500':
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+              example:
+                type: internal-server-error
+                title: Internal server error.
+                status: 500
+                detail: An unexpected condition was encountered which prevented the
+                  server from fulfilling the request.
+          description: Internal Server Error
+        '401':
+          description: Unauthorized
+          content:
+            application/problem+json:
+              example:
+                detail: Auth token is missing or invalid
+  /ping:
+    get:
+      summary: Quick health check
+      description: 'This endpoint serves as a quick and simple service health check.
+
+        Upon sending a GET request to this endpoint, it assesses the availability
+        and responsiveness of the API service.
+
+
+        A successful request will receive a "pong" response, indicating that the connection
+        to the service is healthy and operational.
+
+        This can be particularly useful for monitoring tools or automated health checks
+        in service infrastructure.'
+      operationId: ping_ping_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PongMessage'
+        '400':
+          description: Bad Request
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+              example:
+                type: http-bad-request
+                title: Bad Request
+                status: 400
+                detail: 'Invalid domain name: '''''''''
+        '403':
+          description: Unauthenticated
+          content:
+            application/problem+json:
+              example:
+                detail: Permission denied
+        '404':
+          description: Not Found
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+              example:
+                type: http-not-found
+                title: Not Found
+                status: 404
+                detail: The resource is not found
+        '422':
+          description: Unprocessable Entity
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/APICompositeError'
+              example:
+                type: request-validation-failed
+                title: Request validation error.
+                status: 422
+                detail: One or more fields have validation errors.
+                errors:
+                - loc:
+                  - body
+                  - name
+                  detail: Input should be a valid string
+                - loc:
+                  - body
+                  - date
+                  detail: Field required
+                - loc:
+                  - query
+                  - limit
+                  detail: Field required
+        '500':
+          description: Internal Server Error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/APIError'
+              example:
+                type: internal-server-error
+                title: Internal server error.
+                status: 500
+                detail: An unexpected condition was encountered which prevented the
+                  server from fulfilling the request.
+        '401':
+          description: Unauthorized
+          content:
+            application/problem+json:
+              example:
+                detail: Auth token is missing or invalid
+      security:
+      - Bearer: []
+components:
+  schemas:
+    APICompositeError:
+      properties:
+        type:
+          type: string
+          title: Type
+          description: A URI identifier that categorizes the type of error.
+        title:
+          type: string
+          title: Title
+          description: A brief, human-readable title for the error.
+        status:
+          type: integer
+          title: Status
+          description: The HTTP status code applicable to this error.
+        detail:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Detail
+          description: A detailed human-readable explanation of the error.
+        errors:
+          items:
+            $ref: '#/components/schemas/APIFieldError'
+          type: array
+          title: Errors
+          description: A list of detailed errors for individual fields.
+      type: object
+      required:
+      - type
+      - title
+      - status
+      - detail
+      - errors
+      title: APICompositeError
+    APIError:
+      properties:
+        type:
+          type: string
+          title: Type
+          description: A URI identifier that categorizes the type of error.
+        title:
+          type: string
+          title: Title
+          description: A brief, human-readable title for the error.
+        status:
+          type: integer
+          title: Status
+          description: The HTTP status code applicable to this error.
+        detail:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Detail
+          description: A detailed human-readable explanation of the error.
+      type: object
+      required:
+      - type
+      - title
+      - status
+      - detail
+      title: APIError
+    APIFieldError:
+      properties:
+        loc:
+          anyOf:
+          - items:
+              anyOf:
+              - type: integer
+              - type: string
+            type: array
+          - {}
+          title: Loc
+          description: The location of the field or a character number causing the
+            error.
+        detail:
+          type: string
+          title: Detail
+          description: A human-readable message describing the error.
+      type: object
+      required:
+      - loc
+      - detail
+      title: APIFieldError
+    BillingReportItem:
+      properties:
+        date:
+          type: string
+          title: Date
+          description: The date of the accrued billable consumption item
+        amount:
+          type: integer
+          title: Amount
+          description: The amount of the billable resource accrued on the date
+      type: object
+      required:
+      - date
+      - amount
+      title: BillingReportItem
+    BreakdownBillingReport:
+      properties:
+        clients:
+          additionalProperties:
+            items:
+              $ref: '#/components/schemas/BillingReportItem'
+            type: array
+          type: object
+          title: Clients
+      type: object
+      required:
+      - clients
+      title: BreakdownBillingReport
+    PaginatedResponse_BillingReportItem_:
+      properties:
+        limit:
+          type: integer
+          title: Limit
+          description: Number of items requested in the response
+        offset:
+          type: integer
+          title: Offset
+          description: Items response offset used
+        count:
+          type: integer
+          title: Count
+          description: Number of items contain in the response
+        results:
+          items:
+            $ref: '#/components/schemas/BillingReportItem'
+          type: array
+          title: Results
+          description: List of items returned in the response following given criteria
+      type: object
+      required:
+      - limit
+      - offset
+      - count
+      - results
+      title: PaginatedResponse[BillingReportItem]
+    PongMessage:
+      properties:
+        message:
+          type: string
+          title: Message
+      type: object
+      required:
+      - message
+      title: PongMessage
+      examples:
+      - message: pong
+    StructuredPaginatedResponse_BreakdownBillingReport_:
+      properties:
+        limit:
+          type: integer
+          title: Limit
+          description: Number of items requested in the response
+        offset:
+          type: integer
+          title: Offset
+          description: Items response offset used
+        count:
+          type: integer
+          title: Count
+          description: Number of items contain in the response
+        results:
+          $ref: '#/components/schemas/BreakdownBillingReport'
+          description: Items on the current page from the result set
+      type: object
+      required:
+      - limit
+      - offset
+      - count
+      - results
+      title: StructuredPaginatedResponse[BreakdownBillingReport]
+  securitySchemes:
+    Bearer:
+      type: http
+      scheme: bearer

--- a/docs.json
+++ b/docs.json
@@ -1713,6 +1713,13 @@
                   "source": "api-reference/services_docs_mintlify/fastedge_reseller_api.yaml",
                   "directory": "api-reference/fastedge-resellers"
                 }
+              },
+              {
+                "group": "WAAP",
+                "openapi": {
+                  "source": "api-reference/services_docs_mintlify/waap_reseller_api.yaml",
+                  "directory": "api-reference/waap-resellers"
+                }
               }
             ]
           }


### PR DESCRIPTION
## Summary

Closes [DOC-1669](https://jira.gcore.lu/browse/DOC-1669).

Adds the WAAP Reseller API to the **Resellers** section of the API Reference, so reseller partners can discover and read it on docs.gcore.com alongside Billing, IAM, CDN, Cloud, and FastEdge.

## Changes

- `api-reference/services_docs_mintlify/waap_reseller_api.yaml` — the OpenAPI 3.1 specification (sourced from `https://api.gcore.com/waap/docs/reseller/openapi.yaml`, delivered under [WS-3504](https://jira.gcore.lu/browse/WS-3504)). `info.title`/`description` adjusted to match the existing reseller specs.
- `docs.json` — one new entry under `Resellers` group with `directory: api-reference/waap-resellers`, matching the naming convention used by the other reseller entries.

## Maintenance note

This spec is **not** wired into the api-schemas auto-sync pipeline yet, so it will not auto-refresh from upstream and will not get Stainless code-samples. That can be added as a follow-up by appending a `waap_reseller` entry to `G-Core/api-schemas` `scripts/config.yaml`.

## Related

- [WS-3504](https://jira.gcore.lu/browse/WS-3504) — publish OpenAPI specification at `/waap/docs/reseller/openapi.yaml` (shipped in prod via `gingerbread:v0.60.0`)
- [DOC-1669](https://jira.gcore.lu/browse/DOC-1669) — this ticket