### PR TITLE
[WAAP, CDN] Fix broken Gcore support links

### DIFF
--- a/cdn/cdn-resource-options/security/use-a-secure-token/configure-and-use-secure-token.mdx
+++ b/cdn/cdn-resource-options/security/use-a-secure-token/configure-and-use-secure-token.mdx
@@ -345,5 +345,5 @@ The effect is most visible with [Query String Forwarding](/cdn/cdn-resource-opti
 
 If you observe this pattern — `200` and `403` mixed together for the same user on a mobile network — we can change the default token behavior from binding to a dedicated IP to binding to a wider subnet mask, such as `/24` or even `/16` for very aggressive mobile operators. A wider mask still ties the URL to the user's ISP block (so external sharing and hotlinking remain blocked) while tolerating IP rotation within that block.
 
-This option is available for Enterprise customers. To enable it, contact our [support team](https://gcore.com/support) or your account manager.
+This option is available for Enterprise customers. To enable it, contact our [support team](https://support.gcore.com/hc/en-us) or your account manager.
 

--- a/waap/manage-waap-via-terraform.mdx
+++ b/waap/manage-waap-via-terraform.mdx
@@ -322,7 +322,7 @@ resource "gcore_waap_custom_rule" "tag_monitor" {
 ## Advanced rules
 
 <Info>
-Advanced rules require an Enterprise WAAP plan — accounts without this feature receive a 401 error from the API. Contact [Gcore&nbsp;support](https://gcore.com/docs/support) to upgrade.
+Advanced rules require an Enterprise WAAP plan — accounts without this feature receive a 401 error from the API. Contact [Gcore&nbsp;support](https://support.gcore.com/hc/en-us) to upgrade.
 </Info>
 
 Advanced rules use an expression language to match requests with greater precision than custom rules. The expression is evaluated per request, and the rule fires when it returns true.


### PR DESCRIPTION
## What changed

Updated broken support links in the WAAP Terraform and CDN secure token articles to point to the active Gcore Help Center. This resolves DOC-1910.

## Files changed

- `waap/manage-waap-via-terraform.mdx` — corrected the Gcore Support destination.
- `cdn/cdn-resource-options/security/use-a-secure-token/configure-and-use-secure-token.mdx` — corrected the support team destination.

