### PR TITLE
DOC-923: Resize File Shares for Managed Kubernetes

### DIFF
--- a/cloud/file-shares/resize-file-shares-for-kubernetes.mdx
+++ b/cloud/file-shares/resize-file-shares-for-kubernetes.mdx
@@ -1,0 +1,75 @@
+---
+title: Resize file shares for Managed Kubernetes
+sidebarTitle: Resize for Kubernetes
+ai-navigation: Resize Standard NFS File Shares used by Managed Kubernetes by unmounting workloads, expanding capacity in the Customer Portal, then remounting PersistentVolumeClaims.
+---
+
+Standard NFS [File Shares](/cloud/file-shares/about-file-shares) that Managed Kubernetes mounts through the [NFS CSI driver](/cloud/kubernetes/storage/configure-nfs-csi-driver-for-kubernetes) must be unmounted before a resize. Resizing a mounted share breaks active NFS mounts with a stale file handle, even when pods remain in the Running state.
+
+This procedure covers Standard File Shares already attached to a cluster as a `gcore-nfs-*` StorageClass. The new size must be larger than the current size, because downsizing is not supported. General resize steps for Virtual Machines and Bare Metal are in [configure file shares](/cloud/file-shares/configure-file-shares).
+
+## Resize limitation
+
+A live resize while pods still mount the share interrupts I/O. The pod may stay Running with zero restarts, while writes fail with `Stale file handle`.
+
+After the share is resized and remounted, new or restarted pods see the expanded capacity. Plan a short maintenance window so workloads that use the PersistentVolumeClaim (PVC) can stop, then start again.
+
+## Resize procedure
+
+Unmount every workload that uses the PVC, expand the share in the [Gcore Customer Portal](https://portal.gcore.com), then bring the workloads back so Kubernetes remounts the share.
+
+<Steps>
+  <Step title="Identify workloads">
+    Find every Deployment, StatefulSet, or pod that mounts the PVC backed by the File Share StorageClass.
+
+    ```bash
+    kubectl get pvc
+    kubectl get pods -A -o wide
+    ```
+
+    Note the Deployment or StatefulSet name and the replica count. Those values are needed to restore capacity after the resize.
+  </Step>
+  <Step title="Unmount the share">
+    Scale the workloads to zero replicas, or delete the pods that mount the PVC, so the cluster releases the NFS mount.
+
+    ```bash
+    kubectl scale deployment/<deployment-name> --replicas=0
+    ```
+
+    Confirm that no pods still mount the PVC before continuing:
+
+    ```bash
+    kubectl get pods -A
+    ```
+  </Step>
+  <Step title="Resize the File Share">
+    In the Customer Portal, open **Cloud** → **Storage** → **File Shares**, then select the share.
+
+    In the **Overview** tab, click **Resize**, enter a larger size in GiB, and confirm.
+
+    Wait until the share status returns to Available and the **Size** field shows the new capacity.
+  </Step>
+  <Step title="Remount workloads">
+    Scale the Deployment or StatefulSet back to the previous replica count, or recreate the pods that use the PVC.
+
+    ```bash
+    kubectl scale deployment/<deployment-name> --replicas=<previous-count>
+    ```
+
+    Confirm the pods reach Running:
+
+    ```bash
+    kubectl get pods -l app=<label>
+    ```
+  </Step>
+  <Step title="Verify capacity">
+    From a running pod that mounts the PVC, check that the filesystem reports the new size and that read and write operations succeed.
+
+    ```bash
+    kubectl exec -it <pod-name> -- df -h /mnt/data
+    kubectl exec -it <pod-name> -- sh -c "echo ok >> /mnt/data/resize-check.txt && cat /mnt/data/resize-check.txt"
+    ```
+
+    Replace `/mnt/data` with the mount path used by the application. A successful remount shows the expanded size and accepts new writes without stale file handle errors.
+  </Step>
+</Steps>

--- a/cloud/kubernetes/storage/configure-nfs-csi-driver-for-kubernetes.mdx
+++ b/cloud/kubernetes/storage/configure-nfs-csi-driver-for-kubernetes.mdx
@@ -26,4 +26,4 @@ When the File Share is connected correctly, the output includes a `gcore-nfs-*` 
 
 ## Resize a file share
 
-To resize a file share, first unmount it from the Kubernetes cluster, then resize it in the portal, then remount it. Resizing while mounted will cause applications to stop working correctly.
+Standard File Shares must be unmounted from the cluster before a resize, then remounted afterward. Resizing while mounted breaks I/O with a stale file handle, even when pods remain Running. Follow the [Kubernetes resize procedure](/cloud/file-shares/resize-file-shares-for-kubernetes) for the full steps.

--- a/cloud/llms.txt
+++ b/cloud/llms.txt
@@ -98,6 +98,7 @@
 ## File shares
 - [About file shares](https://docs.gcore.com/cloud/file-shares/about-file-shares.md): Create and manage NFS file shares across Virtual Machines, Bare Metal servers, and Kubernetes pods using the NFS protocol, with support for access rules, snapshots, persistent volumes with RWX mode, and on-demand scaling.
 - [Configuring file shares](https://docs.gcore.com/cloud/file-shares/configure-file-shares.md): Create NFS-based file shares and mount them to Virtual Machines via Customer Portal, REST API, or Terraform.
+- [Resize file shares for Managed Kubernetes](https://docs.gcore.com/cloud/file-shares/resize-file-shares-for-kubernetes.md): Resize Standard NFS File Shares used by Managed Kubernetes by unmounting workloads, expanding capacity in the Customer Portal, then remounting PersistentVolumeClaims.
 - [Migrate data from S3 and EFS to Gcore](https://docs.gcore.com/cloud/file-shares/how-to-migrate-data-from-s3.md): Migrate data from Amazon S3 and EFS to Gcore Object Storage and File Shares using rclone CLI tool with AWS IAM credentials, S3 bucket configuration, and NFS mount paths.
 
 ## Managed Kubernetes

--- a/docs.json
+++ b/docs.json
@@ -675,6 +675,7 @@
                 "pages": [
                   "cloud/file-shares/about-file-shares",
                   "cloud/file-shares/configure-file-shares",
+                  "cloud/file-shares/resize-file-shares-for-kubernetes",
                   "cloud/file-shares/how-to-migrate-data-from-s3"
                 ],
                 "expanded": false

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1,6 +1,6 @@
 # Gcore Docs - Full Index
 
-> Complete article index across all Gcore products. 610 articles.
+> Complete article index across all Gcore products. 611 articles.
 > Use this file for offline indexing, bulk vectorization, or large-context retrieval.
 # Gcore Account settings
 
@@ -401,6 +401,7 @@
 ## File shares
 - [About file shares](https://docs.gcore.com/cloud/file-shares/about-file-shares.md): Create and manage NFS file shares across Virtual Machines, Bare Metal servers, and Kubernetes pods using the NFS protocol, with support for access rules, snapshots, persistent volumes with RWX mode, and on-demand scaling.
 - [Configuring file shares](https://docs.gcore.com/cloud/file-shares/configure-file-shares.md): Create NFS-based file shares and mount them to Virtual Machines via Customer Portal, REST API, or Terraform.
+- [Resize file shares for Managed Kubernetes](https://docs.gcore.com/cloud/file-shares/resize-file-shares-for-kubernetes.md): Resize Standard NFS File Shares used by Managed Kubernetes by unmounting workloads, expanding capacity in the Customer Portal, then remounting PersistentVolumeClaims.
 - [Migrate data from S3 and EFS to Gcore](https://docs.gcore.com/cloud/file-shares/how-to-migrate-data-from-s3.md): Migrate data from Amazon S3 and EFS to Gcore Object Storage and File Shares using rclone CLI tool with AWS IAM credentials, S3 bucket configuration, and NFS mount paths.
 
 ## Managed Kubernetes

--- a/llms.txt
+++ b/llms.txt
@@ -11,7 +11,7 @@
 - [Developer Tools](https://docs.gcore.com/developer-tools/llms.txt): REST API, SDKs, MCP Server, Terraform (24 articles).
 - [CDN](https://docs.gcore.com/cdn/llms.txt): Configure Gcore CDN resources for content delivery including origin groups, caching rules, SSL certificates, HTTP headers, cache purge, logs, Grafana dashboards, and Terraform integration (119 articles).
 - [FastEdge](https://docs.gcore.com/fastedge/llms.txt): FastEdge is a serverless WebAssembly edge compute platform. Run Rust and JavaScript applications at every Gcore edge location — HTTP apps, CDN extensions, edge storage, secrets, and cache available at runtime (29 articles).
-- [Edge Cloud](https://docs.gcore.com/cloud/llms.txt): Gcore Cloud is an IaaS and PaaS platform providing on-demand compute, storage, networking, containers, databases, and managed services across more than 30 global regions (105 articles).
+- [Edge Cloud](https://docs.gcore.com/cloud/llms.txt): Gcore Cloud is an IaaS and PaaS platform providing on-demand compute, storage, networking, containers, databases, and managed services across more than 30 global regions (106 articles).
 - [AI](https://docs.gcore.com/edge-ai/llms.txt): Deploy AI inference and GPU-accelerated training using Gcore AI products - Everywhere Inference for low-latency model serving at the edge and GPU Cloud for Bare Metal and Virtual Machine compute (33 articles).
 - [Gclaw](https://docs.gcore.com/gclaw/llms.txt): Managed OpenClaw service with built-in inference for launching AI agents instantly (10 articles).
 - [Managed DNS](https://docs.gcore.com/dns/llms.txt): Configure Gcore Managed DNS with Anycast routing, dynamic response, Healthchecks, DNSSEC, and OctoDNS, Certbot, Terraform integrations; compare plans (20 articles).


### PR DESCRIPTION
## Summary
- Add Kubernetes NFS File Share resize guide (remount-required flow)
- Link from NFS CSI article; register page in docs.json

## Test plan
- [ ] Mintlify preview loads resize page
- [ ] Nav shows under File shares