### PR TITLE
docs(account-settings): re-audit status page article for style compli…

### DIFF
--- a/account-settings/be-aware-of-the-service-status-scheduled-and-emergency-maintenance.mdx
+++ b/account-settings/be-aware-of-the-service-status-scheduled-and-emergency-maintenance.mdx
@@ -16,6 +16,8 @@ Then select a subscription method: email, Slack, or webhook.
 
 ### Email
 
+To subscribe by email:
+
 1. Enter an email address in the **Email Address** field, then click **Subscribe via email**.
 
 2. This redirects to the subscription management page.
@@ -28,7 +30,9 @@ Then select a subscription method: email, Slack, or webhook.
 
 ### Slack
 
-#### Unsubscribe from the old Slack integration
+Slack notifications route through an app added to the workspace; accounts still using the previous Status Page version need to remove the old integration before setting up the new one.
+
+#### Old Slack integration removal
 
 To correctly configure notifications from the current Status Page, disable notifications from the previous version first: 
 
@@ -60,11 +64,13 @@ To correctly configure notifications from the current Status Page, disable notif
 
 10. Continue to the next section to integrate this channel with the current Status Page. 
 
-#### Subscribe via Slack
+#### New Slack integration setup
 
-<Frame>![Subscribe via Slack](/images/docs/account-settings/status-page/slack-70.png)</Frame>
+To connect the current Status Page to a Slack workspace:
 
 1. Click **Subscribe via Slack**.
+
+<Frame>![Subscribe via Slack](/images/docs/account-settings/status-page/slack-70.png)</Frame>
 
 2. Enter the Slack workspace URL.
 
@@ -96,11 +102,13 @@ Slack confirms the setup and redirects automatically to the subscription managem
 
 ### Webhook
 
-<Frame>![Permission to access](/images/docs/account-settings/status-page/webhook-120.png)</Frame>
+A webhook subscription requires a URL that Status Page can send update requests to.
 
 1. Enter the URL for sending notifications in the first field. 
 
 2. In the second field, specify an email address to use if the URL is unavailable. 
+
+<Frame>![Permission to access](/images/docs/account-settings/status-page/webhook-120.png)</Frame>
 
 3. Click **Subscribe**. 
 
@@ -113,6 +121,8 @@ Slack confirms the setup and redirects automatically to the subscription managem
 7. Manage the subscription by clicking **Manage your subscription**, then select the components to receive status information for and click **Save**. 
 
 ## Subscription management
+
+Existing subscriptions are changed or cancelled from links in the notifications Status Page already sends, regardless of the delivery channel.
 
 ### Email management
 
@@ -146,7 +156,9 @@ The subscription can be changed from any notification sent to the URL specified 
 
 3. Edit the component subscription, then click **Save**.
 
-### Cancel a subscription
+### Subscription cancellation
+
+To stop receiving all Status Page updates:
 
 1. Open the subscription management page and click **Unsubscribe from the updates**. 
 
@@ -160,30 +172,28 @@ The Updates component, under Releases, lists Gcore releases biweekly. The Websit
 
 ### Component statuses
 
+Each component reports one of four statuses.
+
+| Status | Description |
+|--------|--------------|
+| Operational | The component is operating normally |
+| Partial Outage | The component is partially unavailable |
+| Major Outage | The component is completely unavailable |
+| Under Maintenance | The component is under maintenance |
+
 <Frame>![Component statuses](/images/docs/account-settings/status-page/components-140.png)</Frame>
-
-**Operational**: the component is operating normally. 
-
-**Partial Outage**: the component is partially unavailable. 
-
-**Major Outage**: the component is completely unavailable. 
-
-**Under Maintenance**: the component is in the process of maintenance. 
 
 ### Notification types
 
-**Incident | Investigating**: a notification about the component partial or complete outage, the incident is under investigation. 
+Status Page sends eight notification types, covering incident stages and maintenance stages.
 
-**Incident | Identified**: the details of the incident have been detected; we are taking steps to resolve it. 
-
-**Incident | Monitoring**: the incident has been resolved, and the component is under monitoring. 
-
-**Incident | Resolved**: the incident has been completely resolved. 
-
-**Incident | Retrospective**: notification of the incident that has already occurred. 
-
-**Maintenance | Scheduled**: notification of upcoming scheduled works. 
-
-**Maintenance | In progress**: scheduled works have been started. 
-
-**Maintenance | Completed**: scheduled works have been completed.
+| Notification | Description |
+|---------------|--------------|
+| Incident \| Investigating | A partial or complete outage is under investigation |
+| Incident \| Identified | The incident's cause has been identified and is being resolved |
+| Incident \| Monitoring | The incident is resolved and the component is under monitoring |
+| Incident \| Resolved | The incident is completely resolved |
+| Incident \| Retrospective | A retrospective notification about an incident that already occurred |
+| Maintenance \| Scheduled | Notification of upcoming scheduled maintenance |
+| Maintenance \| In progress | Scheduled maintenance has started |
+| Maintenance \| Completed | Scheduled maintenance has completed |


### PR DESCRIPTION
…ance

Fixes issues found on re-review against the updated style guide: three instruction-style headings rewritten as noun phrases, four missing bridge/intro sentences between adjacent headings and before lists, two screenshots repositioned to after the step they illustrate, and the component status and notification type definitions converted from bold text blocks to tables to match sibling articles.