### PR TITLE
polish: fix portal naming, link text, and prose across hosting articles

### DIFF
--- a/hosting/become-reseller-and-resell-our-services.mdx
+++ b/hosting/become-reseller-and-resell-our-services.mdx
@@ -14,4 +14,4 @@ To join the reseller program and receive a reseller discount, [contact&nbsp;supp
 - Product to resell (VPS or Dedicated Server)
 - Expected sales volume
 
-Once your request is approved, the discount will appear under **Client** > **Discounts** in the left sidebar.
+Once the request is approved, the discount will appear in the [Gcore&nbsp;Hosting&nbsp;Portal](https://hosting.gcore.com/billmgr) under **Client** > **Discounts** in the left sidebar.

--- a/hosting/contact-our-technical-support.mdx
+++ b/hosting/contact-our-technical-support.mdx
@@ -1,18 +1,18 @@
 ---
 title: Contact our technical support
 sidebarTitle: Technical support
-ai-navigation: Send a support ticket or use live chat to reach Gcore technical support around the clock via the Gcore hosting portal or gcore.com.
+ai-navigation: Send a support ticket or use live chat to reach Gcore technical support around the clock via the Gcore Hosting Portal or the Gcore website.
 ---
 
 Technical support is available 24/7. There are two ways to get in touch.
 
 ## Chat
 
-Navigate to [gcore.com](https://gcore.com) and use the **Chat with a Gcore Expert** link to start a conversation with a specialist.
+Start a [live&nbsp;chat](https://gcore.com) with a Gcore specialist.
 
 ## Ticket
 
-In the left sidebar, navigate to **Support** > **Support tickets** and click **Add**.
+In the [Gcore&nbsp;Hosting&nbsp;Portal](https://hosting.gcore.com/billmgr), navigate to **Support** > **Support tickets** and click **Add**.
 
 Alternatively, on the Dashboard, select **Submit a ticket** in the **Quick access** section.
 

--- a/hosting/dedicated-servers/manage/networking/additional-ip-addresses/buy-an-additional-ip-address.mdx
+++ b/hosting/dedicated-servers/manage/networking/additional-ip-addresses/buy-an-additional-ip-address.mdx
@@ -1,7 +1,7 @@
 ---
 title: Buy an additional IP address
 sidebarTitle: Buy
-ai-navigation: Order additional IPv4 and IPv6 addresses for dedicated servers and virtual private servers in the Gcore Hosting control panel.
+ai-navigation: Order additional IPv4 and IPv6 addresses for dedicated servers and virtual private servers in the Gcore Hosting Portal.
 ---
 
 Every dedicated server includes one free IPv4 address and one free IPv6 address. Additional IP addresses can be ordered at any time after the server is created. Up to 14 additional IPv4 and 14 additional IPv6 addresses are available for purchase.
@@ -12,7 +12,7 @@ For KVM-SSD-1 virtual private servers, the limit is 2 additional IPv4 addresses 
 
 <Steps>
   <Step title="Open the IP addresses list">
-    Navigate to the **Dedicated Servers** or **Virtual private servers** tab in the Gcore Hosting [control&nbsp;panel](https://hosting.gcore.com/billmgr). Select the server and click **IP addresses**.
+    Navigate to the **Dedicated Servers** or **Virtual private servers** tab in the [Gcore&nbsp;Hosting&nbsp;Portal](https://hosting.gcore.com/billmgr). Select the server and click **IP addresses**.
 
     <Frame>
       ![Dedicated servers list with the IP addresses button highlighted in the toolbar](/images/docs/hosting/dedicated-servers/manage/networking/additional-ip-addresses/buy-an-additional-ip-address/buy-an-additional-ip-address-image1.png)

--- a/hosting/dedicated-servers/upgrade-your-dedicated-server.mdx
+++ b/hosting/dedicated-servers/upgrade-your-dedicated-server.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Upgrade your dedicated server"
 sidebarTitle: "Upgrade"
-ai-navigation: Change Dedicated Server hardware specifications via a support ticket or update the internet plan independently in the Control Panel.
+ai-navigation: Change Dedicated Server hardware specifications via a support ticket or update the internet plan independently in the Hosting Portal.
 ---
 
 Dedicated Server hardware specifications can be upgraded with help from our engineers as a paid service. The internet tariff can be changed independently at no charge.
@@ -13,7 +13,7 @@ Hardware upgrades include: setting up or changing the RAID type, increasing disk
 <Steps>
 <Step title="Select the desired specifications">
 
-Select the desired specifications in the [Dedicated&nbsp;Servers](https://gcore.com/hosting/dedicated) catalog on the website. 10 Gbps network cards are not listed there but can be installed. New specifications must not be lower than the current ones.
+Select the desired specifications in the [Dedicated&nbsp;Servers catalog](https://gcore.com/hosting/dedicated). 10 Gbps network cards are not listed there but can be installed. New specifications must not be lower than the current ones.
 
 <Frame>
   ![Dedicated Servers section](/images/docs/hosting/dedicated-servers/upgrade-your-dedicated-server/upgrade-your-dedicated-server-image1.gif)
@@ -41,7 +41,7 @@ We confirm the cost of the new configuration and coordinate the time and date of
 </Step>
 <Step title="Pay the upgrade fee">
 
-A fee applies for the upgrade. The price depends on the account provider: "Gcore USD" — 150 dollars, "Gcore" — 150 euros (the exact amount is confirmed by support). The provider name is visible in the Control Panel under **Dashboard**. Support sends a payment notification in chat; the funds must be transferred to the account balance before the upgrade begins.
+A fee applies for the upgrade. The price depends on the account provider: "Gcore USD" — 150 dollars, "Gcore" — 150 euros (the exact amount is confirmed by support). The provider name is visible in the [Gcore&nbsp;Hosting&nbsp;Portal](https://hosting.gcore.com/billmgr) under **Dashboard**. Support sends a payment notification in chat; the funds must be transferred to the account balance before the upgrade begins.
 
 <Frame>
   ![Information](/images/docs/hosting/dedicated-servers/upgrade-your-dedicated-server/upgrade-your-dedicated-server-image3.png)
@@ -71,7 +71,7 @@ The server price increases after an upgrade, and the **End date** is recalculate
 
 ## Change the internet plan
 
-The Internet tariff (traffic package and bandwidth) can be changed independently in the Control Panel.
+The Internet tariff (traffic package and bandwidth) can be changed independently in the Hosting Portal.
 
 <Steps>
 <Step title="Open the server settings">

--- a/hosting/llms.txt
+++ b/hosting/llms.txt
@@ -10,7 +10,7 @@
 ## Before purchase
 - [Test the connectivity between your location and the server you want to buy](https://docs.gcore.com/hosting/virtual-servers/before-purchase/test-the-connectivity-between-your-location-and-the-server-you-want-to-buy.md): Use the Gcore Looking Glass tool to test connectivity between an IP address and Gcore server nodes via BGP, PING, and TRACEROUTE commands.
 - [Order a dedicated server](https://docs.gcore.com/hosting/dedicated-servers/order-a-dedicated-server.md): Create a Dedicated Server order via the Control Panel or website by selecting a tariff, configuring parameters, and completing payment.
-- [Upgrade your dedicated server](https://docs.gcore.com/hosting/dedicated-servers/upgrade-your-dedicated-server.md): Change Dedicated Server hardware specifications via a support ticket or update the internet plan independently in the Control Panel.
+- [Upgrade your dedicated server](https://docs.gcore.com/hosting/dedicated-servers/upgrade-your-dedicated-server.md): Change Dedicated Server hardware specifications via a support ticket or update the internet plan independently in the Hosting Portal.
 
 ## Manage
 - [Access DCImanager](https://docs.gcore.com/hosting/dedicated-servers/manage/log-in-to-dcimanager.md): Access DCImanager to manage a dedicated server, restart it, or power it off directly from the hosting Control Panel via the To panel button.
@@ -29,7 +29,7 @@
 ## Networking
 
 ## Additional IP addresses
-- [Buy an additional IP address](https://docs.gcore.com/hosting/dedicated-servers/manage/networking/additional-ip-addresses/buy-an-additional-ip-address.md): Order additional IPv4 and IPv6 addresses for dedicated servers and virtual private servers in the Gcore Hosting control panel.
+- [Buy an additional IP address](https://docs.gcore.com/hosting/dedicated-servers/manage/networking/additional-ip-addresses/buy-an-additional-ip-address.md): Order additional IPv4 and IPv6 addresses for dedicated servers and virtual private servers in the Gcore Hosting Portal.
 - [Configure an additional IP address](https://docs.gcore.com/hosting/virtual-servers/manage/networking/additional-ip-addresses/configure-an-additional-ip-address.md): Configure additional IPv4 and IPv6 addresses on virtual private and dedicated servers via OS network settings on Debian, Ubuntu, and CentOS.
 - [Connect dedicated servers into a VLAN](https://docs.gcore.com/hosting/dedicated-servers/manage/networking/connect-dedicated-servers-into-a-vlan.md): Configure a VLAN on dedicated server switch ports in DCImanager to connect servers into a virtual local network.
 - [Configure a 10 Gbps network card](https://docs.gcore.com/hosting/dedicated-servers/manage/networking/configure-a-10-gbps-network-card.md): Configure a 10 Gbps network interface on a Dedicated Server running Ubuntu, Debian, or CentOS using the ip and ethtool commands.
@@ -68,7 +68,7 @@
 - [Connect to a Linux server via SSH](https://docs.gcore.com/hosting/virtual-servers/manage/connect/linux-server/connect-to-linux-server-via-ssh.md): Connect to Linux virtual servers via SSH using credentials from the Hosting portal Instructions tab, from any terminal on macOS, Linux, or Windows.
 - [Manage SSH keys](https://docs.gcore.com/hosting/virtual-servers/manage/connect/linux-server/manage-ssh-keys.md): Manage SSH keys for Gcore Linux virtual servers — generate a key pair, copy a public key to the server, connect via SSH key, and remove keys from authorized_keys.
 - [Change the port for SSH connections](https://docs.gcore.com/hosting/virtual-servers/manage/connect/linux-server/change-the-port-for-ssh-connections.md): Change the SSH listening port on a Linux virtual server by editing sshd_config, restarting the SSH service, and updating firewall rules.
-- [Connect to a virtual server via VNC in VMmanager 6](https://docs.gcore.com/hosting/virtual-servers/manage/connect/connect-to-a-virtual-server-via-vnc.md): Connect to a virtual server via VNC console in VMmanager 6 using credentials retrieved from the Hosting portal Instructions page or the activation email.
+- [Connect to a virtual server via VNC in VMmanager 6](https://docs.gcore.com/hosting/virtual-servers/manage/connect/connect-to-a-virtual-server-via-vnc.md): Connect to a virtual server via VNC console in VMmanager 6 using credentials retrieved from the Hosting Portal Instructions page or the activation email.
 - [Install GUI (desktop environment) on Ubuntu, CentOS and Debian](https://docs.gcore.com/hosting/virtual-servers/manage/install-gui-desktop-environment-on-ubuntu-centos-and-debian.md): Install XFCE desktop environment on Ubuntu, CentOS, and Debian virtual servers via SSH or VNC using package managers and display managers like lightdm or gdm3.
 
 ## Operating system
@@ -82,10 +82,10 @@
 - [Allocate an IPv6 address in VMmanager 6](https://docs.gcore.com/hosting/virtual-servers/manage/networking/allocate-an-ipv6-address-in-vmmanager-6.md): Allocate IPv6 addresses to virtual servers in VMmanager 6 - view assigned addresses in the Virtual machines tab and configure additional IPs via OS settings.
 
 ## Additional IP addresses
-- [Buy an additional IP address](https://docs.gcore.com/hosting/dedicated-servers/manage/networking/additional-ip-addresses/buy-an-additional-ip-address.md): Order additional IPv4 and IPv6 addresses for dedicated servers and virtual private servers in the Gcore Hosting control panel.
+- [Buy an additional IP address](https://docs.gcore.com/hosting/dedicated-servers/manage/networking/additional-ip-addresses/buy-an-additional-ip-address.md): Order additional IPv4 and IPv6 addresses for dedicated servers and virtual private servers in the Gcore Hosting Portal.
 - [Configure an additional IP address](https://docs.gcore.com/hosting/virtual-servers/manage/networking/additional-ip-addresses/configure-an-additional-ip-address.md): Configure additional IPv4 and IPv6 addresses on virtual private and dedicated servers via OS network settings on Debian, Ubuntu, and CentOS.
 - [Set up a PTR record](https://docs.gcore.com/hosting/virtual-servers/manage/set-up-a-ptr-record.md): Configure PTR records for virtual private and dedicated servers to map IP addresses to domain names for email server identification.
-- [Delete a virtual server](https://docs.gcore.com/hosting/virtual-servers/delete-a-virtual-server.md): Delete a virtual server from the Gcore Hosting control panel and understand the minimum service term restriction that blocks early deletion.
+- [Delete a virtual server](https://docs.gcore.com/hosting/virtual-servers/delete-a-virtual-server.md): Delete a virtual server from the Gcore Hosting Portal and understand the minimum service term restriction that blocks early deletion.
 
 ## Troubleshooting
 - [Server suspended for non-payment](https://docs.gcore.com/hosting/virtual-servers/troubleshooting/troubleshoot-a-server-that-was-suspended-for-non-payment.md): Troubleshoot a suspended virtual server by recharging the account balance or reactivating through auto payment; check payment status in Payments and Expenses.
@@ -123,12 +123,12 @@
 - [View the authorization history of your account](https://docs.gcore.com/hosting/account-management/view-the-authorization-history-of-your-account.md): View account authorization history in the hosting portal - timestamps, user email and ID, remote IP address, action type, and authorization method.
 
 ## Payments
-- [Pay for Gcore services](https://docs.gcore.com/hosting/payments/pay-for-gcore-services-payment-methods.md): Configure payments in the Gcore hosting portal via PayPal, bank transfer, bank card, or Alipay using the Add funds wizard.
+- [Pay for Gcore services](https://docs.gcore.com/hosting/payments/pay-for-gcore-services-payment-methods.md): Configure payments in the Gcore Hosting Portal via PayPal, bank transfer, bank card, or Alipay using the Add funds wizard.
 - [Renew the server](https://docs.gcore.com/hosting/payments/renew-your-server.md): Manage Virtual Server and Dedicated Server renewal in Gcore hosting by keeping the account balance funded; manually renew a Dedicated Server via the portal.
 - [Set up auto payment](https://docs.gcore.com/hosting/payments/set-up-auto-payment.md): Configure auto payment to recharge the Gcore hosting balance from a linked payment method when funds fall short; overcommit charges require manual payment.
 - [Troubleshoot payment errors](https://docs.gcore.com/hosting/payments/troubleshoot-payment-errors.md): Troubleshoot payment errors in Gcore hosting for PayPal, bank cards, AMEX, AliPay, and bank transfers.
 - [Check the payment history](https://docs.gcore.com/hosting/payments/check-the-payment-history.md): View payment history and download invoices as PDF files in the Gcore hosting portal Billing section.
 - [Request a refund](https://docs.gcore.com/hosting/payments/request-a-refund.md): Send a support ticket to request a refund in Gcore hosting; include the refund reason and server details; refunds are processed Monday to Friday.
-- [Contact our technical support](https://docs.gcore.com/hosting/contact-our-technical-support.md): Send a support ticket or use live chat to reach Gcore technical support around the clock via the Gcore hosting portal or gcore.com.
+- [Contact our technical support](https://docs.gcore.com/hosting/contact-our-technical-support.md): Send a support ticket or use live chat to reach Gcore technical support around the clock via the Gcore Hosting Portal or the Gcore website.
 - [Manage hosting services via API](https://docs.gcore.com/hosting/manage-hosting-services-via-api.md): Manage Gcore hosting services via Billmanager, DCImanager, and VMmanager APIs for server provisioning, payments, and server management.
 - [Become a reseller and resell our services](https://docs.gcore.com/hosting/become-reseller-and-resell-our-services.md): Apply for the Gcore hosting reseller program by contacting support with your company details to receive reseller discounts in the hosting portal.

--- a/hosting/manage-hosting-services-via-api.mdx
+++ b/hosting/manage-hosting-services-via-api.mdx
@@ -4,8 +4,4 @@ sidebarTitle: API
 ai-navigation: Manage Gcore hosting services via Billmanager, DCImanager, and VMmanager APIs for server provisioning, payments, and server management.
 ---
 
-The following APIs provide access to hosting management features and automation.
-
-- [Billmanager&nbsp;API](https://docs.ispsystem.com/billmanager/developer-section/billmanager-api) — order servers, manage payments, and perform all actions available in the hosting portal.
-- [DCImanager&nbsp;API](https://docs.ispsystem.com/dcimanager/developer-section/dcimanager-api) — manage Dedicated Servers.
-- [VMmanager&nbsp;API](https://docs.ispsystem.com/vmmanager-kvm/developer-section/vmmanager-kvm-api) — manage VPS instances.
+Hosting management is available through three APIs. The [Billmanager&nbsp;API](https://docs.ispsystem.com/billmanager/developer-section/billmanager-api) covers server provisioning, payments, and all portal actions. The [DCImanager&nbsp;API](https://docs.ispsystem.com/dcimanager/developer-section/dcimanager-api) manages Dedicated Servers. The [VMmanager&nbsp;API](https://docs.ispsystem.com/vmmanager-kvm/developer-section/vmmanager-kvm-api) manages Virtual Private Servers.

--- a/hosting/payments/pay-for-gcore-services-payment-methods.mdx
+++ b/hosting/payments/pay-for-gcore-services-payment-methods.mdx
@@ -1,10 +1,10 @@
 ---
 title: Pay for Gcore services
 sidebarTitle: Pay for Gcore services
-ai-navigation: Configure payments in the Gcore hosting portal via PayPal, bank transfer, bank card, or Alipay using the Add funds wizard.
+ai-navigation: Configure payments in the Gcore Hosting Portal via PayPal, bank transfer, bank card, or Alipay using the Add funds wizard.
 ---
 
-Use the Gcore hosting portal to add funds to the account using PayPal, bank transfer, bank card (Visa, Mastercard, American Express, UnionPay), or Alipay. The available payment currency depends on the account provider: EUR for Gcore accounts and USD for Gcore USD accounts.
+Use the [Gcore&nbsp;Hosting&nbsp;Portal](https://hosting.gcore.com/billmgr) to add funds to the account using PayPal, bank transfer, bank card (Visa, Mastercard, American Express, UnionPay), or Alipay. The available payment currency depends on the account provider: EUR for Gcore accounts and USD for Gcore USD accounts.
 
 <Tabs>
   <Tab title="PayPal">
@@ -13,7 +13,7 @@ Use the Gcore hosting portal to add funds to the account using PayPal, bank tran
 
 <Steps>
   <Step title="Log in and open Add funds">
-    Log in to the [Gcore hosting portal](https://hosting.gcore.com/billmgr). On the **Home** page, click **Add funds** in the **Quick access** section. The account provider is shown in the **Information about account** section on the same page.
+    Log in to the Hosting Portal. On the **Home** page, click **Add funds** in the **Quick access** section. The account provider is shown in the **Information about account** section on the same page.
 
     <Frame>![Home page with Information about account section and Add funds button](/images/docs/hosting/payments/pay-for-gcore-services-payment-methods/pay-image1.png)</Frame>
   </Step>
@@ -51,7 +51,7 @@ The money will be added to the account balance within 72 hours. If this does not
 
 <Steps>
   <Step title="Log in and open Add funds">
-    Log in to the [Gcore hosting portal](https://hosting.gcore.com/billmgr). On the **Home** page, click **Add funds** in the **Quick access** section. The account provider is shown in the **Information about account** section on the same page.
+    Log in to the Hosting Portal. On the **Home** page, click **Add funds** in the **Quick access** section. The account provider is shown in the **Information about account** section on the same page.
 
     <Frame>![Home page with Information about account section and Add funds button](/images/docs/hosting/payments/pay-for-gcore-services-payment-methods/pay-image1.png)</Frame>
   </Step>
@@ -92,7 +92,7 @@ The money will be added to the account balance within 5 business days. If this d
 
 <Steps>
   <Step title="Log in and open Add funds">
-    Log in to the [Gcore hosting portal](https://hosting.gcore.com/billmgr). On the **Home** page, click **Add funds** in the **Quick access** section. The account provider is shown in the **Information about account** section on the same page.
+    Log in to the Hosting Portal. On the **Home** page, click **Add funds** in the **Quick access** section. The account provider is shown in the **Information about account** section on the same page.
 
     <Frame>![Home page with Information about account section and Add funds button](/images/docs/hosting/payments/pay-for-gcore-services-payment-methods/pay-image1.png)</Frame>
   </Step>

--- a/hosting/virtual-servers/delete-a-virtual-server.mdx
+++ b/hosting/virtual-servers/delete-a-virtual-server.mdx
@@ -1,7 +1,7 @@
 ---
 title: Delete a virtual server
 sidebarTitle: Delete
-ai-navigation: Delete a virtual server from the Gcore Hosting control panel and understand the minimum service term restriction that blocks early deletion.
+ai-navigation: Delete a virtual server from the Gcore Hosting Portal and understand the minimum service term restriction that blocks early deletion.
 ---
 
 Deleting a virtual server permanently removes it from the account, erases all data, and stops billing.
@@ -12,7 +12,7 @@ Deletion is irreversible. Back up any important files before proceeding.
 
 ## Delete a server
 
-1. In the Gcore Hosting [control&nbsp;panel](https://hosting.gcore.com/billmgr), navigate to **Virtual private servers** in the left-side menu.
+1. In the [Gcore&nbsp;Hosting&nbsp;Portal](https://hosting.gcore.com/billmgr), navigate to **Virtual private servers** in the left-side menu.
 2. Select the checkbox next to the server and click **Delete** in the toolbar.
 
 <Frame>

--- a/hosting/virtual-servers/manage/connect/connect-to-a-virtual-server-via-vnc.mdx
+++ b/hosting/virtual-servers/manage/connect/connect-to-a-virtual-server-via-vnc.mdx
@@ -1,7 +1,7 @@
 ---
 title: Connect to a virtual server via VNC in VMmanager 6
 sidebarTitle: VNC
-ai-navigation: Connect to a virtual server via VNC console in VMmanager 6 using credentials retrieved from the Hosting portal Instructions page or the activation email.
+ai-navigation: Connect to a virtual server via VNC console in VMmanager 6 using credentials retrieved from the Hosting Portal Instructions page or the activation email.
 ---
 
 The VNC console in VMmanager 6 provides browser-based access to a virtual server without installing a separate client.
@@ -10,7 +10,7 @@ The VNC console in VMmanager 6 provides browser-based access to a virtual server
 
 <Steps>
   <Step title="Retrieve connection credentials">
-    Log in to the [Hosting&nbsp;portal](https://hosting.gcore.com). In the left sidebar, select **Products/Services** → **Virtual private servers**. Check the box next to the server, then click **Instructions** in the toolbar.
+    Log in to the [Gcore&nbsp;Hosting&nbsp;Portal](https://hosting.gcore.com/billmgr). In the left sidebar, select **Products/Services** → **Virtual private servers**. Check the box next to the server, then click **Instructions** in the toolbar.
 
     <Frame>![Virtual private servers list with a server selected and the Instructions button in the toolbar](/images/docs/hosting/virtual-servers/manage/connect/connect-to-a-virtual-server-via-vnc/connect-to-a-virtual-server-via-vnc-image1.png)</Frame>
 

--- a/hosting/virtual-servers/manage/install-gui-desktop-environment-on-ubuntu-centos-and-debian.mdx
+++ b/hosting/virtual-servers/manage/install-gui-desktop-environment-on-ubuntu-centos-and-debian.mdx
@@ -8,7 +8,7 @@ Linux servers are provisioned without a graphical interface. Install XFCE to get
 
 <Frame>![XFCE desktop environment](/images/docs/hosting/virtual-servers/manage/install-gui-desktop-environment-on-ubuntu-centos-and-debian/image2.png)</Frame>
 
-Connect to the server via [SSH](/hosting/virtual-servers/manage/connect/linux-server/connect-to-linux-server-via-ssh) or [VNC](/hosting/virtual-servers/manage/connect/connect-to-a-virtual-server-via-vnc) before starting. The login credentials are available on the **Instructions** tab in the [Hosting&nbsp;portal](https://hosting.gcore.com/billmgr).
+Connect to the server via [SSH](/hosting/virtual-servers/manage/connect/linux-server/connect-to-linux-server-via-ssh) or [VNC](/hosting/virtual-servers/manage/connect/connect-to-a-virtual-server-via-vnc) before starting. The login credentials are available on the **Instructions** tab in the [Gcore&nbsp;Hosting&nbsp;Portal](https://hosting.gcore.com/billmgr).
 
 ## Install XFCE
 

--- a/hosting/virtual-servers/manage/main-features-and-functions-of-vmmanager-6.mdx
+++ b/hosting/virtual-servers/manage/main-features-and-functions-of-vmmanager-6.mdx
@@ -4,9 +4,9 @@ sidebarTitle: VMmanager 6
 ai-navigation: Manage virtual servers in VMmanager 6 - stop, restart, suspend, reinstall OS, mount ISO images, change passwords, manage disks, access VNC, run scripts, and enable recovery mode.
 ---
 
-VMmanager 6 is a control panel for managing virtual private servers. Each server ordered from the Gcore Hosting portal is accessible through this panel.
+VMmanager 6 is a control panel for managing virtual private servers. Each server ordered from the Gcore Hosting Portal is accessible through this panel.
 
-To open VMmanager 6 for a server, log in to the [Hosting portal](https://hosting.gcore.com/billmgr) and complete the following steps:
+To open VMmanager 6 for a server, log in to the [Gcore&nbsp;Hosting&nbsp;Portal](https://hosting.gcore.com/billmgr) and complete the following steps:
 
 <Steps>
   <Step title="Open the server list">

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -593,7 +593,7 @@
 ## Before purchase
 - [Test the connectivity between your location and the server you want to buy](https://docs.gcore.com/hosting/virtual-servers/before-purchase/test-the-connectivity-between-your-location-and-the-server-you-want-to-buy.md): Use the Gcore Looking Glass tool to test connectivity between an IP address and Gcore server nodes via BGP, PING, and TRACEROUTE commands.
 - [Order a dedicated server](https://docs.gcore.com/hosting/dedicated-servers/order-a-dedicated-server.md): Create a Dedicated Server order via the Control Panel or website by selecting a tariff, configuring parameters, and completing payment.
-- [Upgrade your dedicated server](https://docs.gcore.com/hosting/dedicated-servers/upgrade-your-dedicated-server.md): Change Dedicated Server hardware specifications via a support ticket or update the internet plan independently in the Control Panel.
+- [Upgrade your dedicated server](https://docs.gcore.com/hosting/dedicated-servers/upgrade-your-dedicated-server.md): Change Dedicated Server hardware specifications via a support ticket or update the internet plan independently in the Hosting Portal.
 
 ## Manage
 - [Access DCImanager](https://docs.gcore.com/hosting/dedicated-servers/manage/log-in-to-dcimanager.md): Access DCImanager to manage a dedicated server, restart it, or power it off directly from the hosting Control Panel via the To panel button.
@@ -612,7 +612,7 @@
 ## Networking
 
 ## Additional IP addresses
-- [Buy an additional IP address](https://docs.gcore.com/hosting/dedicated-servers/manage/networking/additional-ip-addresses/buy-an-additional-ip-address.md): Order additional IPv4 and IPv6 addresses for dedicated servers and virtual private servers in the Gcore Hosting control panel.
+- [Buy an additional IP address](https://docs.gcore.com/hosting/dedicated-servers/manage/networking/additional-ip-addresses/buy-an-additional-ip-address.md): Order additional IPv4 and IPv6 addresses for dedicated servers and virtual private servers in the Gcore Hosting Portal.
 - [Configure an additional IP address](https://docs.gcore.com/hosting/virtual-servers/manage/networking/additional-ip-addresses/configure-an-additional-ip-address.md): Configure additional IPv4 and IPv6 addresses on virtual private and dedicated servers via OS network settings on Debian, Ubuntu, and CentOS.
 - [Connect dedicated servers into a VLAN](https://docs.gcore.com/hosting/dedicated-servers/manage/networking/connect-dedicated-servers-into-a-vlan.md): Configure a VLAN on dedicated server switch ports in DCImanager to connect servers into a virtual local network.
 - [Configure a 10 Gbps network card](https://docs.gcore.com/hosting/dedicated-servers/manage/networking/configure-a-10-gbps-network-card.md): Configure a 10 Gbps network interface on a Dedicated Server running Ubuntu, Debian, or CentOS using the ip and ethtool commands.
@@ -651,7 +651,7 @@
 - [Connect to a Linux server via SSH](https://docs.gcore.com/hosting/virtual-servers/manage/connect/linux-server/connect-to-linux-server-via-ssh.md): Connect to Linux virtual servers via SSH using credentials from the Hosting portal Instructions tab, from any terminal on macOS, Linux, or Windows.
 - [Manage SSH keys](https://docs.gcore.com/hosting/virtual-servers/manage/connect/linux-server/manage-ssh-keys.md): Manage SSH keys for Gcore Linux virtual servers — generate a key pair, copy a public key to the server, connect via SSH key, and remove keys from authorized_keys.
 - [Change the port for SSH connections](https://docs.gcore.com/hosting/virtual-servers/manage/connect/linux-server/change-the-port-for-ssh-connections.md): Change the SSH listening port on a Linux virtual server by editing sshd_config, restarting the SSH service, and updating firewall rules.
-- [Connect to a virtual server via VNC in VMmanager 6](https://docs.gcore.com/hosting/virtual-servers/manage/connect/connect-to-a-virtual-server-via-vnc.md): Connect to a virtual server via VNC console in VMmanager 6 using credentials retrieved from the Hosting portal Instructions page or the activation email.
+- [Connect to a virtual server via VNC in VMmanager 6](https://docs.gcore.com/hosting/virtual-servers/manage/connect/connect-to-a-virtual-server-via-vnc.md): Connect to a virtual server via VNC console in VMmanager 6 using credentials retrieved from the Hosting Portal Instructions page or the activation email.
 - [Install GUI (desktop environment) on Ubuntu, CentOS and Debian](https://docs.gcore.com/hosting/virtual-servers/manage/install-gui-desktop-environment-on-ubuntu-centos-and-debian.md): Install XFCE desktop environment on Ubuntu, CentOS, and Debian virtual servers via SSH or VNC using package managers and display managers like lightdm or gdm3.
 
 ## Operating system
@@ -665,10 +665,10 @@
 - [Allocate an IPv6 address in VMmanager 6](https://docs.gcore.com/hosting/virtual-servers/manage/networking/allocate-an-ipv6-address-in-vmmanager-6.md): Allocate IPv6 addresses to virtual servers in VMmanager 6 - view assigned addresses in the Virtual machines tab and configure additional IPs via OS settings.
 
 ## Additional IP addresses
-- [Buy an additional IP address](https://docs.gcore.com/hosting/dedicated-servers/manage/networking/additional-ip-addresses/buy-an-additional-ip-address.md): Order additional IPv4 and IPv6 addresses for dedicated servers and virtual private servers in the Gcore Hosting control panel.
+- [Buy an additional IP address](https://docs.gcore.com/hosting/dedicated-servers/manage/networking/additional-ip-addresses/buy-an-additional-ip-address.md): Order additional IPv4 and IPv6 addresses for dedicated servers and virtual private servers in the Gcore Hosting Portal.
 - [Configure an additional IP address](https://docs.gcore.com/hosting/virtual-servers/manage/networking/additional-ip-addresses/configure-an-additional-ip-address.md): Configure additional IPv4 and IPv6 addresses on virtual private and dedicated servers via OS network settings on Debian, Ubuntu, and CentOS.
 - [Set up a PTR record](https://docs.gcore.com/hosting/virtual-servers/manage/set-up-a-ptr-record.md): Configure PTR records for virtual private and dedicated servers to map IP addresses to domain names for email server identification.
-- [Delete a virtual server](https://docs.gcore.com/hosting/virtual-servers/delete-a-virtual-server.md): Delete a virtual server from the Gcore Hosting control panel and understand the minimum service term restriction that blocks early deletion.
+- [Delete a virtual server](https://docs.gcore.com/hosting/virtual-servers/delete-a-virtual-server.md): Delete a virtual server from the Gcore Hosting Portal and understand the minimum service term restriction that blocks early deletion.
 
 ## Troubleshooting
 - [Server suspended for non-payment](https://docs.gcore.com/hosting/virtual-servers/troubleshooting/troubleshoot-a-server-that-was-suspended-for-non-payment.md): Troubleshoot a suspended virtual server by recharging the account balance or reactivating through auto payment; check payment status in Payments and Expenses.
@@ -706,13 +706,13 @@
 - [View the authorization history of your account](https://docs.gcore.com/hosting/account-management/view-the-authorization-history-of-your-account.md): View account authorization history in the hosting portal - timestamps, user email and ID, remote IP address, action type, and authorization method.
 
 ## Payments
-- [Pay for Gcore services](https://docs.gcore.com/hosting/payments/pay-for-gcore-services-payment-methods.md): Configure payments in the Gcore hosting portal via PayPal, bank transfer, bank card, or Alipay using the Add funds wizard.
+- [Pay for Gcore services](https://docs.gcore.com/hosting/payments/pay-for-gcore-services-payment-methods.md): Configure payments in the Gcore Hosting Portal via PayPal, bank transfer, bank card, or Alipay using the Add funds wizard.
 - [Renew the server](https://docs.gcore.com/hosting/payments/renew-your-server.md): Manage Virtual Server and Dedicated Server renewal in Gcore hosting by keeping the account balance funded; manually renew a Dedicated Server via the portal.
 - [Set up auto payment](https://docs.gcore.com/hosting/payments/set-up-auto-payment.md): Configure auto payment to recharge the Gcore hosting balance from a linked payment method when funds fall short; overcommit charges require manual payment.
 - [Troubleshoot payment errors](https://docs.gcore.com/hosting/payments/troubleshoot-payment-errors.md): Troubleshoot payment errors in Gcore hosting for PayPal, bank cards, AMEX, AliPay, and bank transfers.
 - [Check the payment history](https://docs.gcore.com/hosting/payments/check-the-payment-history.md): View payment history and download invoices as PDF files in the Gcore hosting portal Billing section.
 - [Request a refund](https://docs.gcore.com/hosting/payments/request-a-refund.md): Send a support ticket to request a refund in Gcore hosting; include the refund reason and server details; refunds are processed Monday to Friday.
-- [Contact our technical support](https://docs.gcore.com/hosting/contact-our-technical-support.md): Send a support ticket or use live chat to reach Gcore technical support around the clock via the Gcore hosting portal or gcore.com.
+- [Contact our technical support](https://docs.gcore.com/hosting/contact-our-technical-support.md): Send a support ticket or use live chat to reach Gcore technical support around the clock via the Gcore Hosting Portal or the Gcore website.
 - [Manage hosting services via API](https://docs.gcore.com/hosting/manage-hosting-services-via-api.md): Manage Gcore hosting services via Billmanager, DCImanager, and VMmanager APIs for server provisioning, payments, and server management.
 - [Become a reseller and resell our services](https://docs.gcore.com/hosting/become-reseller-and-resell-our-services.md): Apply for the Gcore hosting reseller program by contacting support with your company details to receive reseller discounts in the hosting portal.
 ---


### PR DESCRIPTION
Standardize Gcore Hosting Portal capitalization and linking in delete-a-virtual-server, buy-an-additional-ip-address, connect-to-a-virtual-server-via-vnc, main-features-of-vmmanager-6, install-gui-desktop-environment, pay-for-gcore-services-payment-methods. Remove redundant 'on the website' from upgrade-your-dedicated-server catalog link. Rewrite manage-hosting-services-via-api list as prose. Fix contact-our-technical-support: organic live chat link, add portal context to ticket step. Fix become-reseller: add portal context to Discounts navigation.