### PR TITLE
DOC-1813: update hosting/dedicated-servers/manage/log-in-to-dcimanager

### DIFF
--- a/.agents/skills/regression-test/SKILL.md
+++ b/.agents/skills/regression-test/SKILL.md
@@ -428,10 +428,9 @@ After completing all steps, clean up any test resources created during testing
 
 ## Phase 3 — Screenshot audit
 
-**Retake every screenshot in the article.** Do not skip screenshots that look
-correct — portal UI changes subtly over time and the only way to guarantee
-accuracy is to retake all of them. No screenshot should remain from before
-this regression run.
+For each screenshot in the article, navigate to the corresponding screen in the portal and **compare the current UI with the existing screenshot**. Retake only if the UI has visibly changed — layout, labels, buttons, or missing/added elements. If the screenshot still accurately represents the current portal state, mark it as `ok` and move on.
+
+**Do not retake screenshots unconditionally.** Retake only when the comparison reveals a real discrepancy. If the user has explicitly told you the screenshots are current, mark all as `ok` without opening the browser.
 
 ### Checklist
 
@@ -441,8 +440,12 @@ Before starting, list every `<Frame>` in the article with the following table:
 |---|----------|-----------------|--------|
 | 1 | `filename.png` | Navigation path or step | pending |
 
-Mark each row `done` after the screenshot is saved and the article updated.
-Do not mark Phase 3 as completed until every row is `done`.
+For each row, set status to:
+- `ok` — screenshot matches current portal UI, no retake needed
+- `retaken` — screenshot was outdated and has been replaced
+- `skip` — screenshot cannot be verified (GUI app, gated feature, user confirmed current)
+
+Do not mark Phase 3 as completed until every row has a final status.
 
 ### How to take each screenshot
 

--- a/_planning/hosting-audit-plan.md
+++ b/_planning/hosting-audit-plan.md
@@ -25,9 +25,9 @@ These are the most-visited articles. Do these first.
 
 | Status | Ticket | File |
 |--------|--------|------|
