### PR TITLE
DOC-1781: add Terraform tab to create-and-add-an-ssh-key-to-your-storage

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -725,11 +725,11 @@
 
 - [Object Storage](https://docs.gcore.com/storage.md): Store and manage data in Gcore Object Storage with S3 Fast, S3 Standard, and SFTP storage types supporting the S3 API and SFTP protocols.
 - [How storage is billed](https://docs.gcore.com/storage/how-storage-is-billed.md): Understand Gcore Object Storage billing - S3 Standard, S3 Fast, and SFTP pricing rates, self-commit plans, and monthly subscription management.
-- [Create an object or SFTP storage](https://docs.gcore.com/storage/create-an-s3-or-sftp-storage.md): Create S3 Standard, S3 Fast, or SFTP storage via the Customer Portal or REST API - includes access key rotation for S3 and password management for SFTP.
+- [Create an object or SFTP storage](https://docs.gcore.com/storage/create-an-s3-or-sftp-storage.md): Create S3 Standard, S3 Fast, or SFTP storage via Customer Portal, REST API, or Terraform - includes S3 access key rotation and SFTP password management.
 - [Storage as a CDN origin](https://docs.gcore.com/storage/use-storage-as-the-origin-for-your-cdn-resource.md): Configure Gcore CDN resources with Object Storage or SFTP storage as origins using bucket paths, storage hostnames, custom domains, and authentication options for public or private buckets.
 
 ## Manage object storage
-- [Managing buckets](https://docs.gcore.com/storage/manage-object-storage/manage-buckets-via-the-control-panel.md): Create and manage S3 buckets via Customer Portal or REST API - configure CORS, public access, and lifecycle policies for automatic object deletion.
+- [Managing buckets](https://docs.gcore.com/storage/manage-object-storage/manage-buckets-via-the-control-panel.md): Create and manage S3 buckets via Customer Portal, REST API, or Terraform - configure CORS, public access, and lifecycle policies for automatic object deletion.
 
 ## Configure AWS CLI, S3cmd, and AWS JavaScript SDK
 - [Connect AWS CLI, S3cmd, and AWS JavaScript SDK](https://docs.gcore.com/storage/manage-object-storage/configure-aws-sli-s3cmd-and-aws-javascript-sdk/connect-aws-cli-s3cmd-and-aws-sdk.md): Install and configure AWS CLI, S3cmd, and AWS JavaScript SDK v2 to connect to Gcore Object Storage using S3-compatible credentials and region endpoints.
@@ -740,7 +740,7 @@
 
 ## Manage SFTP storage
 - [FileZilla connection to SFTP storage](https://docs.gcore.com/storage/manage-sftp-storage/connect-to-your-storage-with-filezilla.md): Configure FileZilla SFTP connection to Gcore Storage using SSH File Transfer Protocol on port 2200 with password or SSH key authentication.
-- [SSH key management for SFTP storage](https://docs.gcore.com/storage/manage-sftp-storage/create-and-add-an-ssh-key-to-your-storage.md): Create and assign SSH keys for SFTP storage authentication via Customer Portal or REST API - add, list, and delete keys, then link them to storage.
+- [SSH key management for SFTP storage](https://docs.gcore.com/storage/manage-sftp-storage/create-and-add-an-ssh-key-to-your-storage.md): Create and assign SSH keys for SFTP storage authentication via Customer Portal, REST API, or Terraform - add, list, and delete keys, then link them to storage.
 - [Request content directly from the storage](https://docs.gcore.com/storage/request-content-directly-from-the-storage.md): Request content directly from Object Storage and SFTP Storage using HTTP and HTTPS protocols with the bucket hostname and file path format.
 - [Check storages usage reports](https://docs.gcore.com/storage/check-storages-usage-reports.md): View storage usage statistics via Customer Portal or REST API - retrieve aggregated totals or time-series data for used space, requests, traffic, and objects.
 - [Storage 4xx error troubleshooting](https://docs.gcore.com/storage/4xx-errors-how-to-solve-storage-issues.md): Resolve HTTP 404 and HTTP 403 errors from Gcore Object Storage and SFTP Storage by checking file uploads, request URLs, and ACL rules for public access.

--- a/storage/llms.txt
+++ b/storage/llms.txt
@@ -4,11 +4,11 @@
 
 - [Object Storage](https://docs.gcore.com/storage.md): Store and manage data in Gcore Object Storage with S3 Fast, S3 Standard, and SFTP storage types supporting the S3 API and SFTP protocols.
 - [How storage is billed](https://docs.gcore.com/storage/how-storage-is-billed.md): Understand Gcore Object Storage billing - S3 Standard, S3 Fast, and SFTP pricing rates, self-commit plans, and monthly subscription management.
-- [Create an object or SFTP storage](https://docs.gcore.com/storage/create-an-s3-or-sftp-storage.md): Create S3 Standard, S3 Fast, or SFTP storage via the Customer Portal or REST API - includes access key rotation for S3 and password management for SFTP.
+- [Create an object or SFTP storage](https://docs.gcore.com/storage/create-an-s3-or-sftp-storage.md): Create S3 Standard, S3 Fast, or SFTP storage via Customer Portal, REST API, or Terraform - includes S3 access key rotation and SFTP password management.
 - [Storage as a CDN origin](https://docs.gcore.com/storage/use-storage-as-the-origin-for-your-cdn-resource.md): Configure Gcore CDN resources with Object Storage or SFTP storage as origins using bucket paths, storage hostnames, custom domains, and authentication options for public or private buckets.
 
 ## Manage object storage
-- [Managing buckets](https://docs.gcore.com/storage/manage-object-storage/manage-buckets-via-the-control-panel.md): Create and manage S3 buckets via Customer Portal or REST API - configure CORS, public access, and lifecycle policies for automatic object deletion.
+- [Managing buckets](https://docs.gcore.com/storage/manage-object-storage/manage-buckets-via-the-control-panel.md): Create and manage S3 buckets via Customer Portal, REST API, or Terraform - configure CORS, public access, and lifecycle policies for automatic object deletion.
 
 ## Configure AWS CLI, S3cmd, and AWS JavaScript SDK
 - [Connect AWS CLI, S3cmd, and AWS JavaScript SDK](https://docs.gcore.com/storage/manage-object-storage/configure-aws-sli-s3cmd-and-aws-javascript-sdk/connect-aws-cli-s3cmd-and-aws-sdk.md): Install and configure AWS CLI, S3cmd, and AWS JavaScript SDK v2 to connect to Gcore Object Storage using S3-compatible credentials and region endpoints.
@@ -19,7 +19,7 @@
 
 ## Manage SFTP storage
 - [FileZilla connection to SFTP storage](https://docs.gcore.com/storage/manage-sftp-storage/connect-to-your-storage-with-filezilla.md): Configure FileZilla SFTP connection to Gcore Storage using SSH File Transfer Protocol on port 2200 with password or SSH key authentication.
-- [SSH key management for SFTP storage](https://docs.gcore.com/storage/manage-sftp-storage/create-and-add-an-ssh-key-to-your-storage.md): Create and assign SSH keys for SFTP storage authentication via Customer Portal or REST API - add, list, and delete keys, then link them to storage.
+- [SSH key management for SFTP storage](https://docs.gcore.com/storage/manage-sftp-storage/create-and-add-an-ssh-key-to-your-storage.md): Create and assign SSH keys for SFTP storage authentication via Customer Portal, REST API, or Terraform - add, list, and delete keys, then link them to storage.
 - [Request content directly from the storage](https://docs.gcore.com/storage/request-content-directly-from-the-storage.md): Request content directly from Object Storage and SFTP Storage using HTTP and HTTPS protocols with the bucket hostname and file path format.
 - [Check storages usage reports](https://docs.gcore.com/storage/check-storages-usage-reports.md): View storage usage statistics via Customer Portal or REST API - retrieve aggregated totals or time-series data for used space, requests, traffic, and objects.
 - [Storage 4xx error troubleshooting](https://docs.gcore.com/storage/4xx-errors-how-to-solve-storage-issues.md): Resolve HTTP 404 and HTTP 403 errors from Gcore Object Storage and SFTP Storage by checking file uploads, request URLs, and ACL rules for public access.

--- a/storage/manage-sftp-storage/create-and-add-an-ssh-key-to-your-storage.mdx
+++ b/storage/manage-sftp-storage/create-and-add-an-ssh-key-to-your-storage.mdx
@@ -1,7 +1,7 @@
 ---
 title: SSH key management for SFTP storage
 sidebarTitle: SSH keys
-ai-navigation: Create and assign SSH keys for SFTP storage authentication via Customer Portal or REST API - add, list, and delete keys, then link them to storage.
+ai-navigation: Create and assign SSH keys for SFTP storage authentication via Customer Portal, REST API, or Terraform - add, list, and delete keys, then link them to storage.
 ---
 
 import { MethodSwitch, MethodSection } from "/snippets/method-switch.jsx";
@@ -322,6 +322,67 @@ export GCORE_API_KEY="{YOUR_API_KEY}"
     Returns HTTP 204 with no response body.
   </Tab>
 </Tabs>
+
+  </MethodSection>
+  <MethodSection id="terraform" label="Terraform">
+
+<p>Declare SSH keys for SFTP storage authentication using the Gcore [Terraform&nbsp;provider](/developer-tools/terraform/overview) v2.</p>
+
+## Add an SSH key
+
+<p>Registers a public key in the account-level registry. Supported formats are `ssh-rsa` and `ssh-ed25519`. Changing the key name recreates the resource — the old key is deleted and a new one is created in its place.</p>
+
+```hcl
+resource "gcore_storage_ssh_key" "example" {
+  name       = "my-ssh-key"
+  public_key = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAA... user@host"
+}
+
+output "ssh_key_id" {
+  value = gcore_storage_ssh_key.example.id
+}
+
+# terraform import gcore_storage_ssh_key.example '<ssh_key_id>'
+```
+
+```bash
+terraform apply
+```
+
+## Assign keys to SFTP storage
+
+<p>Pass key IDs in the `ssh_key_ids` attribute of a `gcore_storage_sftp` resource. The list replaces all existing assignments — include every key that should remain active. Up to five keys are allowed per storage.</p>
+
+```hcl
+resource "gcore_storage_sftp" "example" {
+  location_name = "ams"
+  name          = "my-sftp-storage"
+  password_mode = "none"
+  ssh_key_ids   = [gcore_storage_ssh_key.example.id]
+}
+```
+
+```bash
+terraform apply
+```
+
+<p>To remove all key assignments, set `ssh_key_ids = []` and apply.</p>
+
+## Delete an SSH key
+
+<p>Remove the resource block — Terraform deletes the key from the account registry on the next apply. Keys assigned to any SFTP storage are automatically unlinked before deletion.</p>
+
+```hcl
+# Remove or comment out this block:
+# resource "gcore_storage_ssh_key" "example" {
+#   name       = "my-ssh-key"
+#   public_key = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAA... user@host"
+# }
+```
+
+```bash
+terraform apply
+```
 
   </MethodSection>
 </MethodSwitch>


### PR DESCRIPTION
Covers gcore_storage_ssh_key (add, delete) and ssh_key_ids on gcore_storage_sftp for assignment. Live-tested with apply/destroy. Key name change forces resource replacement.