### PR TITLE
Update: hosting overview — rewrite and content accuracy fixes

### DIFF
--- a/hosting.mdx
+++ b/hosting.mdx
@@ -1,24 +1,17 @@
 ---
 title: Hosting
-ai-navigation: Order and manage Gcore Dedicated Servers and Virtual Servers with DDoS protection, BGP, SSL certificates, account management, billing, and API-based server management.
+ai-navigation: Order and manage Gcore Dedicated Servers and Virtual Servers with BGP, DDoS protection, link aggregation, DNS hosting, billing, and account management.
 ---
 
-Welcome to the [Gcore Hosting](https://gcore.com/hosting) documentation page! Here we explain how to order, configure, and troubleshoot Virtual and Dedicated Servers and additional services.
+Gcore Hosting provides Virtual Servers and Dedicated Servers for running websites, applications, and other internet-accessible workloads.
 
-With Gcore Hosting, you can rent a physical or a Virtual Server to host your website, application, or other digital content accessible over the internet.
+The section covers:
 
-From the left–side menu, you can access in–depth documentation about Hosting:
-
-  * **Dedicated Servers** – selecting, purchasing, management, troubleshooting
-  * **Virtual Servers** – selecting, purchasing, management, troubleshooting
-  * **Other services** – BGP, DDoS protection, link aggregation, SSL certificates
-  * **Account management** – notifications, password management, two–factor authentication, user management
-  * **Payments** – payment methods and procedures, troubleshooting payment errors, refunds, auto payment
-  * **Technical support** – connect with the technical support team
-  * **API** – server management via API
-  * **Become a reseller** – information for Gcore resellers
-  * **Referral program** – information about the Gcore referral program
-
-
-
-If you have any questions or think we're missing a topic, please leave a comment and our content team address it.
+- **Virtual Servers** — flexible VPS plans ordered and managed through VMmanager; includes OS installation, networking, SSH access, and VNC
+- **Dedicated Servers** — bare-metal servers with full hardware control via DCImanager and IPMI; includes OS installation, networking, and reboot management
+- **Additional services** — BGP and subnet announcement, DDoS protection, link aggregation, and DNS hosting
+- **Account management** — password, two-factor authentication, notifications, and user access settings
+- **Payments** — payment methods, server renewal, auto payment, payment history, and refund requests
+- **Technical support** — around-the-clock support via ticket or chat
+- **API** — server management via the Billmanager, DCImanager, and VMmanager APIs
+- **Reseller program** — purchase Gcore servers at a discount and resell through a custom billing system

--- a/hosting/llms.txt
+++ b/hosting/llms.txt
@@ -1,8 +1,8 @@
 # Gcore Hosting
 
-> Order and manage Gcore Dedicated Servers and Virtual Servers with DDoS protection, BGP, SSL certificates, account management, billing, and API-based server management.
+> Order and manage Gcore Dedicated Servers and Virtual Servers with BGP, DDoS protection, link aggregation, DNS hosting, billing, and account management.
 
-- [Hosting](https://docs.gcore.com/hosting.md): Order and manage Gcore Dedicated Servers and Virtual Servers with DDoS protection, BGP, SSL certificates, account management, billing, and API-based server management.
+- [Hosting](https://docs.gcore.com/hosting.md): Order and manage Gcore Dedicated Servers and Virtual Servers with BGP, DDoS protection, link aggregation, DNS hosting, billing, and account management.
 
 ## Dedicated servers
 - [About Dedicated Servers](https://docs.gcore.com/hosting/dedicated-servers/about-dedicated-servers.md): Deploy Gcore Dedicated Servers for resource-intensive workloads, data storage, and non-virtualized applications, with IPMI included for independent OS installation.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -583,9 +583,9 @@
 
 # Gcore Hosting
 
-> Order and manage Gcore Dedicated Servers and Virtual Servers with DDoS protection, BGP, SSL certificates, account management, billing, and API-based server management.
+> Order and manage Gcore Dedicated Servers and Virtual Servers with BGP, DDoS protection, link aggregation, DNS hosting, billing, and account management.
 
-- [Hosting](https://docs.gcore.com/hosting.md): Order and manage Gcore Dedicated Servers and Virtual Servers with DDoS protection, BGP, SSL certificates, account management, billing, and API-based server management.
+- [Hosting](https://docs.gcore.com/hosting.md): Order and manage Gcore Dedicated Servers and Virtual Servers with BGP, DDoS protection, link aggregation, DNS hosting, billing, and account management.
 
 ## Dedicated servers
 - [About Dedicated Servers](https://docs.gcore.com/hosting/dedicated-servers/about-dedicated-servers.md): Deploy Gcore Dedicated Servers for resource-intensive workloads, data storage, and non-virtualized applications, with IPMI included for independent OS installation.

--- a/llms.txt
+++ b/llms.txt
@@ -15,7 +15,7 @@
 - [AI](https://docs.gcore.com/edge-ai/llms.txt): Deploy AI inference and GPU-accelerated training using Gcore AI products - Everywhere Inference for low-latency model serving at the edge and GPU Cloud for Bare Metal and Virtual Machine compute (33 articles).
 - [Gclaw](https://docs.gcore.com/gclaw/llms.txt): Managed OpenClaw service with built-in inference for launching AI agents instantly (10 articles).
 - [Managed DNS](https://docs.gcore.com/dns/llms.txt): Manage DNS zones and records using Gcore Managed DNS with Anycast routing, geo-balancing, health checks, DNSSEC, and OctoDNS and Certbot plugin integration (20 articles).
-- [Hosting](https://docs.gcore.com/hosting/llms.txt): Order and manage Gcore Dedicated Servers and Virtual Servers with DDoS protection, BGP, SSL certificates, account management, billing, and API-based server management (80 articles).
+- [Hosting](https://docs.gcore.com/hosting/llms.txt): Order and manage Gcore Dedicated Servers and Virtual Servers with BGP, DDoS protection, link aggregation, DNS hosting, billing, and account management (80 articles).
 - [Colocation](https://docs.gcore.com/colocation/llms.txt): Overview of Gcore Colocation - place customer hardware in facilities certified at Tier II and above across 29 global locations with DDoS protection and on-site support (4 articles).
 - [Object Storage](https://docs.gcore.com/storage/llms.txt): Store and manage data in Gcore Object Storage with S3 Fast, S3 Standard, and SFTP storage types supporting the S3 API and SFTP protocols (15 articles).
 - [Video Streaming](https://docs.gcore.com/streaming/llms.txt): Gcore Video Streaming is a high-load video streaming PaaS. Scale to 1M+ viewers and beyond (72 articles).


### PR DESCRIPTION
- Remove meta-preamble, 'Welcome to', 'From the left-side menu', trailing CTA
- Remove Referral program (does not exist in section)
- Remove SSL certificates (lives under CDN, not Hosting)
- Add DNS hosting (existed in section, missing from overview)
- Rewrite to bold+em-dash format with section descriptions
- Update ai-navigation: accurate service list, approved verb, under 160 chars