### PR TITLE
Add Terraform tabs to GPU Managed Kubernetes articles 

### DIFF
--- a/edge-ai/ai-infrastructure/create-a-bare-metal-gpu-cluster.mdx
+++ b/edge-ai/ai-infrastructure/create-a-bare-metal-gpu-cluster.mdx
@@ -283,7 +283,6 @@ export GCORE_SSH_KEY_NAME="{YOUR_SSH_KEY_NAME}"
 
         client := gcore.NewClient()
         ctx := context.Background()
-        ctx := ctx
 
         // Step 1. List flavors — select the one with fewest GPUs
         flavorList, err := client.Cloud.GPUBaremetal.Clusters.Flavors.List(ctx,

--- a/edge-ai/ai-infrastructure/create-a-virtual-gpu-cluster.mdx
+++ b/edge-ai/ai-infrastructure/create-a-virtual-gpu-cluster.mdx
@@ -282,7 +282,6 @@ export GCORE_SSH_KEY_NAME="{YOUR_SSH_KEY_NAME}"
 
         client := gcore.NewClient()
         ctx := context.Background()
-        ctx := ctx
 
         // Step 1. List flavors — select the one with fewest GPUs
         flavorList, err := client.Cloud.GPUVirtual.Clusters.Flavors.List(ctx,

--- a/edge-ai/ai-infrastructure/spot-bare-metal-gpu.mdx
+++ b/edge-ai/ai-infrastructure/spot-bare-metal-gpu.mdx
@@ -281,7 +281,6 @@ If `capacity` is `0` when the request is submitted, the API returns HTTP 409: `"
 
         client := gcore.NewClient()
         ctx := context.Background()
-        ctx := ctx
 
         // Find an available Spot flavor
         flavorList, err := client.Cloud.GPUBaremetal.Clusters.Flavors.List(ctx,

--- a/edge-ai/llms.txt
+++ b/edge-ai/llms.txt
@@ -19,14 +19,14 @@
 - [Create a GPU Kubernetes cluster](https://docs.gcore.com/edge-ai/managed-kubernetes/create-a-gpu-kubernetes-cluster.md): Create GPU Kubernetes clusters with Bare Metal GPU pools via Customer Portal, REST API, or Terraform - configure version, pools, network, and download kubeconfig.
 
 ## Manage a cluster
-- [Connect to a GPU Kubernetes cluster](https://docs.gcore.com/edge-ai/managed-kubernetes/connect-to-a-gpu-kubernetes-cluster.md): Connect to a Gcore GPU Kubernetes cluster via Customer Portal or REST API - download kubeconfig, configure kubectl, and list or inspect clusters.
-- [Manage node pools](https://docs.gcore.com/edge-ai/managed-kubernetes/manage-node-pools.md): Manage GPU Kubernetes node pools via Customer Portal or REST API - view, scale, add, replace nodes, and delete pools.
-- [Configure cluster autoscaling](https://docs.gcore.com/edge-ai/managed-kubernetes/configure-cluster-autoscaling.md): Configure the Cluster Autoscaler for a Gcore GPU Kubernetes cluster via the Customer Portal or via REST API.
-- [Configure cluster logging](https://docs.gcore.com/edge-ai/managed-kubernetes/configure-cluster-logging.md): Configure container and system log collection for a Gcore GPU Kubernetes cluster via the Customer Portal or via REST API.
-- [Configure OIDC authentication](https://docs.gcore.com/edge-ai/managed-kubernetes/configure-oidc-authentication.md): Configure OIDC Single Sign-On for Kubernetes API access in a Gcore GPU Kubernetes cluster via the Customer Portal or via REST API.
-- [Upgrade a GPU Kubernetes cluster](https://docs.gcore.com/edge-ai/managed-kubernetes/upgrade-a-gpu-kubernetes-cluster.md): Upgrade a Gcore GPU Kubernetes cluster to the next minor version via Customer Portal or REST API.
+- [Connect to a GPU Kubernetes cluster](https://docs.gcore.com/edge-ai/managed-kubernetes/connect-to-a-gpu-kubernetes-cluster.md): Connect to a Gcore GPU Kubernetes cluster via Customer Portal, REST API, or Terraform - download kubeconfig, configure kubectl, and list or inspect clusters.
+- [Manage node pools](https://docs.gcore.com/edge-ai/managed-kubernetes/manage-node-pools.md): Manage GPU Kubernetes node pools via Customer Portal, REST API, or Terraform - view, scale, add, replace nodes, and delete pools.
+- [Configure cluster autoscaling](https://docs.gcore.com/edge-ai/managed-kubernetes/configure-cluster-autoscaling.md): Configure the Cluster Autoscaler for a Gcore GPU Kubernetes cluster via the Customer Portal, REST API, or Terraform.
+- [Configure cluster logging](https://docs.gcore.com/edge-ai/managed-kubernetes/configure-cluster-logging.md): Configure container and system log collection for a Gcore GPU Kubernetes cluster via the Customer Portal, REST API, or Terraform.
+- [Configure OIDC authentication](https://docs.gcore.com/edge-ai/managed-kubernetes/configure-oidc-authentication.md): Configure OIDC Single Sign-On for Kubernetes API access in a Gcore GPU Kubernetes cluster via the Customer Portal, REST API, or Terraform.
+- [Upgrade a GPU Kubernetes cluster](https://docs.gcore.com/edge-ai/managed-kubernetes/upgrade-a-gpu-kubernetes-cluster.md): Update a Gcore GPU Kubernetes cluster to the next minor version via Customer Portal, REST API, or Terraform.
 - [View cluster audit log](https://docs.gcore.com/edge-ai/managed-kubernetes/view-cluster-audit-log.md): View the audit log of GPU Kubernetes cluster operations via the Gcore Customer Portal.
-- [Delete a GPU Kubernetes cluster](https://docs.gcore.com/edge-ai/managed-kubernetes/delete-a-gpu-kubernetes-cluster.md): Delete a Gcore GPU Kubernetes cluster via Customer Portal or REST API.
+- [Delete a GPU Kubernetes cluster](https://docs.gcore.com/edge-ai/managed-kubernetes/delete-a-gpu-kubernetes-cluster.md): Delete a Gcore GPU Kubernetes cluster via Customer Portal, REST API, or Terraform.
 
 ## Everywhere Inference
 - [Overview](https://docs.gcore.com/edge-ai/everywhere-inference.md): Deploy trained AI models on Gcore Everywhere Inference edge nodes using anycast endpoints and smart routing to achieve low-latency inference across global regions with automatic failover.

--- a/edge-ai/managed-kubernetes/configure-cluster-autoscaling.mdx
+++ b/edge-ai/managed-kubernetes/configure-cluster-autoscaling.mdx
@@ -208,10 +208,6 @@ curl -X PATCH "https://api.gcore.com/cloud/v2/k8s/clusters/$GCORE_CLOUD_PROJECT_
 An [API&nbsp;token](/account-settings/api-tokens), a [project&nbsp;ID](/api-reference/cloud/projects/list-projects), and a [region&nbsp;ID](/api-reference/cloud/regions/list-regions) are required. Import an existing cluster with `terraform import` before modifying its autoscaler configuration.
 </Info>
 
-<Warning>
-Provider v2.0.0-alpha.12 throws a "Provider produced inconsistent result after apply" error after every cluster update due to a known bug with `security_group_ids`. The API operation succeeds — verify with the Portal or API, then re-run `terraform import` to sync the state file.
-</Warning>
-
 ## Configure autoscaling
 
 <p>Add the `autoscaler_config` map to the cluster resource block and run `terraform apply`. Omitted parameters keep their current values.</p>

--- a/edge-ai/managed-kubernetes/configure-cluster-autoscaling.mdx
+++ b/edge-ai/managed-kubernetes/configure-cluster-autoscaling.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configure cluster autoscaling
 sidebarTitle: Autoscaling
-ai-navigation: Configure the Cluster Autoscaler for a Gcore GPU Kubernetes cluster via the Customer Portal or via REST API.
+ai-navigation: Configure the Cluster Autoscaler for a Gcore GPU Kubernetes cluster via the Customer Portal, REST API, or Terraform.
 ---
 
 import { MethodSwitch, MethodSection } from "/snippets/method-switch.jsx";
@@ -137,7 +137,6 @@ export CLUSTER_NAME="{YOUR_CLUSTER_NAME}"
 
         client := gcore.NewClient()
         ctx := context.Background()
-        ctx := ctx
 
         result, err := client.Cloud.K8S.Clusters.Update(ctx, clusterName, cloud.K8SClusterUpdateParams{
             ProjectID: gcore.Int(projectID),
@@ -201,4 +200,83 @@ curl -X PATCH "https://api.gcore.com/cloud/v2/k8s/clusters/$GCORE_CLOUD_PROJECT_
 ```
 
   </MethodSection>
+  <MethodSection id="terraform" label="Terraform">
+
+<p>Configure the Cluster Autoscaler for an existing GPU Kubernetes cluster using the [`gcore_cloud_k8s_cluster`](https://registry.terraform.io/providers/G-Core/gcore/latest/docs/resources/cloud_k8s_cluster) resource from the [Terraform&nbsp;provider](/developer-tools/terraform/overview) v2. The `autoscaler_config` attribute is a flat string map — all values, including numbers and booleans, must be quoted.</p>
+
+<Info>
+An [API&nbsp;token](/account-settings/api-tokens), a [project&nbsp;ID](/api-reference/cloud/projects/list-projects), and a [region&nbsp;ID](/api-reference/cloud/regions/list-regions) are required. Import an existing cluster with `terraform import` before modifying its autoscaler configuration.
+</Info>
+
+<Warning>
+Provider v2.0.0-alpha.12 throws a "Provider produced inconsistent result after apply" error after every cluster update due to a known bug with `security_group_ids`. The API operation succeeds — verify with the Portal or API, then re-run `terraform import` to sync the state file.
+</Warning>
+
+## Configure autoscaling
+
+<p>Add the `autoscaler_config` map to the cluster resource block and run `terraform apply`. Omitted parameters keep their current values.</p>
+
+```hcl
+resource "gcore_cloud_k8s_cluster" "example" {
+  project_id    = var.project_id
+  region_id     = var.region_id
+  name          = "my-gpu-k8s"
+  version       = "v1.35.3"
+  keypair       = "my-ssh-key"
+  fixed_network = var.network_id
+  fixed_subnet  = var.subnet_id
+
+  autoscaler_config = {
+    "scan-interval"                    = "20s"
+    "scale-down-unneeded-time"         = "10m"
+    "scale-down-utilization-threshold" = "0.5"
+    "expander"                         = "least-waste"
+  }
+
+  pools = [
+    {
+      name                 = "gpu-pool"
+      flavor_id            = "bm3-ai-1xlarge-a100-80-8"
+      min_node_count       = 1
+      max_node_count       = 3
+      auto_healing_enabled = true
+    }
+  ]
+}
+```
+
+```bash
+terraform import gcore_cloud_k8s_cluster.example '<project_id>/<region_id>/<cluster_name>'
+terraform apply
+```
+
+## Reset to defaults
+
+<p>Set `autoscaler_config` to an empty map — the API restores all parameters to Gcore defaults on the next `terraform apply`.</p>
+
+```hcl
+resource "gcore_cloud_k8s_cluster" "example" {
+  project_id    = var.project_id
+  region_id     = var.region_id
+  name          = "my-gpu-k8s"
+  version       = "v1.35.3"
+  keypair       = "my-ssh-key"
+  fixed_network = var.network_id
+  fixed_subnet  = var.subnet_id
+
+  autoscaler_config = {}
+
+  pools = [
+    {
+      name                 = "gpu-pool"
+      flavor_id            = "bm3-ai-1xlarge-a100-80-8"
+      min_node_count       = 1
+      max_node_count       = 3
+      auto_healing_enabled = true
+    }
+  ]
+}
+```
+
+</MethodSection>
 </MethodSwitch>

--- a/edge-ai/managed-kubernetes/configure-cluster-logging.mdx
+++ b/edge-ai/managed-kubernetes/configure-cluster-logging.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configure cluster logging
 sidebarTitle: Logging
-ai-navigation: Configure container and system log collection for a Gcore GPU Kubernetes cluster via the Customer Portal or via REST API.
+ai-navigation: Configure container and system log collection for a Gcore GPU Kubernetes cluster via the Customer Portal, REST API, or Terraform.
 ---
 
 import { MethodSwitch, MethodSection } from "/snippets/method-switch.jsx";
@@ -139,7 +139,6 @@ curl "https://api.gcore.com/cloud/v1/laas/$GCORE_CLOUD_REGION_ID/destination_reg
 
         client := gcore.NewClient()
         ctx := context.Background()
-        ctx := ctx
 
         result, err := client.Cloud.K8S.Clusters.Update(ctx, clusterName, cloud.K8SClusterUpdateParams{
             ProjectID: gcore.Int(projectID),
@@ -246,7 +245,6 @@ curl "https://api.gcore.com/cloud/v1/laas/$GCORE_CLOUD_REGION_ID/destination_reg
 
         client := gcore.NewClient()
         ctx := context.Background()
-        ctx := ctx
 
         result, err := client.Cloud.K8S.Clusters.Update(ctx, clusterName, cloud.K8SClusterUpdateParams{
             ProjectID: gcore.Int(projectID),
@@ -291,4 +289,83 @@ curl "https://api.gcore.com/cloud/v1/laas/$GCORE_CLOUD_REGION_ID/destination_reg
 <p>The API returns a task ID. Poll <code>GET&nbsp;/cloud/v1/tasks/{task_id}</code> every five seconds until `state` is `FINISHED`.</p>
 
   </MethodSection>
+  <MethodSection id="terraform" label="Terraform">
+
+<p>Configure log forwarding for an existing GPU Kubernetes cluster using the [`gcore_cloud_k8s_cluster`](https://registry.terraform.io/providers/G-Core/gcore/latest/docs/resources/cloud_k8s_cluster) resource from the [Terraform&nbsp;provider](/developer-tools/terraform/overview) v2. The `logging` attribute is a nested block — import the cluster before making changes.</p>
+
+<Info>
+An [API&nbsp;token](/account-settings/api-tokens), a [project&nbsp;ID](/api-reference/cloud/projects/list-projects), and a [region&nbsp;ID](/api-reference/cloud/regions/list-regions) are required. To find valid `destination_region_id` values, query <code>GET&nbsp;/cloud/v1/laas/{region_id}/destination_regions</code>.
+</Info>
+
+## Enable logging
+
+<p>Add the `logging` block with `enabled = true`, a destination region, and a topic name. Run `terraform import` first if the cluster is not yet under Terraform management.</p>
+
+```hcl
+resource "gcore_cloud_k8s_cluster" "example" {
+  project_id    = var.project_id
+  region_id     = var.region_id
+  name          = "my-gpu-k8s"
+  version       = "v1.35.3"
+  keypair       = "my-ssh-key"
+  fixed_network = var.network_id
+  fixed_subnet  = var.subnet_id
+
+  logging = {
+    enabled               = true
+    destination_region_id = 76  # from GET /cloud/v1/laas/{region_id}/destination_regions
+    topic_name            = "my-cluster-logs"
+    retention_policy = {
+      period = 30
+    }
+  }
+
+  pools = [
+    {
+      name                 = "gpu-pool"
+      flavor_id            = "bm3-ai-1xlarge-a100-80-8"
+      min_node_count       = 1
+      max_node_count       = 3
+      auto_healing_enabled = true
+    }
+  ]
+}
+```
+
+```bash
+terraform import gcore_cloud_k8s_cluster.example '<project_id>/<region_id>/<cluster_name>'
+terraform apply
+```
+
+## Disable logging
+
+<p>Set `enabled = false` to stop log forwarding. The log topic and its data in OpenSearch Dashboards are preserved.</p>
+
+```hcl
+resource "gcore_cloud_k8s_cluster" "example" {
+  project_id    = var.project_id
+  region_id     = var.region_id
+  name          = "my-gpu-k8s"
+  version       = "v1.35.3"
+  keypair       = "my-ssh-key"
+  fixed_network = var.network_id
+  fixed_subnet  = var.subnet_id
+
+  logging = {
+    enabled = false
+  }
+
+  pools = [
+    {
+      name                 = "gpu-pool"
+      flavor_id            = "bm3-ai-1xlarge-a100-80-8"
+      min_node_count       = 1
+      max_node_count       = 3
+      auto_healing_enabled = true
+    }
+  ]
+}
+```
+
+</MethodSection>
 </MethodSwitch>

--- a/edge-ai/managed-kubernetes/configure-oidc-authentication.mdx
+++ b/edge-ai/managed-kubernetes/configure-oidc-authentication.mdx
@@ -300,10 +300,6 @@ export CLUSTER_NAME="{YOUR_CLUSTER_NAME}"
 An [API&nbsp;token](/account-settings/api-tokens), a [project&nbsp;ID](/api-reference/cloud/projects/list-projects), and a [region&nbsp;ID](/api-reference/cloud/regions/list-regions) are required. Import an existing cluster with `terraform import` before making changes.
 </Info>
 
-<Warning>
-Provider v2.0.0-alpha.12 throws a "Provider produced inconsistent result after apply" error after every cluster update due to a known bug with `security_group_ids`. The API operation succeeds — verify with the Portal or API, then re-run `terraform import` to sync the state file.
-</Warning>
-
 ## Configure OIDC
 
 <p>Add the `authentication` block with the identity provider settings and run `terraform apply`. Only `issuer_url` and `client_id` are required — all other fields are optional.</p>

--- a/edge-ai/managed-kubernetes/configure-oidc-authentication.mdx
+++ b/edge-ai/managed-kubernetes/configure-oidc-authentication.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configure OIDC authentication
 sidebarTitle: OIDC authentication
-ai-navigation: Configure OIDC Single Sign-On for Kubernetes API access in a Gcore GPU Kubernetes cluster via the Customer Portal or via REST API.
+ai-navigation: Configure OIDC Single Sign-On for Kubernetes API access in a Gcore GPU Kubernetes cluster via the Customer Portal, REST API, or Terraform.
 ---
 
 import { MethodSwitch, MethodSection } from "/snippets/method-switch.jsx";
@@ -128,7 +128,6 @@ export CLUSTER_NAME="{YOUR_CLUSTER_NAME}"
 
         client := gcore.NewClient()
         ctx := context.Background()
-        ctx := ctx
 
         result, err := client.Cloud.K8S.Clusters.Update(ctx, clusterName, cloud.K8SClusterUpdateParams{
             ProjectID: gcore.Int(projectID),
@@ -293,4 +292,91 @@ export CLUSTER_NAME="{YOUR_CLUSTER_NAME}"
 <p>The API returns a task ID. Poll <code>GET&nbsp;/cloud/v1/tasks/{task_id}</code> every five seconds until `state` is `FINISHED`.</p>
 
   </MethodSection>
+  <MethodSection id="terraform" label="Terraform">
+
+<p>Configure OIDC authentication for an existing GPU Kubernetes cluster using the [`gcore_cloud_k8s_cluster`](https://registry.terraform.io/providers/G-Core/gcore/latest/docs/resources/cloud_k8s_cluster) resource from the [Terraform&nbsp;provider](/developer-tools/terraform/overview) v2. The `authentication.oidc` block maps directly to the identity provider settings.</p>
+
+<Info>
+An [API&nbsp;token](/account-settings/api-tokens), a [project&nbsp;ID](/api-reference/cloud/projects/list-projects), and a [region&nbsp;ID](/api-reference/cloud/regions/list-regions) are required. Import an existing cluster with `terraform import` before making changes.
+</Info>
+
+<Warning>
+Provider v2.0.0-alpha.12 throws a "Provider produced inconsistent result after apply" error after every cluster update due to a known bug with `security_group_ids`. The API operation succeeds — verify with the Portal or API, then re-run `terraform import` to sync the state file.
+</Warning>
+
+## Configure OIDC
+
+<p>Add the `authentication` block with the identity provider settings and run `terraform apply`. Only `issuer_url` and `client_id` are required — all other fields are optional.</p>
+
+```hcl
+resource "gcore_cloud_k8s_cluster" "example" {
+  project_id    = var.project_id
+  region_id     = var.region_id
+  name          = "my-gpu-k8s"
+  version       = "v1.35.3"
+  keypair       = "my-ssh-key"
+  fixed_network = var.network_id
+  fixed_subnet  = var.subnet_id
+
+  authentication = {
+    oidc = {
+      issuer_url      = "https://accounts.provider.example"
+      client_id       = "kubernetes"
+      username_claim  = "sub"
+      username_prefix = "oidc:"
+      groups_claim    = "groups"
+      groups_prefix   = "oidc:"
+    }
+  }
+
+  pools = [
+    {
+      name                 = "gpu-pool"
+      flavor_id            = "bm3-ai-1xlarge-a100-80-8"
+      min_node_count       = 1
+      max_node_count       = 3
+      auto_healing_enabled = true
+    }
+  ]
+}
+```
+
+```bash
+terraform import gcore_cloud_k8s_cluster.example '<project_id>/<region_id>/<cluster_name>'
+terraform apply
+```
+
+## Remove OIDC
+
+<p>Remove the `authentication` block — Terraform detects the absence and sends `oidc: null` to the API on the next `terraform apply`, returning the cluster to kubeconfig-based authentication.</p>
+
+```hcl
+resource "gcore_cloud_k8s_cluster" "example" {
+  project_id    = var.project_id
+  region_id     = var.region_id
+  name          = "my-gpu-k8s"
+  version       = "v1.35.3"
+  keypair       = "my-ssh-key"
+  fixed_network = var.network_id
+  fixed_subnet  = var.subnet_id
+
+  # authentication block removed — clears OIDC configuration
+
+  pools = [
+    {
+      name                 = "gpu-pool"
+      flavor_id            = "bm3-ai-1xlarge-a100-80-8"
+      min_node_count       = 1
+      max_node_count       = 3
+      auto_healing_enabled = true
+    }
+  ]
+}
+```
+
+```bash
+terraform apply
+```
+
+</MethodSection>
 </MethodSwitch>

--- a/edge-ai/managed-kubernetes/connect-to-a-gpu-kubernetes-cluster.mdx
+++ b/edge-ai/managed-kubernetes/connect-to-a-gpu-kubernetes-cluster.mdx
@@ -1,7 +1,7 @@
 ---
 title: Connect to a GPU Kubernetes cluster
 sidebarTitle: Connect to a cluster
-ai-navigation: Connect to a Gcore GPU Kubernetes cluster via Customer Portal or REST API - download kubeconfig, configure kubectl, and list or inspect clusters.
+ai-navigation: Connect to a Gcore GPU Kubernetes cluster via Customer Portal, REST API, or Terraform - download kubeconfig, configure kubectl, and list or inspect clusters.
 ---
 
 import { MethodSwitch, MethodSection } from "/snippets/method-switch.jsx";
@@ -138,6 +138,7 @@ export GCORE_CLUSTER_NAME="{YOUR_CLUSTER_NAME}"
     	regionID, _ := strconv.ParseInt(os.Getenv("GCORE_CLOUD_REGION_ID"), 10, 64)
 
     	client := gcore.NewClient()
+    	ctx := context.Background()
 
     	clusters, err := client.Cloud.K8S.Clusters.List(ctx, cloud.K8SClusterListParams{
     		ProjectID: gcore.Int(projectID),
@@ -214,6 +215,7 @@ export GCORE_CLUSTER_NAME="{YOUR_CLUSTER_NAME}"
     	regionID, _ := strconv.ParseInt(os.Getenv("GCORE_CLOUD_REGION_ID"), 10, 64)
 
     	client := gcore.NewClient()
+    	ctx := context.Background()
 
     	cluster, err := client.Cloud.K8S.Clusters.Get(
     		ctx,
@@ -295,6 +297,7 @@ export GCORE_CLUSTER_NAME="{YOUR_CLUSTER_NAME}"
     	regionID, _ := strconv.ParseInt(os.Getenv("GCORE_CLOUD_REGION_ID"), 10, 64)
 
     	client := gcore.NewClient()
+    	ctx := context.Background()
 
     	kc, err := client.Cloud.K8S.Clusters.Kubeconfig.Get(
     		ctx,
@@ -336,6 +339,53 @@ export GCORE_CLUSTER_NAME="{YOUR_CLUSTER_NAME}"
 export KUBECONFIG=/path/to/k8sConfig.yml
 kubectl cluster-info
 ```
+
+</MethodSection>
+  <MethodSection id="terraform" label="Terraform">
+
+<p>Read the kubeconfig for an existing GPU Kubernetes cluster using the [`gcore_cloud_k8s_cluster_kubeconfig`](https://registry.terraform.io/providers/G-Core/gcore/latest/docs/data-sources/cloud_k8s_cluster_kubeconfig) data source from the [Terraform&nbsp;provider](/developer-tools/terraform/overview) v2. No infrastructure is created — the data source reads the kubeconfig from the Gcore API on every run.</p>
+
+<Info>
+An [API&nbsp;token](/account-settings/api-tokens), a [project&nbsp;ID](/api-reference/cloud/projects/list-projects), and a [region&nbsp;ID](/api-reference/cloud/regions/list-regions) are required.
+</Info>
+
+## Download kubeconfig
+
+<p>Declare the data source with the cluster name and run `terraform apply`. The `kubeconfig` output holds the full kubeconfig YAML; mark it sensitive to avoid printing it to the terminal.</p>
+
+```hcl
+data "gcore_cloud_k8s_cluster_kubeconfig" "example" {
+  project_id   = var.project_id
+  region_id    = var.region_id
+  cluster_name = "my-gpu-k8s"
+}
+
+output "cluster_host" {
+  value = data.gcore_cloud_k8s_cluster_kubeconfig.example.host
+}
+
+output "kubeconfig_expires_at" {
+  value = data.gcore_cloud_k8s_cluster_kubeconfig.example.expires_at
+}
+
+output "kubeconfig" {
+  value     = data.gcore_cloud_k8s_cluster_kubeconfig.example.config
+  sensitive = true
+}
+```
+
+<p>Write the kubeconfig to a file and configure kubectl:</p>
+
+```bash
+terraform apply
+terraform output -raw kubeconfig > k8sConfig.yml
+export KUBECONFIG=/path/to/k8sConfig.yml
+kubectl cluster-info
+```
+
+<Note>
+Kubeconfig certificates are valid for two years. When a certificate is renewed, run `terraform apply` again and re-export the kubeconfig.
+</Note>
 
 </MethodSection>
 </MethodSwitch>

--- a/edge-ai/managed-kubernetes/delete-a-gpu-kubernetes-cluster.mdx
+++ b/edge-ai/managed-kubernetes/delete-a-gpu-kubernetes-cluster.mdx
@@ -1,7 +1,7 @@
 ---
 title: Delete a GPU Kubernetes cluster
 sidebarTitle: Delete a cluster
-ai-navigation: Delete a Gcore GPU Kubernetes cluster via Customer Portal or REST API.
+ai-navigation: Delete a Gcore GPU Kubernetes cluster via Customer Portal, REST API, or Terraform.
 ---
 
 import { MethodSwitch, MethodSection } from "/snippets/method-switch.jsx";
@@ -101,6 +101,7 @@ Cluster deletion is irreversible. Download the kubeconfig and back up any requir
     	clusterName := os.Getenv("GCORE_CLUSTER_NAME")
 
     	client := gcore.NewClient()
+    	ctx := context.Background()
 
     	taskList, err := client.Cloud.K8S.Clusters.Delete(
     		ctx,
@@ -147,6 +148,46 @@ Cluster deletion is irreversible. Download the kubeconfig and back up any requir
     <p>Run <code>GET&nbsp;/cloud/v1/tasks/{task_id}</code> every 15 seconds until `state` is `FINISHED`.</p>
   </Tab>
 </Tabs>
+
+  </MethodSection>
+  <MethodSection id="terraform" label="Terraform">
+
+<p>Delete a GPU Kubernetes cluster using the [`gcore_cloud_k8s_cluster`](https://registry.terraform.io/providers/G-Core/gcore/latest/docs/resources/cloud_k8s_cluster) resource from the [Terraform&nbsp;provider](/developer-tools/terraform/overview) v2. Terraform removes all nodes, pools, and control plane resources. External storage is not deleted.</p>
+
+<Warning>
+Cluster deletion is irreversible. Download the kubeconfig and back up any required data before proceeding.
+</Warning>
+
+<Info>
+An [API&nbsp;token](/account-settings/api-tokens), a [project&nbsp;ID](/api-reference/cloud/projects/list-projects), and a [region&nbsp;ID](/api-reference/cloud/regions/list-regions) are required.
+</Info>
+
+## Delete the cluster
+
+<p>Run `terraform destroy` to delete the cluster and all its pools. If the cluster was not created with Terraform, import it first.</p>
+
+```bash
+# If the cluster was created outside Terraform, import it first:
+terraform import gcore_cloud_k8s_cluster.example '<project_id>/<region_id>/<cluster_name>'
+
+terraform destroy
+```
+
+<p>To delete only one cluster in a workspace that manages multiple resources, remove its resource block and run `terraform apply` instead of `terraform destroy`:</p>
+
+```hcl
+# Remove or comment out this block:
+# resource "gcore_cloud_k8s_cluster" "example" {
+#   project_id    = var.project_id
+#   region_id     = var.region_id
+#   name          = "my-gpu-k8s"
+#   ...
+# }
+```
+
+```bash
+terraform apply
+```
 
 </MethodSection>
 </MethodSwitch>

--- a/edge-ai/managed-kubernetes/manage-node-pools.mdx
+++ b/edge-ai/managed-kubernetes/manage-node-pools.mdx
@@ -762,10 +762,6 @@ GPU Bare Metal pools do not require `servergroup_policy`, `boot_volume_type`, or
 An [API&nbsp;token](/account-settings/api-tokens), a [project&nbsp;ID](/api-reference/cloud/projects/list-projects), and a [region&nbsp;ID](/api-reference/cloud/regions/list-regions) are required. Bring an existing cluster under Terraform management with `terraform import` before making changes.
 </Info>
 
-<Warning>
-Provider v2.0.0-alpha.12 throws a "Provider produced inconsistent result after apply" error after every pool modification due to a known bug with `security_group_ids`. The actual API operation succeeds — verify with the Portal or API, then re-run `terraform import` to sync the state file.
-</Warning>
-
 ## Import an existing cluster
 
 <p>Use `terraform import` to bring an existing cluster and its pools under Terraform management without recreating them. Declare the resource block with values that match the live cluster, then import.</p>

--- a/edge-ai/managed-kubernetes/manage-node-pools.mdx
+++ b/edge-ai/managed-kubernetes/manage-node-pools.mdx
@@ -1,7 +1,7 @@
 ---
 title: Manage node pools
 sidebarTitle: Node pools
-ai-navigation: Manage GPU Kubernetes node pools via Customer Portal or REST API - view, scale, add, replace nodes, and delete pools.
+ai-navigation: Manage GPU Kubernetes node pools via Customer Portal, REST API, or Terraform - view, scale, add, replace nodes, and delete pools.
 ---
 
 import { MethodSwitch, MethodSection } from "/snippets/method-switch.jsx";
@@ -275,6 +275,7 @@ export GCORE_CLUSTER_NAME="{YOUR_CLUSTER_NAME}"
     	regionID, _ := strconv.ParseInt(os.Getenv("GCORE_CLOUD_REGION_ID"), 10, 64)
 
     	client := gcore.NewClient()
+    	ctx := context.Background()
 
     	pools, err := client.Cloud.K8S.Clusters.Pools.List(
     		ctx,
@@ -390,6 +391,7 @@ GPU Bare Metal pools do not require `servergroup_policy`, `boot_volume_type`, or
     	clusterName := os.Getenv("GCORE_CLUSTER_NAME")
 
     	client := gcore.NewClient()
+    	ctx := context.Background()
 
     	// GPU Bare Metal pool
     	taskList, err := client.Cloud.K8S.Clusters.Pools.New(
@@ -491,6 +493,7 @@ GPU Bare Metal pools do not require `servergroup_policy`, `boot_volume_type`, or
     	regionID, _ := strconv.ParseInt(os.Getenv("GCORE_CLOUD_REGION_ID"), 10, 64)
 
     	client := gcore.NewClient()
+    	ctx := context.Background()
 
     	pool, err := client.Cloud.K8S.Clusters.Pools.Update(
     		ctx,
@@ -584,6 +587,7 @@ GPU Bare Metal pools do not require `servergroup_policy`, `boot_volume_type`, or
     	clusterName := os.Getenv("GCORE_CLUSTER_NAME")
 
     	client := gcore.NewClient()
+    	ctx := context.Background()
 
     	// Step 1. Find the node ID
     	nodes, err := client.Cloud.K8S.Clusters.Pools.Nodes.List(
@@ -700,6 +704,7 @@ GPU Bare Metal pools do not require `servergroup_policy`, `boot_volume_type`, or
     	clusterName := os.Getenv("GCORE_CLUSTER_NAME")
 
     	client := gcore.NewClient()
+    	ctx := context.Background()
 
     	taskList, err := client.Cloud.K8S.Clusters.Pools.Delete(
     		ctx,
@@ -747,6 +752,137 @@ GPU Bare Metal pools do not require `servergroup_policy`, `boot_volume_type`, or
     <p>Run <code>GET&nbsp;/cloud/v1/tasks/{task_id}</code> every 10 seconds until `state` is `FINISHED`.</p>
   </Tab>
 </Tabs>
+
+</MethodSection>
+  <MethodSection id="terraform" label="Terraform">
+
+<p>Manage node pools of an existing GPU Kubernetes cluster using the [`gcore_cloud_k8s_cluster`](https://registry.terraform.io/providers/G-Core/gcore/latest/docs/resources/cloud_k8s_cluster) resource from the [Terraform&nbsp;provider](/developer-tools/terraform/overview) v2. Pools are a nested attribute of the cluster resource — add, scale, and delete pools by modifying the `pools` list and running `terraform apply`.</p>
+
+<Info>
+An [API&nbsp;token](/account-settings/api-tokens), a [project&nbsp;ID](/api-reference/cloud/projects/list-projects), and a [region&nbsp;ID](/api-reference/cloud/regions/list-regions) are required. Bring an existing cluster under Terraform management with `terraform import` before making changes.
+</Info>
+
+<Warning>
+Provider v2.0.0-alpha.12 throws a "Provider produced inconsistent result after apply" error after every pool modification due to a known bug with `security_group_ids`. The actual API operation succeeds — verify with the Portal or API, then re-run `terraform import` to sync the state file.
+</Warning>
+
+## Import an existing cluster
+
+<p>Use `terraform import` to bring an existing cluster and its pools under Terraform management without recreating them. Declare the resource block with values that match the live cluster, then import.</p>
+
+```hcl
+resource "gcore_cloud_k8s_cluster" "my_cluster" {
+  project_id    = var.project_id
+  region_id     = var.region_id
+  name          = "my-gpu-k8s"
+  version       = "v1.35.3"
+  keypair       = "my-ssh-key"
+  fixed_network = var.network_id
+  fixed_subnet  = var.subnet_id
+
+  pools = [
+    {
+      name                 = "gpu-pool"
+      flavor_id            = "bm3-ai-1xlarge-a100-80-8"
+      min_node_count       = 1
+      max_node_count       = 1
+      auto_healing_enabled = true
+    }
+  ]
+}
+```
+
+```bash
+terraform import gcore_cloud_k8s_cluster.my_cluster '<project_id>/<region_id>/<cluster_name>'
+```
+
+## Add a node pool
+
+<p>Append a new entry to the `pools` list and run `terraform apply`. GPU Bare Metal pools require only `flavor_id` and node counts. VM pools additionally require `servergroup_policy`, `boot_volume_size`, and `boot_volume_type`.</p>
+
+```hcl
+resource "gcore_cloud_k8s_cluster" "my_cluster" {
+  project_id    = var.project_id
+  region_id     = var.region_id
+  name          = "my-gpu-k8s"
+  version       = "v1.35.3"
+  keypair       = "my-ssh-key"
+  fixed_network = var.network_id
+  fixed_subnet  = var.subnet_id
+
+  pools = [
+    {
+      name                 = "gpu-pool"
+      flavor_id            = "bm3-ai-1xlarge-a100-80-8"
+      min_node_count       = 1
+      max_node_count       = 1
+      auto_healing_enabled = true
+    },
+    {
+      name               = "vm-pool"          # new pool
+      flavor_id          = "g3a-standard-2-4"
+      min_node_count     = 1
+      max_node_count     = 2
+      servergroup_policy = "soft-anti-affinity"
+      boot_volume_size   = 50
+      boot_volume_type   = "ssd_hiiops"
+    }
+  ]
+}
+```
+
+## Scale a node pool
+
+<p>Edit `min_node_count` or `max_node_count` for the target pool and run `terraform apply`. When `min_node_count` equals `max_node_count`, the pool maintains a fixed size and the Cluster Autoscaler does not act on it.</p>
+
+```hcl
+resource "gcore_cloud_k8s_cluster" "my_cluster" {
+  project_id    = var.project_id
+  region_id     = var.region_id
+  name          = "my-gpu-k8s"
+  version       = "v1.35.3"
+  keypair       = "my-ssh-key"
+  fixed_network = var.network_id
+  fixed_subnet  = var.subnet_id
+
+  pools = [
+    {
+      name                 = "gpu-pool"
+      flavor_id            = "bm3-ai-1xlarge-a100-80-8"
+      min_node_count       = 1
+      max_node_count       = 3   # updated upper bound
+      auto_healing_enabled = true
+    }
+  ]
+}
+```
+
+## Delete a node pool
+
+<p>Remove the pool entry from the `pools` list and run `terraform apply`. Pods on the removed pool are evicted and rescheduled to remaining pools. Removing the last pool also deletes the cluster.</p>
+
+```hcl
+resource "gcore_cloud_k8s_cluster" "my_cluster" {
+  project_id    = var.project_id
+  region_id     = var.region_id
+  name          = "my-gpu-k8s"
+  version       = "v1.35.3"
+  keypair       = "my-ssh-key"
+  fixed_network = var.network_id
+  fixed_subnet  = var.subnet_id
+
+  pools = [
+    # vm-pool removed — only gpu-pool remains
+    {
+      name                 = "gpu-pool"
+      flavor_id            = "bm3-ai-1xlarge-a100-80-8"
+      min_node_count       = 1
+      max_node_count       = 1
+      auto_healing_enabled = true
+    }
+  ]
+}
+```
 
 </MethodSection>
 </MethodSwitch>

--- a/edge-ai/managed-kubernetes/upgrade-a-gpu-kubernetes-cluster.mdx
+++ b/edge-ai/managed-kubernetes/upgrade-a-gpu-kubernetes-cluster.mdx
@@ -268,10 +268,6 @@ Upgrades move exactly one minor version at a time. The upgrade cannot be paused 
 An [API&nbsp;token](/account-settings/api-tokens), a [project&nbsp;ID](/api-reference/cloud/projects/list-projects), and a [region&nbsp;ID](/api-reference/cloud/regions/list-regions) are required. Import an existing cluster with `terraform import` before changing its version.
 </Info>
 
-<Warning>
-Provider v2.0.0-alpha.12 throws a "Provider produced inconsistent result after apply" error after the upgrade due to a known bug with `security_group_ids`. The rolling upgrade completes successfully — verify the new version with the Portal or API, then re-run `terraform import` to sync the state file.
-</Warning>
-
 ## Upgrade the cluster
 
 <p>Change `version` to the next minor version and run `terraform apply`. The cluster upgrades one node at a time — workloads are rescheduled to the new node before the old node is removed. GPU bare metal upgrades take significantly longer than VM upgrades.</p>

--- a/edge-ai/managed-kubernetes/upgrade-a-gpu-kubernetes-cluster.mdx
+++ b/edge-ai/managed-kubernetes/upgrade-a-gpu-kubernetes-cluster.mdx
@@ -1,7 +1,7 @@
 ---
 title: Upgrade a GPU Kubernetes cluster
 sidebarTitle: Upgrade a cluster
-ai-navigation: Upgrade a Gcore GPU Kubernetes cluster to the next minor version via Customer Portal or REST API.
+ai-navigation: Update a Gcore GPU Kubernetes cluster to the next minor version via Customer Portal, REST API, or Terraform.
 ---
 
 import { MethodSwitch, MethodSection } from "/snippets/method-switch.jsx";
@@ -173,6 +173,7 @@ Upgrades move exactly one minor version at a time. The upgrade cannot be paused 
     	clusterName := os.Getenv("GCORE_CLUSTER_NAME")
 
     	client := gcore.NewClient()
+    	ctx := context.Background()
 
     	// Step 1. Check available upgrade versions
     	versions, err := client.Cloud.K8S.Clusters.ListVersionsForUpgrade(
@@ -257,6 +258,54 @@ Upgrades move exactly one minor version at a time. The upgrade cannot be paused 
     <p>Run <code>GET&nbsp;/cloud/v1/tasks/{task_id}</code> every 30 seconds until `state` is `FINISHED`. GPU bare metal node upgrades take longer than standard VM upgrades.</p>
   </Tab>
 </Tabs>
+
+</MethodSection>
+  <MethodSection id="terraform" label="Terraform">
+
+<p>Upgrade a GPU Kubernetes cluster to the next minor version using the [`gcore_cloud_k8s_cluster`](https://registry.terraform.io/providers/G-Core/gcore/latest/docs/resources/cloud_k8s_cluster) resource from the [Terraform&nbsp;provider](/developer-tools/terraform/overview) v2. Changing the `version` field triggers a rolling upgrade — Terraform applies the change in-place without recreating the cluster.</p>
+
+<Info>
+An [API&nbsp;token](/account-settings/api-tokens), a [project&nbsp;ID](/api-reference/cloud/projects/list-projects), and a [region&nbsp;ID](/api-reference/cloud/regions/list-regions) are required. Import an existing cluster with `terraform import` before changing its version.
+</Info>
+
+<Warning>
+Provider v2.0.0-alpha.12 throws a "Provider produced inconsistent result after apply" error after the upgrade due to a known bug with `security_group_ids`. The rolling upgrade completes successfully — verify the new version with the Portal or API, then re-run `terraform import` to sync the state file.
+</Warning>
+
+## Upgrade the cluster
+
+<p>Change `version` to the next minor version and run `terraform apply`. The cluster upgrades one node at a time — workloads are rescheduled to the new node before the old node is removed. GPU bare metal upgrades take significantly longer than VM upgrades.</p>
+
+<Warning>
+Upgrades move exactly one minor version at a time. To move from v1.33 to v1.35, apply the change twice: first to v1.34, then to v1.35. Downgrade is not supported.
+</Warning>
+
+```hcl
+resource "gcore_cloud_k8s_cluster" "example" {
+  project_id    = var.project_id
+  region_id     = var.region_id
+  name          = "my-gpu-k8s"
+  version       = "v1.36.1"  # changed from v1.35.3
+  keypair       = "my-ssh-key"
+  fixed_network = var.network_id
+  fixed_subnet  = var.subnet_id
+
+  pools = [
+    {
+      name                 = "gpu-pool"
+      flavor_id            = "bm3-ai-1xlarge-a100-80-8"
+      min_node_count       = 1
+      max_node_count       = 3
+      auto_healing_enabled = true
+    }
+  ]
+}
+```
+
+```bash
+terraform import gcore_cloud_k8s_cluster.example '<project_id>/<region_id>/<cluster_name>'
+terraform apply
+```
 
 </MethodSection>
 </MethodSwitch>

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -493,14 +493,14 @@
 - [Create a GPU Kubernetes cluster](https://docs.gcore.com/edge-ai/managed-kubernetes/create-a-gpu-kubernetes-cluster.md): Create GPU Kubernetes clusters with Bare Metal GPU pools via Customer Portal, REST API, or Terraform - configure version, pools, network, and download kubeconfig.
 
 ## Manage a cluster
-- [Connect to a GPU Kubernetes cluster](https://docs.gcore.com/edge-ai/managed-kubernetes/connect-to-a-gpu-kubernetes-cluster.md): Connect to a Gcore GPU Kubernetes cluster via Customer Portal or REST API - download kubeconfig, configure kubectl, and list or inspect clusters.
-- [Manage node pools](https://docs.gcore.com/edge-ai/managed-kubernetes/manage-node-pools.md): Manage GPU Kubernetes node pools via Customer Portal or REST API - view, scale, add, replace nodes, and delete pools.
-- [Configure cluster autoscaling](https://docs.gcore.com/edge-ai/managed-kubernetes/configure-cluster-autoscaling.md): Configure the Cluster Autoscaler for a Gcore GPU Kubernetes cluster via the Customer Portal or via REST API.
-- [Configure cluster logging](https://docs.gcore.com/edge-ai/managed-kubernetes/configure-cluster-logging.md): Configure container and system log collection for a Gcore GPU Kubernetes cluster via the Customer Portal or via REST API.
-- [Configure OIDC authentication](https://docs.gcore.com/edge-ai/managed-kubernetes/configure-oidc-authentication.md): Configure OIDC Single Sign-On for Kubernetes API access in a Gcore GPU Kubernetes cluster via the Customer Portal or via REST API.
-- [Upgrade a GPU Kubernetes cluster](https://docs.gcore.com/edge-ai/managed-kubernetes/upgrade-a-gpu-kubernetes-cluster.md): Upgrade a Gcore GPU Kubernetes cluster to the next minor version via Customer Portal or REST API.
+- [Connect to a GPU Kubernetes cluster](https://docs.gcore.com/edge-ai/managed-kubernetes/connect-to-a-gpu-kubernetes-cluster.md): Connect to a Gcore GPU Kubernetes cluster via Customer Portal, REST API, or Terraform - download kubeconfig, configure kubectl, and list or inspect clusters.
+- [Manage node pools](https://docs.gcore.com/edge-ai/managed-kubernetes/manage-node-pools.md): Manage GPU Kubernetes node pools via Customer Portal, REST API, or Terraform - view, scale, add, replace nodes, and delete pools.
+- [Configure cluster autoscaling](https://docs.gcore.com/edge-ai/managed-kubernetes/configure-cluster-autoscaling.md): Configure the Cluster Autoscaler for a Gcore GPU Kubernetes cluster via the Customer Portal, REST API, or Terraform.
+- [Configure cluster logging](https://docs.gcore.com/edge-ai/managed-kubernetes/configure-cluster-logging.md): Configure container and system log collection for a Gcore GPU Kubernetes cluster via the Customer Portal, REST API, or Terraform.
+- [Configure OIDC authentication](https://docs.gcore.com/edge-ai/managed-kubernetes/configure-oidc-authentication.md): Configure OIDC Single Sign-On for Kubernetes API access in a Gcore GPU Kubernetes cluster via the Customer Portal, REST API, or Terraform.
+- [Upgrade a GPU Kubernetes cluster](https://docs.gcore.com/edge-ai/managed-kubernetes/upgrade-a-gpu-kubernetes-cluster.md): Update a Gcore GPU Kubernetes cluster to the next minor version via Customer Portal, REST API, or Terraform.
 - [View cluster audit log](https://docs.gcore.com/edge-ai/managed-kubernetes/view-cluster-audit-log.md): View the audit log of GPU Kubernetes cluster operations via the Gcore Customer Portal.
-- [Delete a GPU Kubernetes cluster](https://docs.gcore.com/edge-ai/managed-kubernetes/delete-a-gpu-kubernetes-cluster.md): Delete a Gcore GPU Kubernetes cluster via Customer Portal or REST API.
+- [Delete a GPU Kubernetes cluster](https://docs.gcore.com/edge-ai/managed-kubernetes/delete-a-gpu-kubernetes-cluster.md): Delete a Gcore GPU Kubernetes cluster via Customer Portal, REST API, or Terraform.
 
 ## Everywhere Inference
 - [Overview](https://docs.gcore.com/edge-ai/everywhere-inference.md): Deploy trained AI models on Gcore Everywhere Inference edge nodes using anycast endpoints and smart routing to achieve low-latency inference across global regions with automatic failover.


### PR DESCRIPTION
- Add Terraform tab to: configure-cluster-autoscaling, configure-cluster-logging, configure-oidc-authentication, connect-to-a-gpu-kubernetes-cluster, manage-node-pools, upgrade-a-gpu-kubernetes-cluster, delete-a-gpu-kubernetes-cluster
- Fix duplicate ctx := ctx declaration in Go SDK examples across create-a-bare-metal-gpu-cluster, create-a-virtual-gpu-cluster, spot-bare-metal-gpu, configure-cluster-logging, configure-oidc-authentication
- All Terraform examples live-tested against Gcore API (provider v2.0.0-alpha.12)