### PR TITLE
docs: read API specs from directory with specs enriched with code samples

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1646,63 +1646,63 @@
           {
             "group": "IAM",
             "openapi": {
-              "source": "api-reference/services_docs_mintlify/iam_api.yaml",
+              "source": "api-reference/services_docs_mintlify_enriched/iam_api.yaml",
               "directory": "api-reference/iam"
             }
           },
           {
             "group": "CDN",
             "openapi": {
-              "source": "api-reference/services_docs_mintlify/cdn_api.yaml",
+              "source": "api-reference/services_docs_mintlify_enriched/cdn_api.yaml",
               "directory": "api-reference/cdn"
             }
           },
           {
             "group": "Managed DNS",
             "openapi": {
-              "source": "api-reference/services_docs_mintlify/dns_api.yaml",
+              "source": "api-reference/services_docs_mintlify_enriched/dns_api.yaml",
               "directory": "api-reference/dns"
             }
           },
           {
             "group": "Cloud",
             "openapi": {
-              "source": "api-reference/services_docs_mintlify/cloud_api.yaml",
+              "source": "api-reference/services_docs_mintlify_enriched/cloud_api.yaml",
               "directory": "api-reference/cloud"
             }
           },
           {
             "group": "DDoS Protection",
             "openapi": {
-              "source": "api-reference/services_docs_mintlify/ddos_protection_api.yaml",
+              "source": "api-reference/services_docs_mintlify_enriched/ddos_protection_api.yaml",
               "directory": "api-reference/ddos-protection"
             }
           },
           {
             "group": "FastEdge",
             "openapi": {
-              "source": "api-reference/services_docs_mintlify/fastedge_api.yaml",
+              "source": "api-reference/services_docs_mintlify_enriched/fastedge_api.yaml",
               "directory": "api-reference/fastedge"
             }
           },
           {
             "group": "WAAP",
             "openapi": {
-              "source": "api-reference/services_docs_mintlify/waap_api.yaml",
+              "source": "api-reference/services_docs_mintlify_enriched/waap_api.yaml",
               "directory": "api-reference/waap"
             }
           },
           {
             "group": "Streaming",
             "openapi": {
-              "source": "api-reference/services_docs_mintlify/streaming_api.yaml",
+              "source": "api-reference/services_docs_mintlify_enriched/streaming_api.yaml",
               "directory": "api-reference/streaming"
             }
           },
           {
             "group": "Object Storage",
             "openapi": {
-              "source": "api-reference/services_docs_mintlify/object_storage_api.yaml",
+              "source": "api-reference/services_docs_mintlify_enriched/object_storage_api.yaml",
               "directory": "api-reference/storage"
             }
           },
@@ -1712,42 +1712,42 @@
               {
                 "group": "Billing",
                 "openapi": {
-                  "source": "api-reference/services_docs_mintlify/billing_reseller_api.yaml",
+                  "source": "api-reference/services_docs_mintlify_enriched/billing_reseller_api.yaml",
                   "directory": "api-reference/billing"
                 }
               },
               {
                 "group": "IAM",
                 "openapi": {
-                  "source": "api-reference/services_docs_mintlify/iam_reseller_api.yaml",
+                  "source": "api-reference/services_docs_mintlify_enriched/iam_reseller_api.yaml",
                   "directory": "api-reference/iam-resellers"
                 }
               },
               {
                 "group": "CDN",
                 "openapi": {
-                  "source": "api-reference/services_docs_mintlify/cdn_reseller_api.yaml",
+                  "source": "api-reference/services_docs_mintlify_enriched/cdn_reseller_api.yaml",
                   "directory": "api-reference/cdn-resellers"
                 }
               },
               {
                 "group": "Cloud",
                 "openapi": {
-                  "source": "api-reference/services_docs_mintlify/cloud_reseller_api.yaml",
+                  "source": "api-reference/services_docs_mintlify_enriched/cloud_reseller_api.yaml",
                   "directory": "api-reference/cloud-resellers"
                 }
               },
               {
                 "group": "FastEdge",
                 "openapi": {
-                  "source": "api-reference/services_docs_mintlify/fastedge_reseller_api.yaml",
+                  "source": "api-reference/services_docs_mintlify_enriched/fastedge_reseller_api.yaml",
                   "directory": "api-reference/fastedge-resellers"
                 }
               },
               {
                 "group": "WAAP",
                 "openapi": {
-                  "source": "api-reference/services_docs_mintlify/waap_reseller_api.yaml",
+                  "source": "api-reference/services_docs_mintlify_enriched/waap_reseller_api.yaml",
                   "directory": "api-reference/waap-resellers"
                 }
               }


### PR DESCRIPTION
## Problem

`docs.json` reads all OpenAPI specs from `api-reference/services_docs_mintlify/` — the **tier-2** directory, which has **no code samples**. The api-schemas docs flow produces an enriched **tier-3** directory (`services_docs_mintlify_enriched/`) with Stainless code samples (Python/Go/CLI) injected — currently ~58% operation coverage — and that is the tier meant to feed gcore.com/docs.

## Change

- Repoint all **15** OpenAPI `source` paths in `docs.json`:
  `api-reference/services_docs_mintlify/…` → `api-reference/services_docs_mintlify_enriched/…`

## Paired change (required)

`G-Core/api-schemas#169` switches the **push-to-product-documentation** step to ship the enriched tier-3 directory, so `api-reference/services_docs_mintlify_enriched/` starts getting populated/updated here. The `copy_file_to_another_repo_action` names the landed folder after the source basename, so the enriched dir lands as a sibling of the current one.

**Ordering:** merge this before or together with api-schemas#169. Until #169's own prerequisites are met (the `GCORE_OPENAPI_READ_TOKEN` secret and `G-Core/stlc#2`), enrichment is best-effort; the enriched specs already exist and carry samples today.

## Follow-up (not in this PR)

The old `api-reference/services_docs_mintlify/` becomes stale after the switch — cleanup deferred.
