### PR TITLE
DOC-1780: add Terraform tab to manage-buckets-via-the-control-panel

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -725,11 +725,11 @@
 
 - [Object Storage](https://docs.gcore.com/storage.md): Store and manage data in Gcore Object Storage with S3 Fast, S3 Standard, and SFTP storage types supporting the S3 API and SFTP protocols.
 - [How storage is billed](https://docs.gcore.com/storage/how-storage-is-billed.md): Understand Gcore Object Storage billing - S3 Standard, S3 Fast, and SFTP pricing rates, self-commit plans, and monthly subscription management.
-- [Create an object or SFTP storage](https://docs.gcore.com/storage/create-an-s3-or-sftp-storage.md): Create S3 Standard, S3 Fast, or SFTP storage via the Customer Portal or REST API - includes access key rotation for S3 and password management for SFTP.
+- [Create an object or SFTP storage](https://docs.gcore.com/storage/create-an-s3-or-sftp-storage.md): Create S3 Standard, S3 Fast, or SFTP storage via Customer Portal, REST API, or Terraform - includes S3 access key rotation and SFTP password management.
 - [Storage as a CDN origin](https://docs.gcore.com/storage/use-storage-as-the-origin-for-your-cdn-resource.md): Configure Gcore CDN resources with Object Storage or SFTP storage as origins using bucket paths, storage hostnames, custom domains, and authentication options for public or private buckets.
 
 ## Manage object storage
-- [Managing buckets](https://docs.gcore.com/storage/manage-object-storage/manage-buckets-via-the-control-panel.md): Create and manage S3 buckets via Customer Portal or REST API - configure CORS, public access, and lifecycle policies for automatic object deletion.
+- [Managing buckets](https://docs.gcore.com/storage/manage-object-storage/manage-buckets-via-the-control-panel.md): Create and manage S3 buckets via Customer Portal, REST API, or Terraform - configure CORS, public access, and lifecycle policies for automatic object deletion.
 
 ## Configure AWS CLI, S3cmd, and AWS JavaScript SDK
 - [Connect AWS CLI, S3cmd, and AWS JavaScript SDK](https://docs.gcore.com/storage/manage-object-storage/configure-aws-sli-s3cmd-and-aws-javascript-sdk/connect-aws-cli-s3cmd-and-aws-sdk.md): Install and configure AWS CLI, S3cmd, and AWS JavaScript SDK v2 to connect to Gcore Object Storage using S3-compatible credentials and region endpoints.

--- a/storage/llms.txt
+++ b/storage/llms.txt
@@ -4,11 +4,11 @@
 
 - [Object Storage](https://docs.gcore.com/storage.md): Store and manage data in Gcore Object Storage with S3 Fast, S3 Standard, and SFTP storage types supporting the S3 API and SFTP protocols.
 - [How storage is billed](https://docs.gcore.com/storage/how-storage-is-billed.md): Understand Gcore Object Storage billing - S3 Standard, S3 Fast, and SFTP pricing rates, self-commit plans, and monthly subscription management.
-- [Create an object or SFTP storage](https://docs.gcore.com/storage/create-an-s3-or-sftp-storage.md): Create S3 Standard, S3 Fast, or SFTP storage via the Customer Portal or REST API - includes access key rotation for S3 and password management for SFTP.
+- [Create an object or SFTP storage](https://docs.gcore.com/storage/create-an-s3-or-sftp-storage.md): Create S3 Standard, S3 Fast, or SFTP storage via Customer Portal, REST API, or Terraform - includes S3 access key rotation and SFTP password management.
 - [Storage as a CDN origin](https://docs.gcore.com/storage/use-storage-as-the-origin-for-your-cdn-resource.md): Configure Gcore CDN resources with Object Storage or SFTP storage as origins using bucket paths, storage hostnames, custom domains, and authentication options for public or private buckets.
 
 ## Manage object storage
-- [Managing buckets](https://docs.gcore.com/storage/manage-object-storage/manage-buckets-via-the-control-panel.md): Create and manage S3 buckets via Customer Portal or REST API - configure CORS, public access, and lifecycle policies for automatic object deletion.
+- [Managing buckets](https://docs.gcore.com/storage/manage-object-storage/manage-buckets-via-the-control-panel.md): Create and manage S3 buckets via Customer Portal, REST API, or Terraform - configure CORS, public access, and lifecycle policies for automatic object deletion.
 
 ## Configure AWS CLI, S3cmd, and AWS JavaScript SDK
 - [Connect AWS CLI, S3cmd, and AWS JavaScript SDK](https://docs.gcore.com/storage/manage-object-storage/configure-aws-sli-s3cmd-and-aws-javascript-sdk/connect-aws-cli-s3cmd-and-aws-sdk.md): Install and configure AWS CLI, S3cmd, and AWS JavaScript SDK v2 to connect to Gcore Object Storage using S3-compatible credentials and region endpoints.

--- a/storage/manage-object-storage/manage-buckets-via-the-control-panel.mdx
+++ b/storage/manage-object-storage/manage-buckets-via-the-control-panel.mdx
@@ -1,7 +1,7 @@
 ---
 title: Managing buckets
 sidebarTitle: Manage buckets
-ai-navigation: Create and manage S3 buckets via Customer Portal or REST API - configure CORS, public access, and lifecycle policies for automatic object deletion.
+ai-navigation: Create and manage S3 buckets via Customer Portal, REST API, or Terraform - configure CORS, public access, and lifecycle policies for automatic object deletion.
 ---
 
 import { MethodSwitch, MethodSection } from "/snippets/method-switch.jsx";
@@ -622,6 +622,83 @@ export STORAGE_ID="{YOUR_STORAGE_ID}"
     Returns HTTP 204 with no response body.
   </Tab>
 </Tabs>
+
+  </MethodSection>
+  <MethodSection id="terraform" label="Terraform">
+
+<p>Declare S3 buckets with CORS rules, public access policy, and lifecycle settings using the Gcore [Terraform&nbsp;provider](/developer-tools/terraform/overview) v2.</p>
+
+## Create bucket
+
+<p>Declares a bucket in an existing S3 storage. CORS rules, public access, and lifecycle policy are optional — omit any block to leave that setting unconfigured.</p>
+
+```hcl
+resource "gcore_storage_object_storage_bucket" "example" {
+  storage_id = var.storage_id
+  name       = "my-bucket"
+
+  cors = {
+    allowed_origins = ["https://portal.gcore.com"]
+  }
+
+  policy = {
+    is_public = false
+  }
+
+  storage_object_storage_bucket_lifecycle = {
+    expiration_days = 30
+  }
+}
+
+variable "storage_id" {
+  type = number
+}
+```
+
+```bash
+terraform apply
+```
+
+## Update bucket settings
+
+<p>Edit any field in the resource block and run `terraform apply`. To remove the lifecycle policy, omit the `storage_object_storage_bucket_lifecycle` attribute.</p>
+
+```hcl
+resource "gcore_storage_object_storage_bucket" "example" {
+  storage_id = var.storage_id
+  name       = "my-bucket"
+
+  cors = {
+    allowed_origins = ["https://portal.gcore.com", "https://example.com"]
+  }
+
+  policy = {
+    is_public = true
+  }
+
+  # Omit storage_object_storage_bucket_lifecycle to remove the lifecycle policy
+}
+```
+
+```bash
+terraform apply
+```
+
+## Delete bucket
+
+<p>Remove the resource block — Terraform deletes the bucket and all its objects on the next apply.</p>
+
+```hcl
+# Remove or comment out this block:
+# resource "gcore_storage_object_storage_bucket" "example" {
+#   storage_id = var.storage_id
+#   name       = "my-bucket"
+# }
+```
+
+```bash
+terraform apply
+```
 
   </MethodSection>
 </MethodSwitch>


### PR DESCRIPTION
Covers gcore_storage_object_storage_bucket with create, update (CORS, public access, lifecycle), and delete. Live-tested with terraform apply/destroy. Import not supported by provider.