### PR TITLE
fix(ci): copy Terraform schemas using repo workspace path

### DIFF
--- a/.github/workflows/check-terraform-provider.yml
+++ b/.github/workflows/check-terraform-provider.yml
@@ -61,7 +61,8 @@ jobs:
         if: steps.provider.outputs.latest != steps.pinned.outputs.pinned
         run: |
           PINNED="${{ steps.pinned.outputs.pinned }}"
-          mkdir -p /tmp/tf-old
+          SCHEMA_DIR="$GITHUB_WORKSPACE/terraform-provider/schemas"
+          mkdir -p /tmp/tf-old "$SCHEMA_DIR"
           cat > /tmp/tf-old/main.tf <<EOF
           terraform {
             required_providers {
@@ -72,13 +73,14 @@ jobs:
           EOF
           cd /tmp/tf-old && terraform init -input=false 2>&1 | tail -5
           terraform providers schema -json > /tmp/schema-old.json
-          cp /tmp/schema-old.json "terraform-provider/schemas/gcore-$PINNED.json" 2>/dev/null || true
+          cp /tmp/schema-old.json "$SCHEMA_DIR/gcore-$PINNED.json"
 
       - name: Get schema for latest version
         if: steps.provider.outputs.latest != steps.pinned.outputs.pinned
         run: |
           LATEST="${{ steps.provider.outputs.latest }}"
-          mkdir -p /tmp/tf-new
+          SCHEMA_DIR="$GITHUB_WORKSPACE/terraform-provider/schemas"
+          mkdir -p /tmp/tf-new "$SCHEMA_DIR"
           cat > /tmp/tf-new/main.tf <<EOF
           terraform {
             required_providers {
@@ -89,7 +91,7 @@ jobs:
           EOF
           cd /tmp/tf-new && terraform init -input=false 2>&1 | tail -5
           terraform providers schema -json > /tmp/schema-new.json
-          cp /tmp/schema-new.json "terraform-provider/schemas/gcore-$LATEST.json"
+          cp /tmp/schema-new.json "$SCHEMA_DIR/gcore-$LATEST.json"
 
       - name: Rebuild doc index
         if: steps.provider.outputs.latest != steps.pinned.outputs.pinned


### PR DESCRIPTION
After cd /tmp/tf-new the relative cp target pointed under /tmp instead of terraform-provider/schemas. Use GITHUB_WORKSPACE and mkdir -p in both schema steps.