### PR TITLE
Document Bare Metal server start/stop/reboot actions (DOC-1913)

### DIFF
--- a/.agents/skills/api-use-case/SKILL.md
+++ b/.agents/skills/api-use-case/SKILL.md
@@ -145,7 +145,7 @@ client.cloud.something.list(project_id=project_id, region_id=region_id)
 
 ### Go SDK
 
-As of `gcore-go` v0.55.0, `gcore.NewClient()` reads `GCORE_CLOUD_PROJECT_ID` and `GCORE_CLOUD_REGION_ID` automatically, the same way it already read `GCORE_API_KEY` — matching the Python SDK. **Do not pass `ProjectID`/`RegionID` in the params struct** when the three env vars are set; the client-level defaults are used.
+`gcore.NewClient()` reads `GCORE_CLOUD_PROJECT_ID` and `GCORE_CLOUD_REGION_ID` automatically, the same way it reads `GCORE_API_KEY` — matching the Python SDK. **Do not pass `ProjectID`/`RegionID` in the params struct** when the three env vars are set; the client-level defaults are used.
 
 **Correct pattern:**
 ```go

--- a/.agents/skills/api-use-case/SKILL.md
+++ b/.agents/skills/api-use-case/SKILL.md
@@ -145,30 +145,22 @@ client.cloud.something.list(project_id=project_id, region_id=region_id)
 
 ### Go SDK
 
-The Go SDK does not read `project_id`/`region_id` at client level — they must be passed explicitly in every params struct. Only `GCORE_API_KEY` is read automatically by `gcore.NewClient()`.
+As of `gcore-go` v0.55.0, `gcore.NewClient()` reads `GCORE_CLOUD_PROJECT_ID` and `GCORE_CLOUD_REGION_ID` automatically, the same way it already read `GCORE_API_KEY` — matching the Python SDK. **Do not pass `ProjectID`/`RegionID` in the params struct** when the three env vars are set; the client-level defaults are used.
 
 **Correct pattern:**
 ```go
 import (
     "context"
-    "os"
-    "strconv"
 
     gcore "github.com/G-Core/gcore-go"
     "github.com/G-Core/gcore-go/cloud"
 )
 
 func main() {
-    projectID, _ := strconv.ParseInt(os.Getenv("GCORE_CLOUD_PROJECT_ID"), 10, 64)
-    regionID,  _ := strconv.ParseInt(os.Getenv("GCORE_CLOUD_REGION_ID"),  10, 64)
-
-    client := gcore.NewClient()       // reads GCORE_API_KEY automatically — no option.WithAPIKey
+    client := gcore.NewClient()       // reads GCORE_API_KEY, GCORE_CLOUD_PROJECT_ID, GCORE_CLOUD_REGION_ID automatically
     ctx := context.Background()       // created once, passed to every call
 
-    result, err := client.Cloud.Something.Do(ctx, cloud.SomeParams{
-        ProjectID: gcore.Int(projectID),
-        RegionID:  gcore.Int(regionID),
-    })
+    result, err := client.Cloud.Something.Do(ctx, cloud.SomeParams{})   // no ProjectID/RegionID
 }
 ```
 
@@ -178,6 +170,11 @@ import "github.com/G-Core/gcore-go/option"
 client := gcore.NewClient(option.WithAPIKey(os.Getenv("GCORE_API_KEY")))  // wrong — no option import needed
 
 result, err := client.Cloud.Something.Do(context.TODO(), ...)  // wrong — context.TODO() is a placeholder
+
+// wrong — redundant now that the client reads these from env; only add ProjectID/RegionID
+// when a single script must operate across more than one project or region
+projectID, _ := strconv.ParseInt(os.Getenv("GCORE_CLOUD_PROJECT_ID"), 10, 64)
+result, err := client.Cloud.Something.Do(ctx, cloud.SomeParams{ProjectID: gcore.Int(projectID)})
 ```
 
 Key rules:
@@ -185,6 +182,7 @@ Key rules:
 - No `option` import
 - `ctx := context.Background()` — one variable, reused in all calls
 - `context.TODO()` is forbidden
+- Omit `ProjectID`/`RegionID` from params structs — only add them back for an example that deliberately targets a project or region different from the one set in the env vars
 
 ---
 

