### PR TITLE
docs: fix broken /api-reference links via redirects and a direct mdx fix

### DIFF
--- a/cdn/clear-cdn-resource-cache-by-url-pattern-or-all.mdx
+++ b/cdn/clear-cdn-resource-cache-by-url-pattern-or-all.mdx
@@ -117,7 +117,7 @@ We will explain in detail how to do Purge by URL via API calls. Examples of othe
   | **Response**          | **201 Created**<br />Returns an array of the purged URLs<br /><br />**400 Bad Request**<br />The user has exceeded the URL quota<br /><br />**401 Unauthorized**<br />The user does not have the correct authentication credentials<br /><br />**429 Too many requests**<br />The user has exceeded the request quota                                                    |
 </Accordion>
 
-To access the API and make authenticated requests, [generate an access token](/api-reference/account). You can use a REST tool like cURL or Postman to send the requests. For this guide, we used Postman.
+To access the API and make authenticated requests, [generate an access token](/api-reference/iam/account/login). You can use a REST tool like cURL or Postman to send the requests. For this guide, we used Postman.
 
 To send a purge by URL request:
 

--- a/docs.json
+++ b/docs.json
@@ -2212,6 +2212,22 @@
       "destination": "/cdn/terraform/manage-cdn-via-terraform-v2"
     },
     {
+      "source": "/api-reference/cdn/cdn-statistics/cdn-resource-statistics",
+      "destination": "/api-reference/cdn/statistics/cdn-resource-statistics"
+    },
+    {
+      "source": "/api-reference/streaming/ai/create-ai-asr-task",
+      "destination": "/api-reference/streaming/ai/create-ai-task"
+    },
+    {
+      "source": "/api-reference/iam-resellers/services/update-service-s-details",
+      "destination": "/api-reference/iam-resellers/services/update-services-details"
+    },
+    {
+      "source": "/api-reference/cdn/logs-uploader",
+      "destination": "/api-reference/cdn/logs-uploader/get-policies-list"
+    },
+    {
       "source": "/docs/:slug*",
       "destination": "/:slug*"
     }


### PR DESCRIPTION
Add redirects for known-broken OpenAPI-description link targets that can't be fixed at the source (the yaml specs are overwritten by an external sync process): wrong CDN statistics tag folder, a collapsed streaming AI-task operation, an apostrophe-mangled IAM reseller slug, and a dead logs-uploader tag-index link repointed to a real operation.

Also fix a stale hardcoded /api-reference/account link in the CDN purge-cache guide to point at the actual login operation.