### PR TITLE
Fix encoding issue in cms-protection API tab description

### DIFF
--- a/waap/waap-policies/cms-protection.mdx
+++ b/waap/waap-policies/cms-protection.mdx
@@ -85,7 +85,7 @@ We recommend disabling policies for Content Management Systems that you don't us
 </MethodSection>
 <MethodSection id="api" label="REST API">
 
-<p>The [Policies](/api-reference/waap#policies) endpoints manage CMS Protection rules ? preventing WAAP from blocking legitimate CMS admin activity. A firewall allowlist rule can also be created for an admin's static IP address. Response examples include only the fields used in each step.</p>
+<p>The [Policies](/api-reference/waap#policies) endpoints manage CMS Protection rules - preventing WAAP from blocking legitimate CMS admin activity. A firewall allowlist rule can also be created for an admin's static IP address. Response examples include only the fields used in each step.</p>
 
 <Info>
 An [API token](/account-settings/api-tokens) is required, along with the ID of a [WAAP-protected domain](/waap/getting-started/configure-waap-for-a-domain) and the [Python](/developer-tools/sdks/python) or [Go](/developer-tools/sdks/go) SDK installed for SDK examples. CMS Protection policies require a Pro or Enterprise WAAP plan. IP allowlist rules are available on all plans.


### PR DESCRIPTION
Replace corrupted character with hyphen in Policies endpoints description.