--- a/cloud/bare-metal-servers/create-a-bare-metal-server.mdx
+++ b/cloud/bare-metal-servers/create-a-bare-metal-server.mdx
@@ -729,6 +729,78 @@ ssh -i ~/.ssh/my-key ubuntu@<public-ip>
 
 <p>After provisioning, retrieve the server details with `GET /cloud/v1/bminstances/{project_id}/{region_id}/{server_id}` — each trunk appears as a separate interface block in the `addresses` map.</p>
 
+## Start, stop, and reboot
+
+<p>Change a Bare Metal server's power state, or force a hard reboot when a soft reboot does not respond.</p>
+
+<Tabs>
+  <Tab title="Python SDK">
+    ```python
+    result = client.cloud.baremetal.servers.action(server_id=server_id, action="stop")
+    client.cloud.tasks.poll(result.tasks[0])
+    ```
+  </Tab>
+  <Tab title="Go SDK">
+    ```go
+    taskList, err := client.Cloud.Baremetal.Servers.Action(ctx, serverID, cloud.BaremetalServerActionParams{
+        OfBasicBareMetalActionInstanceSerializer: &cloud.BaremetalServerActionParamsBodyBasicBareMetalActionInstanceSerializer{
+            Action: "stop",
+        },
+    })
+    client.Cloud.Tasks.Poll(ctx, taskList.Tasks[0])
+    ```
+  </Tab>
+  <Tab title="curl">
+    ```bash
+    curl -X POST "https://api.gcore.com/cloud/v2/bminstances/$GCORE_CLOUD_PROJECT_ID/$GCORE_CLOUD_REGION_ID/$SERVER_ID/action" \
+      -H "Authorization: APIKey $GCORE_API_KEY" \
+      -H "Content-Type: application/json" \
+      -d '{"action": "stop"}'
+    ```
+
+    Response:
+
+    ```json
+    {"tasks": ["c284dcba-9804-43b9-815a-5c7eb466439e"]}
+    ```
+
+    Poll `GET /cloud/v1/tasks/{task_id}` every 10 seconds until `state` is `FINISHED`. A reboot or hard reboot on physical hardware can take several minutes — longer than the equivalent Virtual Machine operation.
+  </Tab>
+</Tabs>
+
+<p>Replace `"stop"` with `"reboot"` or `"reboot_hard"` for the other basic actions. Starting a stopped server accepts an extra `activate_profile` flag that re-activates the server's [Advanced&nbsp;DDoS&nbsp;protection](/ddos-protection) profile:</p>
+
+<Tabs>
+  <Tab title="Python SDK">
+    ```python
+    result = client.cloud.baremetal.servers.action(
+        server_id=server_id,
+        action="start",
+        activate_profile=True,
+    )
+    ```
+  </Tab>
+  <Tab title="Go SDK">
+    ```go
+    taskList, err := client.Cloud.Baremetal.Servers.Action(ctx, serverID, cloud.BaremetalServerActionParams{
+        OfStartActionInstanceSerializer: &cloud.BaremetalServerActionParamsBodyStartActionInstanceSerializer{
+            ActivateProfile: gcore.Bool(true),
+        },
+    })
+    ```
+  </Tab>
+  <Tab title="curl">
+    ```bash
+    curl -X POST "https://api.gcore.com/cloud/v2/bminstances/$GCORE_CLOUD_PROJECT_ID/$GCORE_CLOUD_REGION_ID/$SERVER_ID/action" \
+      -H "Authorization: APIKey $GCORE_API_KEY" \
+      -H "Content-Type: application/json" \
+      -d '{"action": "start", "activate_profile": true}'
+    ```
+  </Tab>
+</Tabs>
+
+<p>`activate_profile` defaults to `true` — set it to `false` to start the server without touching the DDoS profile.</p>
+
 ## Clean up
 
 <p>Bare Metal deletion is asynchronous and takes 3–5 minutes — the server must be fully deprovisioned before the hardware is released. Local NVMe storage is wiped during deprovisioning.</p>


### PR DESCRIPTION
- Add Start, stop, and reboot section to the REST API tab of create-a-bare-metal-server.mdx, covering stop/start/reboot/reboot_hard and the activate_profile flag, with curl, Python SDK, and Go SDK examples verified against the live API.
- Update api-use-case/SKILL.md Go SDK pattern: gcore-go v0.55.0 now reads GCORE_CLOUD_PROJECT_ID and GCORE_CLOUD_REGION_ID from env, so ProjectID/ RegionID no longer need to be passed explicitly in params structs.