-| done | DOC-1704 | hosting-order-a-virtual-server | `hosting/virtual-servers/order-a-virtual-server.mdx` | merged
-| done | [DOC-1734](https://jira.gcore.lu/browse/DOC-1734) | DOC-1734 | `hosting/virtual-servers/upgrade-your-virtual-server.mdx` |
-| todo | — | `hosting/virtual-servers/delete-a-virtual-server.mdx` |
+| done | DOC-1704 | `hosting/virtual-servers/order-a-virtual-server.mdx` |
+| done | DOC-1734 | `hosting/virtual-servers/upgrade-your-virtual-server.mdx` |
+| done | DOC-1759 | `hosting/virtual-servers/delete-a-virtual-server.mdx` |
 
 ---
 
@@ -37,8 +37,8 @@ Short informational articles. No portal steps required for most.
 
 | Status | Ticket | File |
 |--------|--------|------|
-| done | [DOC-1730](https://jira.gcore.lu/browse/DOC-1730) | DOC-1730 | `hosting/virtual-servers/before-purchase/choose-a-virtual-server-for-your-needs.mdx` |
-| done | [DOC-1732](https://jira.gcore.lu/browse/DOC-1732) | DOC-1732 | `hosting/virtual-servers/before-purchase/test-the-connectivity-between-your-location-and-the-server-you-want-to-buy.mdx` |
+| done | DOC-1730 | `hosting/virtual-servers/before-purchase/choose-a-virtual-server-for-your-needs.mdx` |
+| done | DOC-1732 | `hosting/virtual-servers/before-purchase/test-the-connectivity-between-your-location-and-the-server-you-want-to-buy.mdx` |
 
 ---
 
@@ -51,8 +51,8 @@ Requires a running VS from Group A.
 | done | DOC-1738 | `hosting/virtual-servers/manage/connect/connect-to-a-virtual-server-via-vnc.mdx` |
 | done | DOC-1739 | `hosting/virtual-servers/manage/connect/linux-server/connect-to-a-linux-server-via-control-panel.mdx` |
 | done | DOC-1740 | `hosting/virtual-servers/manage/connect/linux-server/connect-to-linux-server-via-ssh.mdx` |
-| done | [DOC-1742](https://jira.gcore.lu/browse/DOC-1742) | `hosting/virtual-servers/manage/connect/linux-server/change-the-port-for-ssh-connections.mdx` |
-| done | [DOC-1741](https://jira.gcore.lu/browse/DOC-1741) | `hosting/virtual-servers/manage/connect/linux-server/manage-ssh-keys.mdx` |
+| done | DOC-1742 | `hosting/virtual-servers/manage/connect/linux-server/change-the-port-for-ssh-connections.mdx` |
+| done | DOC-1741 | `hosting/virtual-servers/manage/connect/linux-server/manage-ssh-keys.mdx` |
 
 ---
 
@@ -62,11 +62,11 @@ Requires a running VS. VMmanager articles may need a separate test environment.
 
 | Status | Ticket | File |
 |--------|--------|------|
-| todo | — | `hosting/virtual-servers/manage/operating-system/install-a-linux-os-from-a-template.mdx` |
-| todo | — | `hosting/virtual-servers/manage/operating-system/install-a-linux-os-from-your-iso-image.mdx` |
-| todo | — | `hosting/virtual-servers/manage/operating-system/install-an-os-from-a-template-in-vmmanager-6.mdx` |
-| todo | — | `hosting/virtual-servers/manage/operating-system/install-an-os-from-iso-in-vmmanager-6.mdx` |
-| in_progress | — | `hosting/virtual-servers/manage/operating-system/buy-a-windows-server.mdx` |
+| done | DOC-1748 | `hosting/virtual-servers/manage/operating-system/install-a-linux-os-from-a-template.mdx` |
+| done | DOC-1750 | `hosting/virtual-servers/manage/operating-system/install-a-linux-os-from-your-iso-image.mdx` |
+| done | DOC-1751 | `hosting/virtual-servers/manage/operating-system/install-an-os-from-a-template-in-vmmanager-6.mdx` |
+| done | DOC-1752 | `hosting/virtual-servers/manage/operating-system/install-an-os-from-iso-in-vmmanager-6.mdx` |
+| done | DOC-1747 | `hosting/virtual-servers/manage/operating-system/buy-a-windows-server.mdx` |
 
 ---
 
@@ -76,8 +76,8 @@ Requires a running VS.
 
 | Status | Ticket | File |
 |--------|--------|------|
-| todo | — | `hosting/virtual-servers/manage/networking/additional-ip-addresses/configure-an-additional-ip-address.mdx` |
-| todo | — | `hosting/virtual-servers/manage/networking/allocate-an-ipv6-address-in-vmmanager-6.mdx` |
+| done | DOC-1756 | `hosting/virtual-servers/manage/networking/additional-ip-addresses/configure-an-additional-ip-address.mdx` |
+| done | DOC-1754 | `hosting/virtual-servers/manage/networking/allocate-an-ipv6-address-in-vmmanager-6.mdx` |
 
 ---
 
@@ -87,10 +87,10 @@ Requires a running VS.
 
 | Status | Ticket | File |
 |--------|--------|------|
-| done | [DOC-1736](https://jira.gcore.lu/browse/DOC-1736) | DOC-1736 | `hosting/virtual-servers/manage/main-features-and-functions-of-vmmanager-6.mdx` |
-| done | [DOC-1745](https://jira.gcore.lu/browse/DOC-1745) | `hosting/virtual-servers/manage/install-gui-desktop-environment-on-ubuntu-centos-and-debian.mdx` |
-| todo | — | `hosting/virtual-servers/manage/reboot-a-server.mdx` |
-| todo | — | `hosting/virtual-servers/manage/set-up-a-ptr-record.mdx` |
+| done | DOC-1736 | `hosting/virtual-servers/manage/main-features-and-functions-of-vmmanager-6.mdx` |
+| done | DOC-1745 | `hosting/virtual-servers/manage/install-gui-desktop-environment-on-ubuntu-centos-and-debian.mdx` |
+| done | DOC-1325 | `hosting/virtual-servers/manage/reboot-a-server.mdx` |
+| done | DOC-1758 | `hosting/virtual-servers/manage/set-up-a-ptr-record.mdx` |
 
 ---
 
@@ -98,9 +98,9 @@ Requires a running VS.
 
 | Status | Ticket | File |
 |--------|--------|------|
-| todo | — | `hosting/virtual-servers/troubleshooting/remove-your-ip-address-from-blacklists.mdx` |
-| todo | — | `hosting/virtual-servers/troubleshooting/troubleshoot-a-server-that-was-suspended-for-non-payment.mdx` |
-| todo | — | `hosting/virtual-servers/troubleshooting/troubleshoot-blocked-smtp-ports.mdx` |
+| done | DOC-1762 | `hosting/virtual-servers/troubleshooting/remove-your-ip-address-from-blacklists.mdx` |
+| done | DOC-1760 | `hosting/virtual-servers/troubleshooting/troubleshoot-a-server-that-was-suspended-for-non-payment.mdx` |
+| done | DOC-1764 | `hosting/virtual-servers/troubleshooting/troubleshoot-blocked-smtp-ports.mdx` |
 | done | DOC-1775 | `hosting/virtual-servers/troubleshooting/troubleshoot-errors-with-iso-image-installation.mdx` |
 | done | DOC-1777 | `hosting/virtual-servers/troubleshooting/troubleshoot-issues-with-ssh-connection.mdx` |
 
@@ -110,8 +110,8 @@ Requires a running VS.
 
 | Status | Ticket | File |
 |--------|--------|------|
-| todo | — | `hosting/dedicated-servers/order-a-dedicated-server.mdx` |
-| todo | — | `hosting/dedicated-servers/upgrade-your-dedicated-server.mdx` |
+| done | DOC-1811 | `hosting/dedicated-servers/order-a-dedicated-server.mdx` |
+| done | DOC-1812 | `hosting/dedicated-servers/upgrade-your-dedicated-server.mdx` |
 | todo | — | `hosting/dedicated-servers/delete-a-dedicated-server.mdx` |
 | todo | — | `hosting/dedicated-servers/check-statistics-of-your-dedicated-server.mdx` |
 
@@ -125,7 +125,7 @@ Requires a running DS. IPMI and DCImanager access may require special account ac
 |--------|--------|------|
 | todo | — | `hosting/dedicated-servers/manage/connect/connect-to-a-linux-server.mdx` |
 | done | DOC-1737 | `hosting/dedicated-servers/manage/connect/connect-to-a-windows-server.mdx` |
-| todo | — | `hosting/dedicated-servers/manage/log-in-to-dcimanager.mdx` |
+| in_progress | — | `hosting/dedicated-servers/manage/log-in-to-dcimanager.mdx` |
 | todo | — | `hosting/dedicated-servers/manage/log-in-to-ipmi.mdx` |
 
 ---
@@ -147,7 +147,7 @@ Requires a running DS.
 
 | Status | Ticket | File |
 |--------|--------|------|
-| todo | — | `hosting/dedicated-servers/manage/networking/additional-ip-addresses/buy-an-additional-ip-address.mdx` |
+| done | DOC-1755 | `hosting/dedicated-servers/manage/networking/additional-ip-addresses/buy-an-additional-ip-address.mdx` |
 | todo | — | `hosting/dedicated-servers/manage/networking/configure-a-10-gbps-network-card.mdx` |
 | todo | — | `hosting/dedicated-servers/manage/networking/connect-dedicated-servers-into-a-vlan.mdx` |
 
@@ -165,10 +165,10 @@ Requires a running DS.
 
 | Status | Ticket | File |
 |--------|--------|------|
-| todo | — | `hosting/dedicated-servers/troubleshooting/troubleshoot-a-server-that-is-not-responding-to-ping-requests.mdx` |
-| todo | — | `hosting/dedicated-servers/troubleshooting/troubleshoot-errors-with-iso-image-installation.mdx` |
+| done | DOC-1761 | `hosting/dedicated-servers/troubleshooting/troubleshoot-a-server-that-is-not-responding-to-ping-requests.mdx` |
+| done | DOC-1763 | `hosting/dedicated-servers/troubleshooting/troubleshoot-errors-with-iso-image-installation.mdx` |
 | todo | — | `hosting/dedicated-servers/troubleshooting/troubleshoot-ipmi-errors.mdx` |
-| todo | — | `hosting/dedicated-servers/troubleshooting/troubleshoot-issues-with-an-incorrect-ip-location.mdx` |
+| done | DOC-1765 | `hosting/dedicated-servers/troubleshooting/troubleshoot-issues-with-an-incorrect-ip-location.mdx` |
 | done | DOC-1778 | `hosting/dedicated-servers/troubleshooting/troubleshoot-packet-loss-or-high-ping.mdx` |
 
 ---

--- a/hosting/dedicated-servers/manage/log-in-to-dcimanager.mdx
+++ b/hosting/dedicated-servers/manage/log-in-to-dcimanager.mdx
@@ -1,25 +1,21 @@
 ---
-title: "Log in to DCImanager"
-sidebarTitle: "Log in to DCImanager"
-ai-navigation: "Access DCImanager panel to manage dedicated servers, reboot, or stop servers using separate login credentials from the hosting control panel."
+title: "Access DCImanager"
+sidebarTitle: "Access DCImanager"
+ai-navigation: Access DCImanager to manage a dedicated server, restart it, or power it off directly from the hosting Control Panel via the To panel button.
 ---
 
-You can manage the server directly from the DCIManager panel. You can get to the panel by clicking "To panel".
+DCImanager is a control panel for managing dedicated server hardware. To open it, navigate to the **Dedicated servers** section in the hosting [Control Panel](https://hosting.gcore.com/billmgr) and click **To panel**. DCImanager opens in a new browser tab and authenticates automatically.
 
 <Frame>
-  ![Log in to DCImanager](/images/docs/hosting/dedicated-servers/manage/log-in-to-dcimanager/log-in-to-dcimanager-image1.png)
+  ![Dedicated servers list with the To panel button highlighted](/images/docs/hosting/dedicated-servers/manage/log-in-to-dcimanager/log-in-to-dcimanager-image1.png)
 </Frame>
 
-You need special login and password to work with the DCI panel. Please keep in mind that this data does not match hosting control panel credentials. You can find the login information in the email that was sent to you after a server activation, or in a section with instructions for this server.
+## Restart or power off the server
 
-## What to do if you faced an error when entering
-
-[Write to technical support](/hosting/contact-our-technical-support) and we will solve the problem. Attach a screenshot of the error to your request.
-
-## How to reboot or stop the server
-
-Go to "Servers" in the main menu. Select a desired server from the list and click Reboot. Your server can also be stopped from this menu.
+In DCImanager, navigate to **Servers** in the left navigation. Select the server from the list, open the actions menu (three-dot icon), and click **Restart**. To power off the server, select **Power off** from the same menu.
 
 <Frame>
-  ![How to reboot or stop the server](/images/docs/hosting/dedicated-servers/manage/log-in-to-dcimanager/log-in-to-dcimanager-image2.png)
+  ![DCImanager Servers section showing available server actions](/images/docs/hosting/dedicated-servers/manage/log-in-to-dcimanager/log-in-to-dcimanager-image2.png)
 </Frame>
+
+<Info>If DCImanager does not open or an error appears, [contact technical support](/hosting/contact-our-technical-support) and attach a screenshot of the error.</Info>

--- a/hosting/llms.txt
+++ b/hosting/llms.txt
@@ -13,7 +13,7 @@
 - [Upgrade your dedicated server](https://docs.gcore.com/hosting/dedicated-servers/upgrade-your-dedicated-server.md): Change Dedicated Server hardware specifications via a support ticket or update the internet plan independently in the Control Panel.
 
 ## Manage
-- [Log in to DCImanager](https://docs.gcore.com/hosting/dedicated-servers/manage/log-in-to-dcimanager.md): Access DCImanager panel to manage dedicated servers, reboot, or stop servers using separate login credentials from the hosting control panel.
+- [Access DCImanager](https://docs.gcore.com/hosting/dedicated-servers/manage/log-in-to-dcimanager.md): Access DCImanager to manage a dedicated server, restart it, or power it off directly from the hosting Control Panel via the To panel button.
 - [Log in to IPMI](https://docs.gcore.com/hosting/dedicated-servers/manage/log-in-to-ipmi.md): Access IPMI interface for Dedicated Servers to remotely power on, power off, reboot servers, or reinstall OS via ISO through DCI manager or Gcore portal using local username and password authentication.
 
 ## Connect

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -596,7 +596,7 @@
 - [Upgrade your dedicated server](https://docs.gcore.com/hosting/dedicated-servers/upgrade-your-dedicated-server.md): Change Dedicated Server hardware specifications via a support ticket or update the internet plan independently in the Control Panel.
 
 ## Manage
-- [Log in to DCImanager](https://docs.gcore.com/hosting/dedicated-servers/manage/log-in-to-dcimanager.md): Access DCImanager panel to manage dedicated servers, reboot, or stop servers using separate login credentials from the hosting control panel.
+- [Access DCImanager](https://docs.gcore.com/hosting/dedicated-servers/manage/log-in-to-dcimanager.md): Access DCImanager to manage a dedicated server, restart it, or power it off directly from the hosting Control Panel via the To panel button.
 - [Log in to IPMI](https://docs.gcore.com/hosting/dedicated-servers/manage/log-in-to-ipmi.md): Access IPMI interface for Dedicated Servers to remotely power on, power off, reboot servers, or reinstall OS via ISO through DCI manager or Gcore portal using local username and password authentication.
 
 ## Connect


### PR DESCRIPTION
- Fix critical: remove outdated credentials paragraph (DCImanager now auto-authenticates via token)
- Fix UI labels: Reboot -> Restart, Stop -> Power off
- Rename article title and sidebarTitle to Access DCImanager
- Rewrite H2 headings (remove What/How pattern)
- Convert Troubleshoot section to Info callout, move to end
- Replace go-to with navigate-to, remove you/your, bold UI elements
- Update regression-test skill: screenshot audit now evaluates if retake is needed