### PR TITLE
fix(ci): open PRs instead of pushing to protected main

### DIFF
--- a/.github/workflows/check-api-sdk.yml
+++ b/.github/workflows/check-api-sdk.yml
@@ -15,6 +15,7 @@ jobs:
     permissions:
       issues: write
       contents: write
+      pull-requests: write
 
     steps:
       - name: Checkout repository
@@ -91,7 +92,8 @@ jobs:
             --label "api-sdk-tracker" \
             --body-file /tmp/issue_body.md
 
-      - name: Commit rebuilt doc index
+      - name: Commit rebuilt doc index (feature branch)
+        if: github.ref != 'refs/heads/main'
         run: |
           git config user.name  "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -100,12 +102,26 @@ jobs:
           git commit -m "chore: rebuild API/SDK doc index"
           git push
 
+      - name: Open PR with rebuilt doc index (main)
+        if: github.ref == 'refs/heads/main'
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore: rebuild API/SDK doc index"
+          branch: chore/rebuild-api-sdk-doc-index
+          delete-branch: true
+          title: "chore: rebuild API/SDK doc index"
+          body: "Automated update of `api-sdk-tracker/doc_index.json` triggered by a push to `main`."
+          labels: automated,api-sdk-tracker
+          add-paths: api-sdk-tracker/doc_index.json
+
   sdk-diff:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
       issues: write
       contents: write
+      pull-requests: write
 
     steps:
       - name: Checkout repository
@@ -286,11 +302,14 @@ jobs:
             --label "api-sdk-tracker" \
             --body-file /tmp/issue_body.md
 
-      - name: Commit rebuilt doc index
-        run: |
-          git config user.name  "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add api-sdk-tracker/doc_index.json
-          git diff --cached --quiet && echo "Nothing to commit" && exit 0
-          git commit -m "chore: rebuild API/SDK doc index"
-          git push
+      - name: Open PR with rebuilt doc index
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore: rebuild API/SDK doc index"
+          branch: chore/rebuild-api-sdk-doc-index
+          delete-branch: true
+          title: "chore: rebuild API/SDK doc index"
+          body: "Automated update of `api-sdk-tracker/doc_index.json` from the scheduled SDK diff run."
+          labels: automated,api-sdk-tracker
+          add-paths: api-sdk-tracker/doc_index.json

--- a/.github/workflows/check-terraform-provider.yml
+++ b/.github/workflows/check-terraform-provider.yml
@@ -198,12 +198,15 @@ jobs:
             --label "terraform" \
             --body-file /tmp/issue-body.md
 
-      - name: Commit updated schemas and doc index
+      - name: Open PR with updated schemas and doc index
         if: steps.provider.outputs.latest != steps.pinned.outputs.pinned
-        run: |
-          git config user.name  "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add terraform-provider/
-          git diff --cached --quiet && echo "Nothing to commit" && exit 0
-          git commit -m "chore: update Terraform provider schema to v${{ steps.provider.outputs.latest }}"
-          git push
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore: update Terraform provider schema to v${{ steps.provider.outputs.latest }}"
+          branch: chore/update-terraform-provider-schema
+          delete-branch: true
+          title: "chore: update Terraform provider schema to v${{ steps.provider.outputs.latest }}"
+          body: "Automated update of Terraform provider schemas and `terraform-provider/doc_index.json` for v${{ steps.provider.outputs.latest }}."
+          labels: automated,terraform
+          add-paths: terraform-provider/


### PR DESCRIPTION
Automated doc-index rebuilds from check-api-sdk and check-terraform-provider were failing with GH006 because main requires pull requests. Use create-pull-request on main; keep direct push on feature branches only.