### PR TITLE
DOC-1669: add WAAP reseller link to API overview table

### DIFF
--- a/api-reference/overview.mdx
+++ b/api-reference/overview.mdx
@@ -29,7 +29,7 @@ Each Gcore product has its own path prefix on the shared base `https://api.gcore
 | FastEdge (Edge Functions) | `https://api.gcore.com/fastedge` | [FastEdge reseller](/api-reference/fastedge-resellers) |
 | Video Streaming | `https://api.gcore.com/streaming` | — |
 | DDoS | `https://api.gcore.com/security/iaas` | — |
-| WAAP | `https://api.gcore.com/waap` | — |
+| WAAP | `https://api.gcore.com/waap` | [WAAP reseller](/api-reference/waap-resellers) |
 | Billing | — | [Billing reseller](/api-reference/billing) |
 
 ## Authentication


### PR DESCRIPTION
## Summary

- Added WAAP reseller API link to the "Base URLs by product" table in `api-reference/overview.mdx`
- WAAP reseller docs are available at `/api-reference/waap-resellers` (yaml already registered in docs.json)

## Test plan

- [ ] Verify the link renders correctly on the docs site
- [ ] Confirm `/api-reference/waap-resellers` resolves