### PR TITLE
Update link to PlayerEvent class documentation

### DIFF
--- a/streaming/api/player-api-tutorial.mdx
+++ b/streaming/api/player-api-tutorial.mdx
@@ -423,7 +423,7 @@ player.on("play", () => {
 | **Audio**       | `volumeupdate`  | Fired when volume or mute state changes                                     |
 | **Errors**      | `error`         | Fired when playback fails or media cannot be loaded                         |
 
-For a complete list of player events and their parameters, refer to the [PlayerEvent class](https://docs.gcore.com/video-streaming/sdk/player-events) documentation.
+For a complete list of player events and their parameters, refer to the [PlayerEvent class](https://docs.gcore.com/streaming/player/player-api-tutorial#events-overview) documentation.
 
 
 ### Errors overview


### PR DESCRIPTION
Replaced broken link: https://docs.gcore.com/video-streaming/sdk/player-events

With: https://docs.gcore.com/streaming/player/player-api-tutorial#events-overview