### PR TITLE
Update manage-cdn-via-terraform-v2.mdx

### DIFF
--- a/cdn/terraform/manage-cdn-via-terraform-v2.mdx
+++ b/cdn/terraform/manage-cdn-via-terraform-v2.mdx
@@ -260,7 +260,6 @@ The following table lists commonly used options. The full list is in the [Terraf
 | `static_request_headers` | Add headers to origin requests. Set `value` to a map. |
 | `static_response_headers` | Add headers to CDN responses. Set `value` to a list of objects. |
 | `response_headers_hiding_policy` | Hide response headers from clients. |
-| `request_limiter` | Rate limiting. Set `rate` and `rate_unit`. |
 | `limit_bandwidth` | Bandwidth throttling. Set `limit_type`, `speed`, and `buffer`. |
 | `follow_origin_redirect` | Follow redirects from the origin. Set `codes` to a list of redirect codes. |
 | `websockets` | Enable WebSocket pass-through. Set `value = true`. |


### PR DESCRIPTION
Removed "request_limiter {}Rate limiting. Set rate and rate_unit." which does not apply anymore.