### PR TITLE
DOC-1508: fix outdated API-only claim and Mojibake em-dashes

### DIFF
--- a/waap/waap-rules/advanced-rules.mdx
+++ b/waap/waap-rules/advanced-rules.mdx
@@ -14,8 +14,6 @@ Similarly to WAAP [custom rules](/waap/waap-rules/custom-rules), you can create,
 
 ## Create advanced rules
 
-Due to the highly technical aspect of the advanced rules functionality, the ability to create and edit these rules is currently only available through our API.
-
 Check out the following guides for details on how to create advanced rules and their key components:
 
 - [API docs](https://api.gcore.com/docs/waap): Learn how to construct and manage advanced rules.
@@ -60,7 +58,7 @@ The advanced rule object contains the following properties:
 <Info>
   **Info**
 
-  Each rule can contain only one action ΓÇö `block`, `allow`, `captcha`, `handshake`, or `tag`. If you use multiple actions in a single rule, the API will return an error.
+  Each rule can contain only one action — `block`, `allow`, `captcha`, `handshake`, or `tag`. If you use multiple actions in a single rule, the API will return an error.
 </Info>
 
 <Accordion title="Description of the properties">
@@ -657,7 +655,7 @@ Retrieve all advanced rules configured for a domain, including their current ena
     rules = client.waap.domains.advanced_rules.list(domain_id)
     for rule in rules:
         status = "enabled" if rule.enabled else "disabled"
-        print(f"{rule.id}: {rule.name} [{status}] ΓÇö {rule.source[:60]}")
+        print(f"{rule.id}: {rule.name} [{status}] — {rule.source[:60]}")
     ```
   </Tab>
   <Tab title="Go SDK">


### PR DESCRIPTION
- Remove 'currently only available through our API' sentence from Create advanced rules section — portal UI now supports create/edit per DOC-1361
- Fix ΓÇö -> — in Advanced rule properties Info block (prose)
- Fix ΓÇö -> — in List rules Python SDK code block (print statement)