### PR TITLE
[WAAP] Fix reserved tag article links

### DIFF
--- a/waap/api-discovery-and-protection/configure-api-access-with-reserved-tags.mdx
+++ b/waap/api-discovery-and-protection/configure-api-access-with-reserved-tags.mdx
@@ -4,9 +4,9 @@ sidebarTitle: Configure API Protection using reserved tags
 ai-navigation: Configure API protection reserved tags for API-level authorization, Auth token protection, and Sensitive data exposure via Customer Portal or Gcore API.
 ---
 
-Reserved tags provide additional context about API endpoints and matching requests during policy evaluation.
+The [API&nbsp;Protection](/waap/waap-policies/advanced-api-protection) reserved tags described in this article provide additional context about API endpoints and tagged requests during policy evaluation.
 
-Three [API&nbsp;Protection](/waap/waap-policies/advanced-api-protection) policies evaluate these tags: API-level authorization, Auth token protection, and Sensitive data exposure.
+Three API Protection policies evaluate these tags: API-level authorization, Auth token protection, and Sensitive data exposure.
 
 [Reserved&nbsp;tag](/waap/waap-rules/custom-rules/tag-rules/reserved-tags) names and purposes are predefined and can't be customized.
 
@@ -36,9 +36,9 @@ Sensitive data exposure evaluates the following reserved exception tags for supp
 | Ignore Email Address Detection | Prevents the policy from blocking a response based on detected email addresses when the tag is present | Confirmed API paths |
 | Ignore Phone Number Detection | Prevents the policy from blocking a response based on detected phone numbers when the tag is present | Confirmed API paths |
 
-Assign endpoint-related tags to confirmed API paths in the [Gcore Customer Portal](https://portal.gcore.com) on the [API&nbsp;Discovery](https://portal.gcore.com/waap/api-discovery/) page, or through the [Gcore&nbsp;API](/api-reference/waap#api-discovery).
+Assign endpoint-related tags to confirmed API paths in the [Gcore Customer Portal](https://portal.gcore.com) on the [API&nbsp;Discovery](https://portal.gcore.com/waap/api-discovery/) page, or through the [Gcore&nbsp;API](/api-reference/waap/api-discovery/update-an-api-path).
 
-Apply requester-role tags to matching requests with Custom or Advanced Rules on the Customer Portal [Custom&nbsp;Rules](https://portal.gcore.com/waap/waap-rules) page, or through the Gcore API [Custom&nbsp;Rules](/api-reference/waap#custom-rules) or [Advanced&nbsp;Rules](/api-reference/waap#advanced-rules) endpoints.
+Apply requester-role tags to matching requests with Custom or Advanced Rules on the Customer Portal [Custom&nbsp;Rules](https://portal.gcore.com/waap/waap-rules) page, or through the Gcore API [Custom&nbsp;Rules](/api-reference/waap/custom-rules/create-a-custom-rule) or [Advanced&nbsp;Rules](/api-reference/waap/advanced-rules/create-an-advanced-rule) endpoints.
 
 ## API-level authorization in API Protection
 


### PR DESCRIPTION
What changed
Updated the API Protection reserved tags article to clarify its scope and corrected links to the relevant WAAP API operations.

Files changed
waap/api-discovery-and-protection/configure-api-access-with-reserved-tags.mdx — revised the introduction and fixed three API links.