### PR TITLE
docs(storage): add REST API tab to manage-buckets article (DOC-1773)

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -729,7 +729,7 @@
 - [Storage as a CDN origin](https://docs.gcore.com/storage/use-storage-as-the-origin-for-your-cdn-resource.md): Configure Gcore CDN resources with Object Storage or SFTP storage as origins using bucket paths, storage hostnames, custom domains, and authentication options for public or private buckets.
 
 ## Manage object storage
-- [Managing buckets](https://docs.gcore.com/storage/manage-object-storage/manage-buckets-via-the-control-panel.md): Create and manage S3 buckets in Gcore Object Storage via the Customer Portal, configure CORS and public HTTP access, upload and organize files in the built-in file manager using Access Key and Secret Key authentication, and set lifecycle policies for automatic object deletion.
+- [Managing buckets](https://docs.gcore.com/storage/manage-object-storage/manage-buckets-via-the-control-panel.md): Create and manage S3 buckets via Customer Portal or REST API - configure CORS, public access, and lifecycle policies for automatic object deletion.
 
 ## Configure AWS CLI, S3cmd, and AWS JavaScript SDK
 - [Connect AWS CLI, S3cmd, and AWS JavaScript SDK](https://docs.gcore.com/storage/manage-object-storage/configure-aws-sli-s3cmd-and-aws-javascript-sdk/connect-aws-cli-s3cmd-and-aws-sdk.md): Install and configure AWS CLI, S3cmd, and AWS JavaScript SDK v2 to connect to Gcore Object Storage using S3-compatible credentials and region endpoints.

--- a/storage/llms.txt
+++ b/storage/llms.txt
@@ -8,7 +8,7 @@
 - [Storage as a CDN origin](https://docs.gcore.com/storage/use-storage-as-the-origin-for-your-cdn-resource.md): Configure Gcore CDN resources with Object Storage or SFTP storage as origins using bucket paths, storage hostnames, custom domains, and authentication options for public or private buckets.
 
 ## Manage object storage
-- [Managing buckets](https://docs.gcore.com/storage/manage-object-storage/manage-buckets-via-the-control-panel.md): Create and manage S3 buckets in Gcore Object Storage via the Customer Portal, configure CORS and public HTTP access, upload and organize files in the built-in file manager using Access Key and Secret Key authentication, and set lifecycle policies for automatic object deletion.
+- [Managing buckets](https://docs.gcore.com/storage/manage-object-storage/manage-buckets-via-the-control-panel.md): Create and manage S3 buckets via Customer Portal or REST API - configure CORS, public access, and lifecycle policies for automatic object deletion.
 
 ## Configure AWS CLI, S3cmd, and AWS JavaScript SDK
 - [Connect AWS CLI, S3cmd, and AWS JavaScript SDK](https://docs.gcore.com/storage/manage-object-storage/configure-aws-sli-s3cmd-and-aws-javascript-sdk/connect-aws-cli-s3cmd-and-aws-sdk.md): Install and configure AWS CLI, S3cmd, and AWS JavaScript SDK v2 to connect to Gcore Object Storage using S3-compatible credentials and region endpoints.

--- a/storage/manage-object-storage/manage-buckets-via-the-control-panel.mdx
+++ b/storage/manage-object-storage/manage-buckets-via-the-control-panel.mdx
@@ -1,10 +1,15 @@
 ---
 title: Managing buckets
 sidebarTitle: Manage buckets
-ai-navigation: Create and manage S3 buckets in Gcore Object Storage via the Customer Portal, configure CORS and public HTTP access, upload and organize files in the built-in file manager using Access Key and Secret Key authentication, and set lifecycle policies for automatic object deletion.
+ai-navigation: Create and manage S3 buckets via Customer Portal or REST API - configure CORS, public access, and lifecycle policies for automatic object deletion.
 ---
 
-Gcore Object Storage organizes files into buckets. The built-in file manager handles uploading and organizing files, with controls for public access and lifecycle policies.
+import { MethodSwitch, MethodSection } from "/snippets/method-switch.jsx";
+
+<MethodSwitch>
+  <MethodSection id="portal" label="Customer Portal">
+
+<p>Gcore Object Storage organizes files into buckets. The built-in file manager handles uploading and organizing files, with controls for public access and lifecycle policies.</p>
 
 ## Bucket creation
 
@@ -20,7 +25,7 @@ Gcore Object Storage organizes files into buckets. The built-in file manager han
   <Step title="Name the bucket">
     In the dialog that appears, enter a name that meets the following criteria:
 
-    - Between 3 and 63 characters.
+    - 3–63 characters.
     - Lowercase only.
     - No underscores, trailing dashes, consecutive dots, or a mix of dots and dashes — these conflict with DNS notation rules.
     - Unique across the entire Gcore Object Storage system. A `This bucket name already exists. Please use a different name` error appears if the name is taken.
@@ -31,38 +36,38 @@ Gcore Object Storage organizes files into buckets. The built-in file manager han
 
 <Note>Avoid using sensitive information in the bucket name. The bucket name appears in object URLs and is publicly visible.</Note>
 
-The new bucket appears in the list once created. The following sections cover how to upload and manage files, control public access, and configure lifecycle policies.
+<p>The new bucket appears in the list once created. The following sections cover how to upload and manage files, control public access, and configure lifecycle policies.</p>
 
 ## File manager
 
-The file manager is a browser-based interface for managing files in a bucket. Two setup steps are required before use: configuring CORS and authenticating with S3 credentials.
+<p>The file manager is a browser-based interface for managing files in a bucket. Two setup steps are required before use: configuring CORS and authenticating with S3 credentials.</p>
 
 ### CORS setup
 
-To access the file manager, add `https://portal.gcore.com` to the bucket's CORS policy. This is a one-time setup per bucket.
+<p>To access the file manager, add `https://portal.gcore.com` to the bucket's CORS policy. This is a one-time setup per bucket.</p>
 
-Click the bucket name to open the access settings dialog, then click **Override CORS**.
+<p>Click the bucket name to open the access settings dialog, then click **Override CORS**.</p>
 
 <Note>Configure CORS individually for each bucket.</Note>
 
 <Frame>![Override CORS dialog](/images/docs/storage/manage-object-storage/manage-buckets-via-the-control-panel/manage-buckets-cp-30.png)</Frame>
 
-The [API](/api-reference/storage/storage/create-s3-bucket-cors) also supports multiple allowed origins beyond `https://portal.gcore.com`.
+<p>The [API](/api-reference/storage/storage/create-s3-bucket-cors) also supports multiple allowed origins beyond `https://portal.gcore.com`.</p>
 
 ### Authorization
 
-To authorize, click the bucket name, enter the Access key and Secret key, then click **Auth**.
+<p>To authorize, click the bucket name, enter the Access key and Secret key, then click **Auth**.</p>
 
 <Frame>![Authorization form for the file manager](/images/docs/storage/manage-object-storage/manage-buckets-via-the-control-panel/manage-buckets-cp-40.png)</Frame>
 
-Alternatively, access the file manager from the bucket's three-dot menu by selecting **File manager**.
+<p>Alternatively, access the file manager from the bucket's three-dot menu by selecting **File manager**.</p>
 
 <Accordion title="Access key and Secret key features">
 <Note>Keys entered during a session remain active for that session. Each new session requires entering them again.</Note>
 
-To avoid re-entering keys manually, save them using the browser's credential manager.
+<p>To avoid re-entering keys manually, save them using the browser's credential manager.</p>
 
-Storage creation generates the Access key and Secret key. Gcore does not store these values. To regenerate lost keys, click **Generate new keys** in the **Object Storage** list using the three-dot menu.
+<p>Storage creation generates the Access key and Secret key. Gcore does not store these values. To regenerate lost keys, click **Generate new keys** in the **Object Storage** list using the three-dot menu.</p>
 
 <Frame>![Object storage three-dot menu with the Generate new keys option](/images/docs/storage/manage-object-storage/manage-buckets-via-the-control-panel/manage-buckets-cp-60.png)</Frame>
 
@@ -70,21 +75,21 @@ Storage creation generates the Access key and Secret key. Gcore does not store t
 
 ### Adding folders
 
-After [authorizing](/storage/manage-object-storage/manage-buckets-via-the-control-panel#authorization), click **Add folder**. Enter a name in the field and click **Create**.
+<p>After [authorizing](/storage/manage-object-storage/manage-buckets-via-the-control-panel#authorization), click **Add folder**. Enter a name in the field and click **Create**.</p>
 
 <Frame>![Add folder dialog](/images/docs/storage/manage-object-storage/manage-buckets-via-the-control-panel/manage-buckets-cp-70.png)</Frame>
 
-Each folder displays its last modification date. Click a folder name to open it.
+<p>Each folder displays its last modification date. Click a folder name to open it.</p>
 
 ### Uploading files
 
-To upload files, [authorize](/storage/manage-object-storage/manage-buckets-via-the-control-panel#authorization) and click **Select and upload file(s)** either in the bucket root or within a specific folder. Then, follow the standard upload process.
+<p>To upload files, [authorize](/storage/manage-object-storage/manage-buckets-via-the-control-panel#authorization) and click **Select and upload file(s)** either in the bucket root or within a specific folder. Then, follow the standard upload process.</p>
 
 <Frame>![File manager with uploaded file and folder](/images/docs/storage/manage-object-storage/manage-buckets-via-the-control-panel/manage-buckets-cp-80.png)</Frame>
 
 ### Deleting folders and files
 
-To delete folders or files, [authorize](/storage/manage-object-storage/manage-buckets-via-the-control-panel#authorization) and click **Delete** next to the desired object. Alternatively, select the checkboxes next to the object names and click **Delete selected**.
+<p>To delete folders or files, [authorize](/storage/manage-object-storage/manage-buckets-via-the-control-panel#authorization) and click **Delete** next to the desired object. Alternatively, select the checkboxes next to the object names and click **Delete selected**.</p>
 
 <Frame>![Delete confirmation dialog](/images/docs/storage/manage-object-storage/manage-buckets-via-the-control-panel/manage-buckets-cp-90.png)</Frame>
 
@@ -92,11 +97,11 @@ To delete folders or files, [authorize](/storage/manage-object-storage/manage-bu
 
 ### Copying file URLs
 
-To copy file URLs, [authorize](/storage/manage-object-storage/manage-buckets-via-the-control-panel#authorization), select objects, and click the relevant button: **Copy S3 URL** or **Copy URL**.
+<p>To copy file URLs, [authorize](/storage/manage-object-storage/manage-buckets-via-the-control-panel#authorization), select objects, and click the relevant button: **Copy S3 URL** or **Copy URL**.</p>
 
 <Frame>![Copy S3 URL and Copy URL buttons visible for a selected file](/images/docs/storage/manage-object-storage/manage-buckets-via-the-control-panel/manage-buckets-cp-100.png)</Frame>
 
-The links for the file `image 3972.png` look like this:
+<p>The links for the file `image 3972.png` look like this:</p>
 
 - `s3://s-ed1.cloud.gcore.lu/000-sample-for-articles/test/image%203972.png`
 - `https://s-ed1.cloud.gcore.lu/000-sample-for-articles/test/image%203972.png`
@@ -105,20 +110,518 @@ The links for the file `image 3972.png` look like this:
 
 ## Managing access
 
-Enable public HTTP access to make files directly accessible by URL or to use the bucket as a [CDN&nbsp;origin](/storage/use-storage-as-the-origin-for-your-cdn-resource). Click the three-dot menu on the bucket row, select **Public access to all files**, and confirm by clicking **Apply**.
+<p>Enable public HTTP access to make files directly accessible by URL or to serve them through a [CDN&nbsp;origin](/storage/use-storage-as-the-origin-for-your-cdn-resource). Click the three-dot menu on the bucket row, select **Public access to all files**, and confirm by clicking **Apply**.</p>
 
 <Frame>![Confirmation dialog for enabling public HTTP access to all files in the bucket](/images/docs/storage/manage-object-storage/manage-buckets-via-the-control-panel/http-access-s3-bucket.png)</Frame>
 
-To revert to private access, click the three-dot menu on the bucket row and click **Default access to all files**.
+<p>To revert to private access, click the three-dot menu on the bucket row and click **Default access to all files**.</p>
 
 <Frame>![Confirmation dialog for reverting the bucket to default private access](/images/docs/storage/manage-object-storage/manage-buckets-via-the-control-panel/default-access-s3-bucket.png)</Frame>
 
 ## Adding lifecycle policy (for S3 in Luxembourg only)
 
-Click the three-dot menu on the bucket row and select **Lifecycle Management**. Set the retention period and click **Save changes**.
+<p>Click the three-dot menu on the bucket row and select **Lifecycle Management**. Set the retention period and click **Save changes**.</p>
 
 <Frame>![Lifecycle policy configuration dialog](/images/docs/storage/manage-object-storage/manage-buckets-via-the-control-panel/manage-buckets-cp-120.png)</Frame>
 
-To remove an existing policy, click **Cancel policy**.
+<p>To remove an existing policy, click **Cancel policy**.</p>
 
-For other storage locations, configure lifecycle policies with the [AWS&nbsp;CLI](/storage/manage-object-storage/configure-aws-sli-s3cmd-and-aws-javascript-sdk/remove-objects-from-a-bucket-automatically-with-aws-cli).
+<p>For other storage locations, configure lifecycle policies with the [AWS&nbsp;CLI](/storage/manage-object-storage/configure-aws-sli-s3cmd-and-aws-javascript-sdk/remove-objects-from-a-bucket-automatically-with-aws-cli).</p>
+
+  </MethodSection>
+  <MethodSection id="api" label="REST API">
+
+<p>Bucket operations within an S3 storage — creation, CORS rules, public access, and lifecycle policies — are managed through the buckets endpoint. Each request requires the numeric storage ID, returned when [creating&nbsp;storage](/storage/create-an-s3-or-sftp-storage) or available from the [storage&nbsp;list](/api-reference/storage/storage/list-object-storages).</p>
+
+<Info>
+An [API&nbsp;token](/account-settings/api-tokens) is required.
+</Info>
+
+```bash
+export GCORE_API_KEY="{YOUR_API_KEY}"
+export STORAGE_ID="{YOUR_STORAGE_ID}"
+```
+
+## Create bucket
+
+<p>Bucket names must be globally unique across the Gcore Object Storage system, 3–63 lowercase characters, with no underscores, trailing dashes, consecutive dots, or combinations of dots and dashes.</p>
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `name` | Yes | Globally unique bucket name, 3–63 lowercase characters |
+
+<Tabs>
+  <Tab title="Python SDK">
+    ```python
+    import os
+    from gcore import Gcore
+
+    client = Gcore()
+    storage_id = int(os.environ["STORAGE_ID"])
+
+    bucket = client.storage.object_storages.buckets.create(
+        storage_id,
+        name="my-bucket",
+    )
+    print(f"Bucket: {bucket.name}  storage_id={bucket.storage_id}")
+    ```
+  </Tab>
+  <Tab title="Go SDK">
+    ```go
+    package main
+
+    import (
+        "context"
+        "fmt"
+        "log"
+        "os"
+        "strconv"
+
+        gcore "github.com/G-Core/gcore-go"
+        "github.com/G-Core/gcore-go/storage"
+    )
+
+    func main() {
+        storageID, _ := strconv.ParseInt(os.Getenv("STORAGE_ID"), 10, 64)
+
+        client := gcore.NewClient()
+        ctx := context.Background()
+
+        bucket, err := client.Storage.ObjectStorages.Buckets.New(ctx, storageID, storage.ObjectStorageBucketNewParams{
+            Name: "my-bucket",
+        })
+        if err != nil {
+            log.Fatalf("create bucket: %v", err)
+        }
+        fmt.Printf("Bucket: %s  storage_id=%d\n", bucket.Name, bucket.StorageID)
+    }
+    ```
+  </Tab>
+  <Tab title="curl">
+    ```bash
+    curl -X POST "https://api.gcore.com/storage/v4/object_storages/$STORAGE_ID/buckets" \
+      -H "Authorization: APIKey $GCORE_API_KEY" \
+      -H "Content-Type: application/json" \
+      -d '{"name": "my-bucket"}'
+    ```
+
+    The API returns:
+
+    ```json
+    {
+      "name": "my-bucket",
+      "storage_id": 13799,
+      "cors": null,
+      "lifecycle": null,
+      "policy": null
+    }
+    ```
+  </Tab>
+</Tabs>
+
+## List buckets
+
+<p>Returns all buckets in a storage, including their current CORS, lifecycle, and public access settings.</p>
+
+<Tabs>
+  <Tab title="Python SDK">
+    ```python
+    import os
+    from gcore import Gcore
+
+    client = Gcore()
+    storage_id = int(os.environ["STORAGE_ID"])
+
+    buckets = client.storage.object_storages.buckets.list(storage_id)
+    for b in buckets:
+        print(f"{b.name}  is_public={b.policy.is_public if b.policy else False}")
+    ```
+  </Tab>
+  <Tab title="Go SDK">
+    ```go
+    package main
+
+    import (
+        "context"
+        "fmt"
+        "log"
+        "os"
+        "strconv"
+
+        gcore "github.com/G-Core/gcore-go"
+        "github.com/G-Core/gcore-go/storage"
+    )
+
+    func main() {
+        storageID, _ := strconv.ParseInt(os.Getenv("STORAGE_ID"), 10, 64)
+
+        client := gcore.NewClient()
+        ctx := context.Background()
+
+        page, err := client.Storage.ObjectStorages.Buckets.List(ctx, storageID, storage.ObjectStorageBucketListParams{})
+        if err != nil {
+            log.Fatalf("list buckets: %v", err)
+        }
+        for _, b := range page.Results {
+            fmt.Printf("%s  is_public=%v\n", b.Name, b.Policy.IsPublic)
+        }
+    }
+    ```
+  </Tab>
+  <Tab title="curl">
+    ```bash
+    curl "https://api.gcore.com/storage/v4/object_storages/$STORAGE_ID/buckets" \
+      -H "Authorization: APIKey $GCORE_API_KEY"
+    ```
+
+    The API returns:
+
+    ```json
+    {
+      "count": 2,
+      "results": [
+        {
+          "name": "my-bucket",
+          "storage_id": 13799,
+          "cors": {
+            "allowed_origins": ["https://portal.gcore.com"]
+          },
+          "lifecycle": null,
+          "policy": {
+            "is_public": false
+          }
+        },
+        {
+          "name": "my-other-bucket",
+          "storage_id": 13799,
+          "cors": null,
+          "lifecycle": {
+            "expiration_days": 30
+          },
+          "policy": {
+            "is_public": true
+          }
+        }
+      ]
+    }
+    ```
+  </Tab>
+</Tabs>
+
+## Configure CORS
+
+<p>CORS rules control which web origins can make direct browser requests to the bucket. Sending an empty array removes all CORS rules.</p>
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `cors.allowed_origins` | Yes | List of allowed origin URLs, e.g. `["https://portal.gcore.com"]`. Send `[]` to remove CORS. |
+
+<Tabs>
+  <Tab title="Python SDK">
+    ```python
+    import os
+    from gcore import Gcore
+
+    client = Gcore()
+    storage_id = int(os.environ["STORAGE_ID"])
+
+    bucket = client.storage.object_storages.buckets.update(
+        "my-bucket",
+        storage_id=storage_id,
+        cors={"allowed_origins": ["https://portal.gcore.com", "https://example.com"]},
+    )
+    print(f"Allowed origins: {bucket.cors.allowed_origins}")
+    ```
+  </Tab>
+  <Tab title="Go SDK">
+    ```go
+    package main
+
+    import (
+        "context"
+        "fmt"
+        "log"
+        "os"
+        "strconv"
+
+        gcore "github.com/G-Core/gcore-go"
+        "github.com/G-Core/gcore-go/storage"
+    )
+
+    func main() {
+        storageID, _ := strconv.ParseInt(os.Getenv("STORAGE_ID"), 10, 64)
+
+        client := gcore.NewClient()
+        ctx := context.Background()
+
+        bucket, err := client.Storage.ObjectStorages.Buckets.Update(ctx, "my-bucket", storage.ObjectStorageBucketUpdateParams{
+            StorageID: storageID,
+            Cors: storage.ObjectStorageBucketUpdateParamsCors{
+                AllowedOrigins: []string{"https://portal.gcore.com", "https://example.com"},
+            },
+        })
+        if err != nil {
+            log.Fatalf("update CORS: %v", err)
+        }
+        fmt.Printf("Allowed origins: %v\n", bucket.Cors.AllowedOrigins)
+    }
+    ```
+  </Tab>
+  <Tab title="curl">
+    ```bash
+    curl -X PATCH "https://api.gcore.com/storage/v4/object_storages/$STORAGE_ID/buckets/my-bucket" \
+      -H "Authorization: APIKey $GCORE_API_KEY" \
+      -H "Content-Type: application/json" \
+      -d '{"cors": {"allowed_origins": ["https://portal.gcore.com", "https://example.com"]}}'
+    ```
+
+    The API returns the updated bucket object with `cors.allowed_origins` set.
+  </Tab>
+</Tabs>
+
+## Enable or disable public access
+
+<p>Setting `is_public` to `true` allows unauthenticated downloads of all objects in the bucket by direct URL. Set to `false` to require S3 credentials for all requests.</p>
+
+<Tabs>
+  <Tab title="Python SDK">
+    ```python
+    import os
+    from gcore import Gcore
+
+    client = Gcore()
+    storage_id = int(os.environ["STORAGE_ID"])
+
+    # Enable public access
+    bucket = client.storage.object_storages.buckets.update(
+        "my-bucket",
+        storage_id=storage_id,
+        policy={"is_public": True},
+    )
+    print(f"is_public={bucket.policy.is_public}")
+
+    # Revert to private
+    bucket = client.storage.object_storages.buckets.update(
+        "my-bucket",
+        storage_id=storage_id,
+        policy={"is_public": False},
+    )
+    print(f"is_public={bucket.policy.is_public}")
+    ```
+  </Tab>
+  <Tab title="Go SDK">
+    ```go
+    package main
+
+    import (
+        "context"
+        "fmt"
+        "log"
+        "os"
+        "strconv"
+
+        gcore "github.com/G-Core/gcore-go"
+        "github.com/G-Core/gcore-go/packages/param"
+        "github.com/G-Core/gcore-go/storage"
+    )
+
+    func main() {
+        storageID, _ := strconv.ParseInt(os.Getenv("STORAGE_ID"), 10, 64)
+
+        client := gcore.NewClient()
+        ctx := context.Background()
+
+        // Enable public access
+        bucket, err := client.Storage.ObjectStorages.Buckets.Update(ctx, "my-bucket", storage.ObjectStorageBucketUpdateParams{
+            StorageID: storageID,
+            Policy: storage.ObjectStorageBucketUpdateParamsPolicy{
+                IsPublic: param.NewOpt[bool](true),
+            },
+        })
+        if err != nil {
+            log.Fatalf("enable public access: %v", err)
+        }
+        fmt.Printf("is_public=%v\n", bucket.Policy.IsPublic)
+    }
+    ```
+  </Tab>
+  <Tab title="curl">
+    ```bash
+    # Enable public access
+    curl -X PATCH "https://api.gcore.com/storage/v4/object_storages/$STORAGE_ID/buckets/my-bucket" \
+      -H "Authorization: APIKey $GCORE_API_KEY" \
+      -H "Content-Type: application/json" \
+      -d '{"policy": {"is_public": true}}'
+
+    # Revert to private
+    curl -X PATCH "https://api.gcore.com/storage/v4/object_storages/$STORAGE_ID/buckets/my-bucket" \
+      -H "Authorization: APIKey $GCORE_API_KEY" \
+      -H "Content-Type: application/json" \
+      -d '{"policy": {"is_public": false}}'
+    ```
+
+    The API returns the updated bucket object with `policy.is_public` reflecting the new value.
+  </Tab>
+</Tabs>
+
+## Set lifecycle policy
+
+<p>Lifecycle policies automatically delete objects after a set number of days. This feature is available for S3 storage in Luxembourg only. Set `expiration_days` to a positive integer to enable, or to `0` to remove an existing policy.</p>
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `lifecycle.expiration_days` | Yes | Days before objects are deleted. Use `0` to remove the rule. |
+
+<Tabs>
+  <Tab title="Python SDK">
+    ```python
+    import os
+    from gcore import Gcore
+
+    client = Gcore()
+    storage_id = int(os.environ["STORAGE_ID"])
+
+    # Set 30-day expiration
+    bucket = client.storage.object_storages.buckets.update(
+        "my-bucket",
+        storage_id=storage_id,
+        lifecycle={"expiration_days": 30},
+    )
+    print(f"expiration_days={bucket.lifecycle.expiration_days}")
+
+    # Remove the lifecycle policy
+    bucket = client.storage.object_storages.buckets.update(
+        "my-bucket",
+        storage_id=storage_id,
+        lifecycle={"expiration_days": 0},
+    )
+    print(f"lifecycle={bucket.lifecycle}")  # None
+    ```
+  </Tab>
+  <Tab title="Go SDK">
+    ```go
+    package main
+
+    import (
+        "context"
+        "fmt"
+        "log"
+        "os"
+        "strconv"
+
+        gcore "github.com/G-Core/gcore-go"
+        "github.com/G-Core/gcore-go/packages/param"
+        "github.com/G-Core/gcore-go/storage"
+    )
+
+    func main() {
+        storageID, _ := strconv.ParseInt(os.Getenv("STORAGE_ID"), 10, 64)
+
+        client := gcore.NewClient()
+        ctx := context.Background()
+
+        // Set 30-day expiration
+        bucket, err := client.Storage.ObjectStorages.Buckets.Update(ctx, "my-bucket", storage.ObjectStorageBucketUpdateParams{
+            StorageID: storageID,
+            Lifecycle: storage.ObjectStorageBucketUpdateParamsLifecycle{
+                ExpirationDays: param.NewOpt[int64](30),
+            },
+        })
+        if err != nil {
+            log.Fatalf("set lifecycle: %v", err)
+        }
+        fmt.Printf("expiration_days=%d\n", bucket.Lifecycle.ExpirationDays)
+
+        // Remove the lifecycle policy
+        bucket, err = client.Storage.ObjectStorages.Buckets.Update(ctx, "my-bucket", storage.ObjectStorageBucketUpdateParams{
+            StorageID: storageID,
+            Lifecycle: storage.ObjectStorageBucketUpdateParamsLifecycle{
+                ExpirationDays: param.NewOpt[int64](0),
+            },
+        })
+        if err != nil {
+            log.Fatalf("remove lifecycle: %v", err)
+        }
+        fmt.Printf("lifecycle removed: expiration_days=%d\n", bucket.Lifecycle.ExpirationDays)
+    }
+    ```
+  </Tab>
+  <Tab title="curl">
+    ```bash
+    # Set 30-day expiration
+    curl -X PATCH "https://api.gcore.com/storage/v4/object_storages/$STORAGE_ID/buckets/my-bucket" \
+      -H "Authorization: APIKey $GCORE_API_KEY" \
+      -H "Content-Type: application/json" \
+      -d '{"lifecycle": {"expiration_days": 30}}'
+
+    # Remove the lifecycle policy
+    curl -X PATCH "https://api.gcore.com/storage/v4/object_storages/$STORAGE_ID/buckets/my-bucket" \
+      -H "Authorization: APIKey $GCORE_API_KEY" \
+      -H "Content-Type: application/json" \
+      -d '{"lifecycle": {"expiration_days": 0}}'
+    ```
+
+    The API returns the updated bucket object. When the policy is removed, `lifecycle` is `null`.
+  </Tab>
+</Tabs>
+
+## Delete bucket
+
+<p>Deleting a bucket permanently removes it and all objects it contains. The bucket name becomes available again after deletion.</p>
+
+<Tabs>
+  <Tab title="Python SDK">
+    ```python
+    import os
+    from gcore import Gcore
+
+    client = Gcore()
+    storage_id = int(os.environ["STORAGE_ID"])
+
+    client.storage.object_storages.buckets.delete("my-bucket", storage_id=storage_id)
+    print("Bucket deleted")
+    ```
+  </Tab>
+  <Tab title="Go SDK">
+    ```go
+    package main
+
+    import (
+        "context"
+        "fmt"
+        "log"
+        "os"
+        "strconv"
+
+        gcore "github.com/G-Core/gcore-go"
+        "github.com/G-Core/gcore-go/storage"
+    )
+
+    func main() {
+        storageID, _ := strconv.ParseInt(os.Getenv("STORAGE_ID"), 10, 64)
+
+        client := gcore.NewClient()
+        ctx := context.Background()
+
+        err := client.Storage.ObjectStorages.Buckets.Delete(ctx, "my-bucket", storage.ObjectStorageBucketDeleteParams{
+            StorageID: storageID,
+        })
+        if err != nil {
+            log.Fatalf("delete bucket: %v", err)
+        }
+        fmt.Println("Bucket deleted")
+    }
+    ```
+  </Tab>
+  <Tab title="curl">
+    ```bash
+    curl -X DELETE "https://api.gcore.com/storage/v4/object_storages/$STORAGE_ID/buckets/my-bucket" \
+      -H "Authorization: APIKey $GCORE_API_KEY"
+    ```
+
+    Returns HTTP 204 with no response body.
+  </Tab>
+</Tabs>
+
+  </MethodSection>
+</MethodSwitch>


### PR DESCRIPTION
Add MethodSwitch with Customer Portal and REST API tabs to manage-buckets-via-the-control-panel.mdx. API tab covers bucket creation, listing, CORS configuration, public access toggle, lifecycle policy, and deletion via the v4 buckets endpoint. All examples live-tested with curl, Python SDK, and Go SDK.