### PR TITLE
docs(account-settings): DOC-1782 epic finishing-touches audit

### DIFF
--- a/account-settings/account/additional-accounts.mdx
+++ b/account-settings/account/additional-accounts.mdx
@@ -8,6 +8,8 @@ A single Gcore login controls multiple accounts without re-authorization. Switch
 
 ## Create an additional account
 
+To create an additional account:
+
 1\. Click the profile icon in the top-right corner of the page.
 
 2\. Click **Switch account** to expand the account menu.
@@ -41,6 +43,8 @@ The services of a newly created account are inactive by default.
 
 ## Switch to another account
 
+To switch to a different account:
+
 1\. Click the profile icon in the top-right corner of the page.
 
 2\. Click **Switch account** to display a list of all available accounts.
@@ -54,8 +58,10 @@ The services of a newly created account are inactive by default.
 
 ## Log in to a specific account
 
-1\. Enter a username and password on the [authorization page](https://auth.gcore.com/login/signin).
+To log in directly to one of several linked accounts:
 
-2\. If multiple accounts are linked to the login, a selection page appears to choose the account to use.
+1\. Enter a username and password on the [authorization&nbsp;page](https://auth.gcore.com/login/signin).
+
+2\. If multiple accounts are linked to the login, a selection page appears for selecting the account to use.
 
 3\. Click the required account to log in.

--- a/account-settings/account/create-account.mdx
+++ b/account-settings/account/create-account.mdx
@@ -8,7 +8,9 @@ Creating a Gcore account grants access to the [Gcore Customer Portal](https://po
 
 ## For individuals
 
-1\. To sign up for Gcore services, go to [the Gcore website](https://gcore.com) and click **Sign up for free** in the top navigation.
+Creating an account takes a few minutes:
+
+1\. To sign up for Gcore services, navigate to the [Gcore website](https://gcore.com) and click **Sign up for free** in the top navigation.
 
 
 <Frame>![Gcore homepage with the Sign up for free button highlighted](/images/docs/account-settings/account/create-account/get-started-gcore-website-10.png)</Frame>

--- a/account-settings/account/overview.mdx
+++ b/account-settings/account/overview.mdx
@@ -105,7 +105,7 @@ To add a payment method:
 4. Confirm the payment method address.
 5. Click **Confirm information**.
 
-A small verification charge is processed and immediately refunded to validate the [payment method](/account-settings/billing/payments).
+A small verification charge is processed and immediately refunded to validate the [payment&nbsp;method](/account-settings/billing/payments).
 
 ## Services
 
@@ -113,4 +113,4 @@ The [Services](/account-settings/account/services) page lists every Gcore produc
 
 ## Account deletion
 
-If [account deletion](/account-settings/account/account-deletion) has been requested, the General information page displays an **Account deletion status** section showing the current deletion status.
+If [account&nbsp;deletion](/account-settings/account/account-deletion) has been requested, the General information page displays an **Account deletion status** section showing the current deletion status.

--- a/account-settings/account/services.mdx
+++ b/account-settings/account/services.mdx
@@ -30,7 +30,7 @@ To disable an active service:
 
 
 
-After disabling, the service continues running until the date shown in the Customer Portal, then it becomes unavailable. This triggers deletion of the service and its data (associated resources and settings), with complete removal following a [specified suspension period](/account-settings/billing/data-deletion).
+After disabling, the service continues running until the date shown in the Customer Portal, then it becomes unavailable. This triggers deletion of the service and its data (associated resources and settings), with complete removal following a [suspension&nbsp;period](/account-settings/billing/data-deletion).
 
 ## Resume or activate a service
 

--- a/account-settings/api-tokens.mdx
+++ b/account-settings/api-tokens.mdx
@@ -8,9 +8,9 @@ An API token is a unique identifier an application uses to request access to a G
 
 ## Use cases for API tokens
 
-A standard [authorization token](/api-reference/iam/account/login) is valid for one hour, and a [refresh token](/api-reference/iam/account/refresh-token) used to renew it is valid for 24 hours; these short validity periods work for one-time requests but are impractical for an automated process, such as scheduled CDN cache clearing, because that process would need to re-authenticate constantly.
+A standard [authorization&nbsp;token](/api-reference/iam/account/login) is valid for 1 hour, and a [refresh&nbsp;token](/api-reference/iam/account/refresh-token) used to renew it is valid for 24 hours; these short validity periods work for one-time requests but are impractical for an automated process like scheduled CDN cache clearing, which would need to re-authenticate constantly.
 
-An API token solves this by letting the expiration be set at creation, including no expiration at all. Check the specific product's [API documentation](/api-reference/iam) to confirm it accepts an API token for authorization, since support varies by product. A reseller account can't create an API token, though the reseller's own customers can.
+An API token solves this by letting the expiration be set at creation, including no expiration at all. Support for API tokens varies by product; the specific product's [API&nbsp;documentation](/api-reference/iam) confirms whether it accepts an API token for authorization. A reseller account can't create an API token, though the reseller's own customers can.
 
 To authorize a request with an API token, add it after `APIKey` in the Authorization header: `Authorization: APIKey 7711_eyJ0eXAiOiJKV`. This differs from a standard authorization token, which uses `Bearer` instead of `APIKey`. The header name is case-insensitive, so `authorization` and `AUTHORIZATION` work identically.
 
@@ -30,7 +30,7 @@ A maximum of 100 API tokens can be created per account.
 3. In the **Name** field, enter a name for the token. This field is required.
 4. In the **Description** field, optionally enter additional information about the token.
 5. In the **Expiration** section, select **Never expire** for an unlimited validity period, or **Set expiration date** to set a specific expiration date.
-6. For each listed product (such as Cloud, Managed DNS, Streaming, Object Storage, and Billing) and for IAM/CDN, select the role to assign to the token. Available roles depend on the account's own IAM access role, and a token can't be created with a role higher than the account holder's own; a user with the Users role, for example, can't create a token with the Administrators role.
+6. For each listed product (Cloud, Managed DNS, Streaming, Object Storage, and Billing) and for IAM/CDN, select the role to assign to the token. Available roles depend on the account's own IAM access role, and a token can't be created with a role higher than the account holder's own: a user with the Users role can't create a token with the Administrators role.
 7. Click **Create**.
 
 <Frame>
@@ -44,13 +44,13 @@ A maximum of 100 API tokens can be created per account.
 
 A user with the Administrators role can delete any token issued for the account; other users can delete only tokens they issued themselves.
 
-<Frame>
-  ![Delete an API token](/images/docs/account-settings/my-profile/overview/api-tokens-delete-menu.png)
-</Frame>
-
 1. In the Gcore Customer Portal, click the avatar in the top-right corner, select **Profile**, then **API tokens** in the sidebar.
 2. Next to the token to remove, click the three-dot icon.
 3. Select **Delete API token**.
+
+<Frame>
+  ![API tokens list with the three-dot menu open and Delete API token highlighted](/images/docs/account-settings/my-profile/overview/api-tokens-delete-menu.png)
+</Frame>
 
 ## API tokens section
 
@@ -64,13 +64,13 @@ A user with the Administrators role can see and manage every token issued for th
 
 ## API token expiration notifications
 
-Expiration notifications are sent by email to the user who issued a token and to users with the Administrators role, seven days and again one day before the token expires. This notification is controlled by the **API token is expiring** toggle in the Notifications section of the [Profile](/account-settings/notifications) tab.
+Expiration notifications are sent by email to the user who issued a token and to users with the Administrators role, 7 days and again 1 day before the token expires. This notification is controlled by the **API token is expiring** toggle in the [Notifications](/account-settings/notifications) section of the Profile tab.
 
 <Frame>
   ![API token expiration notifications](/images/docs/account-settings/api-tokens/expiration-notification-60.png)
 </Frame>
 
-The API tokens section shows an exclamation mark for any token expiring within seven days or less.
+The API tokens section shows an exclamation mark for any token expiring within 7 days or less.
 
 ## API tokens and SSO
 

--- a/account-settings/be-aware-of-the-service-status-scheduled-and-emergency-maintenance.mdx
+++ b/account-settings/be-aware-of-the-service-status-scheduled-and-emergency-maintenance.mdx
@@ -4,7 +4,7 @@ sidebarTitle: Status page
 ai-navigation: Subscribe to Gcore Status Page by email, Slack, or webhook for incident and maintenance notifications, and manage or cancel subscriptions by component.
 ---
 
-[Status Page](https://status.gcore.com) is a communication tool that displays information about service status, outages, and planned maintenance. It is reached directly, or from the book icon in the top-right corner of the [Gcore Customer Portal](https://portal.gcore.com).
+[Status&nbsp;Page](https://status.gcore.com) is a communication tool that displays information about service status, outages, and planned maintenance. It is reached directly, or from the book icon in the top-right corner of the [Gcore Customer Portal](https://portal.gcore.com).
 
 ## Subscription methods
 
@@ -18,15 +18,13 @@ Then select a subscription method: email, Slack, or webhook.
 
 To subscribe by email:
 
-1. Enter an email address in the **Email Address** field, then click **Subscribe via email**.
+1. Enter an email address in the **Email Address** field, then click **Subscribe via email**. This redirects to the subscription management page.
 
-2. This redirects to the subscription management page.
-
-3. Select the components to receive status information for, then click **Save**.
+2. Select the components to receive status information for, then click **Save**.
 
 <Frame>![Status Page of Gcore](/images/docs/account-settings/status-page/email-sp-20.png)</Frame>
 
-4. Confirm the subscription by clicking **Confirm subscription** in the email sent to the specified address.
+3. Confirm the subscription by clicking **Confirm subscription** in the email sent to the specified address.
 
 ### Slack
 
@@ -48,21 +46,19 @@ To correctly configure notifications from the current Status Page, disable notif
 
 <Frame>![Incoming WebHooks](/images/docs/account-settings/status-page/open-old-app-40.png)</Frame>
 
-5. Go to the **Configuration** section. 
+5. Navigate to the **Configuration** section.
 
-<Frame>![Configuration section.](/images/docs/account-settings/status-page/configuration-50.png)</Frame>
+<Frame>![Configuration section](/images/docs/account-settings/status-page/configuration-50.png)</Frame>
 
 6. Find the channel the notifications are configured for. 
 
-7. Click the pencil icon to go to the integration settings.
+7. Click the pencil icon to navigate to the integration settings.
 
 8. In the upper-right corner, click **Disable** to switch off the integration, then click **Remove** to delete it. 
 
 <Frame>![Disable and Remove](/images/docs/account-settings/status-page/remove-integration-60.png)</Frame>
 
 9. Confirm the action.
-
-10. Continue to the next section to integrate this channel with the current Status Page. 
 
 #### New Slack integration setup
 
@@ -104,21 +100,15 @@ Slack confirms the setup and redirects automatically to the subscription managem
 
 A webhook subscription requires a URL that Status Page can send update requests to.
 
-1. Enter the URL for sending notifications in the first field. 
+1. Enter the URL for sending notifications in the first field.
 
-2. In the second field, specify an email address to use if the URL is unavailable. 
+2. In the second field, specify an email address to use if the URL is unavailable.
 
 <Frame>![Permission to access](/images/docs/account-settings/status-page/webhook-120.png)</Frame>
 
-3. Click **Subscribe**. 
+3. Click **Subscribe**. A confirmation message confirms that webhook notifications are configured, and a confirmation email is sent to the specified address.
 
-4. A confirmation message shows that webhook notifications are configured. 
-
-5. A confirmation email is also sent to the specified address. 
-
-6. Webhook documentation is available by clicking **View documentation**. 
-
-7. Manage the subscription by clicking **Manage your subscription**, then select the components to receive status information for and click **Save**. 
+Webhook documentation is available by clicking **View documentation**.
 
 ## Subscription management
 

--- a/account-settings/billing/bonuses-and-discounts.mdx
+++ b/account-settings/billing/bonuses-and-discounts.mdx
@@ -3,7 +3,7 @@ title: Bonuses and discounts
 ai-navigation: View bonus credit status, expiration, and discount details on the Bonuses and discounts page, and apply promo codes to receive bonus credits.
 ---
 
-The [Bonuses and discounts](https://portal.gcore.com/accounts/billing/bonuses) page displays bonus credits and active discounts for the account.
+The **Bonuses and discounts** page displays bonus credits and active discounts for the account.
 
 To open this page:
 
@@ -62,15 +62,11 @@ After successful activation, the bonus credits appear in the Bonus credits table
 
 ### Bonus debiting
 
-Bonuses are debited automatically as part of the payment for products, applied to expenses to reduce the total amount due; the applied amount also appears in billing details and invoices.
+Bonuses are debited automatically as part of the payment for products, applied to expenses to reduce the total amount due. The applied amount appears in billing details and on invoices as a credit value against the affected expense items, reducing the final invoice total accordingly.
 
 <Warning>
 As bonus credits reduce the taxable amount of expenses, the tax is also recalculated downward.
 </Warning>
-
-#### Bonuses in invoices
-
-Bonuses are applied to individual expense items and shown as a credit value in the invoice, reducing the final invoice total accordingly.
 
 ## Discounts
 

--- a/account-settings/billing/data-deletion.mdx
+++ b/account-settings/billing/data-deletion.mdx
@@ -3,12 +3,12 @@ title: Data deletion
 ai-navigation: Determine how long Gcore products retain data after suspension before deleting it, by product and feature.
 ---
 
-Gcore deletes a suspended service, its settings, and associated customer data after a retention period that depends on the product; full retention periods by product appear below. This retention period applies to an individual product still tied to an active account; closing the entire account, including all products and personal data at once, is covered separately in [account deletion](/account-settings/account/account-deletion).
+Gcore deletes a suspended service, its settings, and associated customer data after a retention period that depends on the product; full retention periods by product appear below. This retention period applies to an individual product still tied to an active account; closing the entire account, including all products and personal data at once, is covered separately in [account&nbsp;deletion](/account-settings/account/account-deletion).
 
 A product can be suspended in three cases:
 
 1. The product was [disabled](/account-settings/account/services#disable-a-service) manually.
-2. A [Base Trial](/account-settings/billing/trial-conditions) ended without a plan enabled.
+2. A [Base&nbsp;Trial](/account-settings/billing/trial-conditions) ended without a plan enabled.
 3. A payment charge attempt failed. When one product is suspended for this reason, all other products on the account are also suspended.
 
 ## Deletion timelines by product
@@ -24,12 +24,12 @@ Gcore reserves the right to delete data, including without prior notice, to enfo
 | Product | Feature | Period after suspension |
 |---------|---------|---------------------------|
 | CDN | - | 90 days |
-| Edge Cloud | [Managed Kubernetes](/cloud/kubernetes/about-gcore-kubernetes) | 0 days* |
+| Edge Cloud | [Managed&nbsp;Kubernetes](/cloud/kubernetes/about-gcore-kubernetes) | 0 days* |
 | Edge Cloud | [Function as a Service](/cloud/faas/about-function-as-a-service) | 0 days* |
 | Edge Cloud | [Container as a Service](/cloud/caas) | 0 days* |
 | Edge Cloud | GPU SPOT Clusters | 0 days* |
-| Edge Cloud | [Managed Logging](/cloud/logging-as-a-service/about-logging-as-a-service) | 14 days |
-| Edge Cloud | [Managed PostgreSQL](/cloud/managed-database-postgresql) | 14 days |
+| Edge Cloud | [Managed&nbsp;Logging](/cloud/logging-as-a-service/about-logging-as-a-service) | 14 days |
+| Edge Cloud | [Managed&nbsp;PostgreSQL](/cloud/managed-database-postgresql) | 14 days |
 | Edge Cloud | Other features (Basic VM, Virtual Machines, Volumes, File Shares, Snapshots, Bare Metal) | 48 hours |
 | Object Storage | - | 48 hours** |
 | Managed DNS | - | 90 days |
@@ -41,7 +41,7 @@ Gcore reserves the right to delete data, including without prior notice, to enfo
 An asterisk (*) means data stored on worker nodes is deleted immediately after suspension, while data on volumes attached to the cluster is deleted within 48 hours. Two asterisks (**) mean Object Storage data can still be manually recovered for 14 days after deletion.
 </Note>
 
-Standard retention periods are subject to change; check the [Master Services Agreement](https://gcore.com/legal) (item 16) and individual product specifications for the current terms.
+Standard retention periods are subject to change, per the [Master Services Agreement](https://gcore.com/legal) (item 16) and individual product specifications.
 
 ## Deleted data by product
 

--- a/account-settings/billing/expenses.mdx
+++ b/account-settings/billing/expenses.mdx
@@ -21,7 +21,7 @@ Each row lists the following details for a consumed product:
 
 ## Pricing rules overview
 
-The **Pricing rule** column shows whether resource usage stays within a pre-agreed reservation or exceeds it. This applies to [resource reservation](/cloud/getting-started/resource-reservation/about-resource-reservation), a long-term rental of resources at a discount.
+The **Pricing rule** column applies to [resource&nbsp;reservation](/cloud/getting-started/resource-reservation/about-resource-reservation), a long-term rental of resources at a discount.
 
 | Status | Description |
 |--------|--------------|
@@ -42,7 +42,7 @@ Clicking the info icon next to the Sum column opens a detailed breakdown of the 
 | Tax rate | Percentage of tax applied to the expense, based on local tax regulations |
 | Tax amount | Total amount of tax charged |
 
-Tax rates follow local regulations and vary by country, as listed in [VAT rates](/account-settings/billing/vat-rates).
+Tax rates follow local regulations and vary by country, as listed in [VAT&nbsp;rates](/account-settings/billing/vat-rates).
 
 <Frame>![Expense breakdown dialog showing expense before tax, discount, tax rate, and tax amount](/images/docs/account-settings/billing/expenses/tax-calculation.png)</Frame>
 

--- a/account-settings/billing/payments.mdx
+++ b/account-settings/billing/payments.mdx
@@ -3,7 +3,7 @@ title: "Payments and payment methods"
 ai-navigation: View payment history and filter by method, date, or status, and add, verify, or remove payment methods, including manual and automatic balance top-ups.
 ---
 
-Payment for Gcore products follows either a pay-as-you-go model, based on actual resource consumption, or a fixed monthly cost tied to a committed plan. Costs for each product are listed on the [Pricing page](https://gcore.com/pricing).
+Payment for Gcore products follows either a pay-as-you-go model, based on actual resource consumption, or a fixed monthly cost tied to a committed plan. Costs for each product are listed on the [Pricing&nbsp;page](https://gcore.com/pricing).
 
 ## Payment history
 
@@ -69,30 +69,18 @@ A payment method is added directly on the **Payment methods** page.
 2. Enter the payment information.
 
 <Info>
-The payment method address is separate from the [billing address](/account-settings/account/overview), so changes made on one page do not affect the other.
+The payment method address is separate from the [billing&nbsp;address](/account-settings/account/overview), so changes made on one page do not affect the other.
 </Info>
 
 3. Click **Confirm information** to apply the changes.
 
 ### Payment method verification
 
-Adding a payment card triggers a brief verification step to confirm it's valid before it can be used for charges.
-
-#### Verification charge
-
-A verification charge of approximately 1 EUR/USD applies when a payment card is added. This is not a fee, it's a temporary authorization hold confirming that the card is valid.
-
-#### Refund
-
-Refunds are processed automatically, usually instantly or within 24 hours, though it can take up to 3–7 business days depending on the bank.
-
-#### Multiple charges
-
-Each attempt to add a card creates a separate hold, and all holds are refunded automatically.
+Adding a payment card triggers a brief verification step to confirm it's valid before it can be used for charges. A verification charge of approximately 1 EUR/USD applies when a card is added; this is not a fee, but a temporary authorization hold that confirms the card is valid. Refunds are processed automatically, usually instantly or within 24 hours, though it can take up to 3–7 business days depending on the bank. Each attempt to add a card creates a separate hold, and all holds are refunded automatically.
 
 ### Default payment method
 
-The default payment method is the option automatically selected for transactions unless a different one is chosen. Multiple payment methods can be added; the first one added becomes the default, though it can be changed at any time by clicking the three-dot icon next to the preferred method and selecting **Make default**.
+The default payment method is the option automatically selected for transactions unless a different one is selected. Multiple payment methods can be added; the first one added becomes the default, though it can be changed at any time by clicking the three-dot icon next to the preferred method and selecting **Make default**.
 
 <Frame>
   ![Example of a card with Make default option available](/images/docs/account-settings/billing/payments/make-payment-method-default.png)

--- a/account-settings/billing/tax-location.mdx
+++ b/account-settings/billing/tax-location.mdx
@@ -18,7 +18,7 @@ To view the tax location and its rate:
 
 ## Tax location calculation
 
-The tax location is calculated from the billing address entered on the General information page. For an individual account, other account details required for EU tax compliance, such as the IP address and payment method, are also factored in, because tax laws in some countries require verification beyond a self-reported address. For an organization account, the tax location is based on the billing address, and the resulting VAT rate depends on whether a valid EU VAT number was provided. Standard VAT rates by country and account type are covered in [VAT rates in different countries](/account-settings/billing/vat-rates).
+The tax location is calculated from the billing address entered on the General information page. For an individual account, other account details required for EU tax compliance, including the IP address and payment method, are also factored in, because tax laws in some countries require verification beyond a self-reported address. For an organization account, the tax location is based on the billing address, and the resulting VAT rate depends on whether a valid EU VAT number was provided. Standard VAT rates by country and account type are covered in [VAT&nbsp;rates](/account-settings/billing/vat-rates).
 
 ## Update billing address
 
@@ -32,4 +32,4 @@ An organization with a registered EU VAT number can remove VAT charges from invo
 
 ## Tax rate changes during a billing period
 
-If the tax rate changes during a billing month, expenses for that month are recalculated to apply the new rate consistently across the entire invoice; the invoice isn't adjusted when the rate stays the same. For daily billed accounts, all overcommit expenses for the month are deleted and re-created even when the rate doesn't change, so expenses and expense statistics stay consistent. As a result, old overcommit expenses can appear as Deleted in both the Customer Portal and the API.
+A tax rate change during a billing month triggers recalculation of that month's [expenses](/account-settings/billing/expenses), which can cause old overcommit expenses to appear as Deleted in the Customer Portal and the API.

--- a/account-settings/billing/trial-conditions.mdx
+++ b/account-settings/billing/trial-conditions.mdx
@@ -3,7 +3,7 @@ title: Trial conditions
 ai-navigation: View free trial durations and limits for CDN, Video Streaming, WAAP, and Managed DNS Pro, and activate a trial from the Customer Portal.
 ---
 
-A trial period allows testing a Gcore service for free for a limited time, regardless of the plan chosen. For pricing details on specific services and tariffs, check [Gcore Pricing](https://gcore.com/pricing/edge-network) or the [Gcore Customer Portal](https://portal.gcore.com).
+A trial period allows testing a Gcore service for free for a limited time, regardless of the plan selected. Pricing for each service and tariff after the trial ends is listed on [Gcore&nbsp;Pricing](https://gcore.com/pricing/edge-network) and in the [Gcore Customer Portal](https://portal.gcore.com).
 
 ## Trial availability by service
 
@@ -34,7 +34,7 @@ For accounts with services already activated, tariff plan activation (including 
 
 <Frame>![Services page listing services with Activate service buttons](/images/docs/account-settings/billing/trial-conditions/trial-20.png)</Frame>
 
-An email confirms the start of the trial, followed by a reminder two days before it ends. Contact support ([support@gcore.com](mailto:support@gcore.com) or chat) or an account manager to extend the trial duration or add gigabytes.
+An email confirms the start of the trial, followed by a reminder 2 days before it ends. Contact support ([support@gcore.com](mailto:support@gcore.com) or chat) or an account manager to extend the trial duration or add gigabytes.
 
 <Info>
 The activation flow differs for some services, including DDoS Protection. Follow the instructions in the Customer Portal to activate these services.

--- a/account-settings/how-quickly-our-support-team-will-respond-to-you.mdx
+++ b/account-settings/how-quickly-our-support-team-will-respond-to-you.mdx
@@ -10,9 +10,9 @@ Gcore technical support handles requests through several plans, priority levels,
 
 Five Technical Support plans are available: Basic, Standard, Advanced, Enterprise, and Premium. The Basic plan is the default and does not guarantee a response time, while Standard through Enterprise progressively add faster guaranteed first-response times and additional channels, including chat, WhatsApp, and calls. Premium is a custom, modular plan built from add-on features. These plans apply to every Gcore product except Hosting, which is fixed at the Standard plan's P3 and P4 response guarantees.
 
-All plans include access to Gcore product documentation and the [Gcore Help Center](https://support.gcore.com/hc/en-us). Current features, pricing, and response times for each [Technical Support](https://gcore.com/support-as-a-service) plan are listed separately.
+All plans include access to Gcore product documentation and the Gcore [Help&nbsp;Center](https://support.gcore.com/hc/en-us). Current features, pricing, and response times for each [Technical&nbsp;Support](https://gcore.com/support-as-a-service) plan are listed separately.
 
-The active Technical Support plan can be changed the same way as any other service, from the [Services](/account-settings/account/services) page under **Account** in the [Gcore Customer Portal](https://portal.gcore.com).
+The active Technical Support plan can be changed the same way as any other service, on the [Services](/account-settings/account/services) page.
 
 ## Request priority
 

--- a/account-settings/notifications.mdx
+++ b/account-settings/notifications.mdx
@@ -10,7 +10,7 @@ Notification settings control which email alerts each user in a Gcore account re
 
 To view and configure notification settings:
 
-1. In the [Gcore Customer Portal](https://portal.gcore.com/accounts/reports/dashboard), click the account icon in the top-right corner, then click **Profile**.
+1. In the [Gcore Customer Portal](https://portal.gcore.com), click the account icon in the top-right corner, then click **Profile**.
 
 <Frame>![Profile section in the Customer Portal](/images/docs/account-settings/my-profile/overview/profile-menu.png)</Frame>
 
@@ -42,7 +42,7 @@ The **General notifications** group is shared across all account users and cover
 
 ## Product notifications
 
-Each active product adds its own notifications card below the account-wide groups, covering events specific to that product. CDN and Object Storage additionally support a configurable usage limit: once enabled, usage counters reset on the first day of each month, and the usage volume is checked hourly, at the top of the hour with a variance of up to three minutes.
+Each active product adds its own notifications card below the account-wide groups, covering events specific to that product. CDN and Object Storage additionally support a configurable usage limit: once enabled, usage counters reset on the first day of each month, and the usage volume is checked hourly, at the top of the hour with a variance of up to 3 minutes.
 
 ### CDN notifications
 

--- a/account-settings/roadmap-provide-feedback-suggest-new-features-follow-development.mdx
+++ b/account-settings/roadmap-provide-feedback-suggest-new-features-follow-development.mdx
@@ -47,7 +47,7 @@ The **Changelog** tab lists the latest Gcore releases, searchable and filterable
 
 ## Authorized and unauthorized access
 
-Roadmap uses the [same account as Gcore](/account-settings/account/create-account); sign in or sign up with email, SSO, Google, Apple, GitHub, or Microsoft. Authorized and unauthorized users have different access levels.
+Roadmap uses the same [Gcore&nbsp;account](/account-settings/account/create-account) as the Customer Portal; sign in or sign up with email, a passkey, SSO, Google, Apple, GitHub, or Microsoft. Authorized and unauthorized users have different access levels.
 
 | Action | Authorized | Unauthorized |
 |--------|------------|--------------|


### PR DESCRIPTION
Full style-guide.md and technical-accuracy pass across the remaining account-settings articles in the epic: fixes missing nbsp in multi-word links, over-length link text, numbered-list result-statements written as fake steps, missing heading intro sentences, duplicated cross-article content, wrong link destinations, banned link-routing phrasing, and measurement digit formatting for small time durations.