### PR TITLE
docs(streaming spec): relativize links skipped due to description-bef…

### DIFF
--- a/api-reference/services_docs_mintlify/streaming_api.yaml
+++ b/api-reference/services_docs_mintlify/streaming_api.yaml
@@ -154,7 +154,7 @@ paths:
         **How to use?**
 
         - Explicit call to this AI method. Applicable for any file stored with us or located on the Internet.
-        - Standard video upload but with automatic subtitle generation. Look at ["VOD uploading"](/api-reference/streaming/videos/create-video).
+        - Standard video upload but with automatic subtitle generation. Look at ["VOD uploading"](../videos/create-video).
 
 
         **What language will the subtitles be in?**
@@ -241,7 +241,7 @@ paths:
 
         Create AI CM:nsfw task
 
-        This algorithm allows to quickly detect inappropriate content, determining that the content is NSFW ("Not Safe For Work") or normal. Generic info about all capabilities and limits see in the generic ["Content Moderation"](/api-reference/streaming/ai/create-ai-task) method.
+        This algorithm allows to quickly detect inappropriate content, determining that the content is NSFW ("Not Safe For Work") or normal. Generic info about all capabilities and limits see in the generic ["Content Moderation"](create-ai-task) method.
 
 
         **What is "Not Safe For Work"?**
@@ -294,7 +294,7 @@ paths:
 
         Create AI CM:`hard_nudity` task
 
-        This algorithm allows to detect explicit nudity of the human body (involving genitals) in a video. Generic info about all capabilities and limits see in the generic ["Content Moderation"](/api-reference/streaming/ai/create-ai-task) method.
+        This algorithm allows to detect explicit nudity of the human body (involving genitals) in a video. Generic info about all capabilities and limits see in the generic ["Content Moderation"](create-ai-task) method.
 
 
         **What is Hard nudity detection?**
@@ -372,7 +372,7 @@ paths:
 
         Create AI CM:`soft_nudity` task
 
-        This algorithm allows to identify explicit nudity and partial nudity too (including the presence of male and female faces and other uncovered body parts) in a video. Generic info about all capabilities and limits see in the generic ["Content Moderation"](/api-reference/streaming/ai/create-ai-task) method.
+        This algorithm allows to identify explicit nudity and partial nudity too (including the presence of male and female faces and other uncovered body parts) in a video. Generic info about all capabilities and limits see in the generic ["Content Moderation"](create-ai-task) method.
 
 
         **What is Soft nudity detection?**
@@ -462,7 +462,7 @@ paths:
 
         Create AI CM:sport task
 
-        This algorithm allows to identify various sporting activities in a video. Generic info about all capabilities and limits see in the generic ["Content Moderation"](/api-reference/streaming/ai/create-ai-task) method.
+        This algorithm allows to identify various sporting activities in a video. Generic info about all capabilities and limits see in the generic ["Content Moderation"](create-ai-task) method.
 
 
         **What is Sports activity detection?**


### PR DESCRIPTION
…ore-tags order

The Create AI-task operation puts its description (with cross-links) before its tags block, so the earlier relativization pass saw no tag and left 5 links root-relative. Convert them to page-relative paths consistent with the rest of the operation-description links.