### PR TITLE
DOC-1754: Update allocate-an-ipv6-address-in-vmmanager-6

### DIFF
--- a/.agents/tools/style_check.py
+++ b/.agents/tools/style_check.py
@@ -375,7 +375,7 @@ def check_frontmatter(raw_lines: list[str]) -> list[Violation]:
         "receive", "assign", "attach", "detach", "scale", "resize", "start", "stop",
         "restart", "reinstall", "resolve", "troubleshoot", "convert", "import", "export",
         "protect", "apply", "validate", "audit", "review", "check", "change", "edit",
-        "move", "copy", "share", "publish", "back",
+        "move", "copy", "share", "publish", "back", "allocate",
     }
     in_fm = False
     for i, raw in enumerate(raw_lines, start=1):

--- a/hosting/llms.txt
+++ b/hosting/llms.txt
@@ -79,7 +79,7 @@
 - [Install an OS from an ISO image in VMmanager 6](https://docs.gcore.com/hosting/virtual-servers/manage/operating-system/install-an-os-from-iso-in-vmmanager-6.md): Mount an ISO image to a virtual server in VMmanager 6 to install a custom OS - provide an HTTP, HTTPS, or FTP URL up to 8 GB and complete installation via VNC.
 
 ## Networking
-- [Allocate an IPv6 address in VMmanager 6](https://docs.gcore.com/hosting/virtual-servers/manage/networking/allocate-an-ipv6-address-in-vmmanager-6.md): Allocate IPv6 subnets and addresses to Virtual Servers in VMmanager 6, with automatic assignment of the first subnet IP to the VM interface and manual OS-level configuration options.
+- [Allocate an IPv6 address in VMmanager 6](https://docs.gcore.com/hosting/virtual-servers/manage/networking/allocate-an-ipv6-address-in-vmmanager-6.md): Allocate IPv6 addresses to virtual servers in VMmanager 6 - view assigned addresses in the Virtual machines tab and configure additional IPs via OS settings.
 
 ## Additional IP addresses
 - [Buy an additional IP address](https://docs.gcore.com/hosting/dedicated-servers/manage/networking/additional-ip-addresses/buy-an-additional-ip-address.md): Purchase additional IPv4 and IPv6 addresses for Dedicated Servers and Virtual Private Servers via Control Panel, with limits of 14 IPv4 and 14 IPv6 addresses per server (2 IPv4 and 2 IPv6 for KVM-SSD-1 instances), and move additional IPs between servers through support.

--- a/hosting/virtual-servers/manage/networking/allocate-an-ipv6-address-in-vmmanager-6.mdx
+++ b/hosting/virtual-servers/manage/networking/allocate-an-ipv6-address-in-vmmanager-6.mdx
@@ -1,18 +1,15 @@
 ---
 title: Allocate an IPv6 address in VMmanager 6
 sidebarTitle: IPv6 in VMmanager 6
-ai-navigation: Allocate IPv6 subnets and addresses to Virtual Servers in VMmanager 6, with automatic assignment of the first subnet IP to the VM interface and manual OS-level configuration options.
+ai-navigation: Allocate IPv6 addresses to virtual servers in VMmanager 6 - view assigned addresses in the Virtual machines tab and configure additional IPs via OS settings.
 ---
 
-After activation, every Virtual Server is allocated a separate IPv6 subnet, and the first IP address of the subnet is automatically assigned to its interface.
+IPv6 must be enabled for the account before use. Contact [support](/hosting/contact-our-technical-support) to request activation.
 
-To find the IP address, go to the **Virtual machines** tab and expand the **all 2** menu in the **IP address** column.
+After activation, every virtual server receives a dedicated IPv6 subnet. The first IP address of the subnet is automatically assigned to the server's network interface.
 
+To find the assigned IPv6 address, navigate to the **Virtual machines** tab in VMmanager 6 and expand the **all 2** menu in the **IP address** column.
 
-<Frame>![Allocate an IPv6 address in VMmanager 6](/images/docs/hosting/virtual-servers/manage/networking/allocate-an-ipv6-address-in-vmmanager-6/1-ipv6-address-in-the-vmmanager-menu.jpg)</Frame>
+<Frame>![VMmanager 6 Virtual machines list with the IP address dropdown open, showing an IPv6 and IPv4 address assigned to eth0](/images/docs/hosting/virtual-servers/manage/networking/allocate-an-ipv6-address-in-vmmanager-6/1-ipv6-address-in-the-vmmanager-menu.jpg)</Frame>
 
-
-
-If you want to change the IPv6 address, you can do so manually in the OS settings.
-
-For more details, contact [our support team](/hosting/contact-our-technical-support).
+To use a different IPv6 address from the subnet, configure it manually in the OS network settings.

--- a/hosting/virtual-servers/manage/networking/allocate-an-ipv6-address-in-vmmanager-6.mdx
+++ b/hosting/virtual-servers/manage/networking/allocate-an-ipv6-address-in-vmmanager-6.mdx
@@ -4,12 +4,18 @@ sidebarTitle: IPv6 in VMmanager 6
 ai-navigation: Allocate IPv6 addresses to virtual servers in VMmanager 6 - view assigned addresses in the Virtual machines tab and configure additional IPs via OS settings.
 ---
 
-IPv6 must be enabled for the account before use. Contact [support](/hosting/contact-our-technical-support) to request activation.
+IPv6 is available on request. Contact [support](/hosting/contact-our-technical-support) to enable it for the account.
 
-After activation, every virtual server receives a dedicated IPv6 subnet. The first IP address of the subnet is automatically assigned to the server's network interface.
+<Steps>
+  <Step title="Enable IPv6">
+    Contact [support](/hosting/contact-our-technical-support) to enable IPv6 for the account. After IPv6 is enabled, every virtual server receives a dedicated IPv6 subnet. The first address from this subnet is assigned automatically to the server's primary network interface.
+  </Step>
+  <Step title="View the assigned address">
+    Navigate to the **Virtual machines** tab in VMmanager 6 and expand the **all 2** menu in the **IP address** column.
 
-To find the assigned IPv6 address, navigate to the **Virtual machines** tab in VMmanager 6 and expand the **all 2** menu in the **IP address** column.
-
-<Frame>![VMmanager 6 Virtual machines list with the IP address dropdown open, showing an IPv6 and IPv4 address assigned to eth0](/images/docs/hosting/virtual-servers/manage/networking/allocate-an-ipv6-address-in-vmmanager-6/1-ipv6-address-in-the-vmmanager-menu.jpg)</Frame>
-
-To use a different IPv6 address from the subnet, configure it manually in the OS network settings.
+    <Frame>![VMmanager 6 Virtual machines list with the IP address dropdown open, showing an IPv6 and IPv4 address assigned to eth0](/images/docs/hosting/virtual-servers/manage/networking/allocate-an-ipv6-address-in-vmmanager-6/1-ipv6-address-in-the-vmmanager-menu.jpg)</Frame>
+  </Step>
+  <Step title="Configure additional addresses">
+    To use additional IPv6 addresses from the assigned subnet, configure them manually in the operating system.
+  </Step>
+</Steps>

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -660,7 +660,7 @@
 - [Install an OS from an ISO image in VMmanager 6](https://docs.gcore.com/hosting/virtual-servers/manage/operating-system/install-an-os-from-iso-in-vmmanager-6.md): Mount an ISO image to a virtual server in VMmanager 6 to install a custom OS - provide an HTTP, HTTPS, or FTP URL up to 8 GB and complete installation via VNC.
 
 ## Networking
-- [Allocate an IPv6 address in VMmanager 6](https://docs.gcore.com/hosting/virtual-servers/manage/networking/allocate-an-ipv6-address-in-vmmanager-6.md): Allocate IPv6 subnets and addresses to Virtual Servers in VMmanager 6, with automatic assignment of the first subnet IP to the VM interface and manual OS-level configuration options.
+- [Allocate an IPv6 address in VMmanager 6](https://docs.gcore.com/hosting/virtual-servers/manage/networking/allocate-an-ipv6-address-in-vmmanager-6.md): Allocate IPv6 addresses to virtual servers in VMmanager 6 - view assigned addresses in the Virtual machines tab and configure additional IPs via OS settings.
 
 ## Additional IP addresses
 - [Buy an additional IP address](https://docs.gcore.com/hosting/dedicated-servers/manage/networking/additional-ip-addresses/buy-an-additional-ip-address.md): Purchase additional IPv4 and IPv6 addresses for Dedicated Servers and Virtual Private Servers via Control Panel, with limits of 14 IPv4 and 14 IPv6 addresses per server (2 IPv4 and 2 IPv6 for KVM-SSD-1 instances), and move additional IPs between servers through support.


### PR DESCRIPTION
- Add activation prerequisite (contact support to enable IPv6)
- Fix 'go to' -> 'navigate to'
- Remove 'you/your' violations
- Shorten ai-navigation to 159 chars (was 182)
- Fix link text 'our support team' (3 words) -> 'support' (1 word)
- Rewrite 'For more details...' sentence to eliminate banned lead-in
- Improve alt text: describe screenshot content instead of repeating title
- style_check.py: add 'allocate' to action_verbs (false positive fix)