### PR TITLE
[CDN] Update SSL overview for post-creation HTTPS setup

### DIFF
--- a/cdn/llms.txt
+++ b/cdn/llms.txt
@@ -133,7 +133,7 @@
 - [Log viewer: view and download CDN resource logs](https://docs.gcore.com/cdn/logs/log-viewer-view-and-download-cdn-resource-logs.md): View and download CDN resource logs using Log viewer with filters for time interval, client IP, HTTP method, status code, data center, and cache status; export up to 10,000 log entries per 24-hour period.
 
 ## SSL certificates
-- [Add an SSL certificate to deliver content over HTTPS](https://docs.gcore.com/cdn/ssl-certificates/add-an-ssl-certificate-to-deliver-content-over-https.md): Attach SSL certificates to CDN resources for HTTPS delivery using custom domains, supporting both third-party certificates and free Let's Encrypt certificates via Gcore Customer Portal.
+- [Add an SSL certificate to deliver content over HTTPS](https://docs.gcore.com/cdn/ssl-certificates/add-an-ssl-certificate-to-deliver-content-over-https.md): Attach SSL certificates to CDN resources for HTTPS delivery with custom domains using custom or free Let's Encrypt certificates in the Customer Portal.
 - [Configure your own SSL certificate](https://docs.gcore.com/cdn/ssl-certificates/configure-your-own-ssl-certificate.md): Upload custom SSL certificates in PEM format with certificate chain (personal certificate, intermediate CA, root CA) and private key to Gcore CDN, then attach to CDN resources for custom domains and wildcard subdomains.
 - [Configure Let's Encrypt certificate](https://docs.gcore.com/cdn/ssl-certificates/configure-lets-encrypt-certificate.md): Enable HTTPS with free Let's Encrypt certificates on CDN resources using HTTP-01 or DNS-01 challenge validation, with optional Gcore Managed DNS delegation to ns1.gcorelabs.net and ns2.gcdn.services for domain ownership verification.
 

--- a/cdn/ssl-certificates/add-an-ssl-certificate-to-deliver-content-over-https.mdx
+++ b/cdn/ssl-certificates/add-an-ssl-certificate-to-deliver-content-over-https.mdx
@@ -16,9 +16,9 @@ Only one certificate can be attached per CDN resource.
 
 Two SSL certificate types are available:
 
-1. Custom SSL certificate. A third-party certificate authority issues the certificate for the custom domain — `cdn.example.com`. Upload the [custom&nbsp;certificate](/cdn/ssl-certificates/configure-your-own-ssl-certificate#method-2-add-ssl-certificate-for-an-existing-cdn-resource) in the Customer Portal and attach it to the CDN resource.
+- Custom SSL certificate. A third-party certificate authority issues the certificate for the custom domain — `cdn.example.com`. Upload the certificate in the Customer Portal and attach it to the CDN resource.
 
-2. Free Let's Encrypt certificate. Select a free [Let's&nbsp;Encrypt&nbsp;certificate](/cdn/ssl-certificates/configure-lets-encrypt-certificate#for-created-resource) for the custom domain. Gcore issues and attaches it automatically.
+- Free Let's Encrypt certificate. Select a free [Let's&nbsp;Encrypt&nbsp;certificate](/cdn/ssl-certificates/configure-lets-encrypt-certificate#for-created-resource) for the custom domain. Gcore issues and attaches it automatically.
 
 ## SSL configuration
 
@@ -36,19 +36,11 @@ Attach a certificate from the CDN resource settings:
     Open **SSL** and turn on **Enable HTTPS**.
   </Step>
   <Step title="Select a certificate">
-    Select **Free Let's Encrypt certificate** or **Custom SSL certificate**.
+    Select **Free Let's Encrypt certificate** or **Custom SSL certificate**. For a custom certificate, select the uploaded certificate from the list of available certificates.
+  </Step>
+  <Step title="Apply the configuration">
+    Click **Save changes**.
   </Step>
 </Steps>
 
-### Custom certificate upload
-
-Add a custom certificate from the CDN certificate list:
-
-<Steps>
-  <Step title="Open SSL certificates">
-    In the Customer Portal, navigate to **CDN** > **SSL certificates**.
-  </Step>
-  <Step title="Start the upload">
-    Click **Add SSL certificate**.
-  </Step>
-</Steps>
+For custom uploads, the [custom&nbsp;certificate](/cdn/ssl-certificates/configure-your-own-ssl-certificate#method-2-add-ssl-certificate-for-an-existing-cdn-resource) procedure covers entering the certificate name, certificate chain, and private key, configuring the certificate-authority option, and submitting the form.

--- a/cdn/ssl-certificates/add-an-ssl-certificate-to-deliver-content-over-https.mdx
+++ b/cdn/ssl-certificates/add-an-ssl-certificate-to-deliver-content-over-https.mdx
@@ -16,7 +16,7 @@ Only one certificate can be attached per CDN resource.
 
 Two SSL certificate types are available:
 
-- Custom SSL certificate. A third-party certificate authority issues the certificate for the custom domain — `cdn.example.com`. Upload the certificate in the Customer Portal and attach it to the CDN resource.
+- Custom SSL certificate. A third-party certificate authority issues the certificate for a custom domain such as `cdn.example.com`. Upload the certificate in the Customer Portal and attach it to the CDN resource.
 
 - Free Let's Encrypt certificate. Select a free [Let's&nbsp;Encrypt&nbsp;certificate](/cdn/ssl-certificates/configure-lets-encrypt-certificate#for-created-resource) for the custom domain. Gcore issues and attaches it automatically.
 
@@ -43,4 +43,4 @@ Attach a certificate from the CDN resource settings:
   </Step>
 </Steps>
 
-For custom uploads, the [custom&nbsp;certificate](/cdn/ssl-certificates/configure-your-own-ssl-certificate#method-2-add-ssl-certificate-for-an-existing-cdn-resource) procedure covers entering the certificate name, certificate chain, and private key, configuring the certificate-authority option, and submitting the form.
+For custom uploads, the [custom&nbsp;certificate](/cdn/ssl-certificates/configure-your-own-ssl-certificate#how-to-upload-an-ssl-certificate-to-your-account) procedure covers entering the certificate name, certificate chain, and private key, configuring the certificate-authority option, and submitting the form.

--- a/cdn/ssl-certificates/add-an-ssl-certificate-to-deliver-content-over-https.mdx
+++ b/cdn/ssl-certificates/add-an-ssl-certificate-to-deliver-content-over-https.mdx
@@ -1,22 +1,27 @@
 ---
 title: Add an SSL certificate to deliver content over HTTPS
 sidebarTitle: SSL overview
-ai-navigation: Attach SSL certificates to CDN resources for HTTPS delivery using custom domains, supporting both third-party certificates and free Let's Encrypt certificates via Gcore Customer Portal.
+ai-navigation: Attach SSL certificates to CDN resources for HTTPS delivery with custom domains using custom or free Let's Encrypt certificates in the Customer Portal.
 ---
 
-## What is an SSL certificate?
+An SSL certificate is a digital signature for a domain that verifies authenticity and enables the HTTPS protocol. HTTPS encrypts the connection between a client and a server and is required when sensitive data is transferred, including financial transactions. Background on certificates is available in [SSL&nbsp;certificates](https://gcore.com/learning/what-are-ssl-certificates).
 
-An SSL certificate is a unique digital signature for your website that verifies the authenticity of your domain and allows you to configure the HTTPS protocol for the site. This protocol provides a secure connection between a client and a server. It is essential when sensitive information is being transferred, such as during financial transactions. Learn more about SSL certificates in our [Learning article](https://gcore.com/learning/what-are-ssl-certificates).
+To deliver content over HTTPS through Gcore CDN, attach an SSL certificate to the CDN resource [custom&nbsp;domain](/cdn/cdn-resource-options/general/create-and-set-a-custom-domain-for-the-content-delivery-via-cdn).
 
-If you want to deliver content using our CDN via secured HTTPS protocol, you need to add an SSL certificate for your CDN resource's [custom domain](/cdn/cdn-resource-options/general/create-and-set-a-custom-domain-for-the-content-delivery-via-cdn). 
-
-**Note** : You can only attach one certificate per CDN resource.
+<Note>
+Only one certificate can be attached per CDN resource.
+</Note>
 
 ## SSL certificate types in Gcore
 
-In Gcore, two types of SSL certificates are available:
+Two SSL certificate types are available:
 
-  1. Your own SSL certificate. You can issue a certificate for the custom domain in the format, e.g., cdn.example.com from a third-party company and add its data to the Gcore Customer Portal. Either do so during [CDN resource creation](/cdn/ssl-certificates/configure-your-own-ssl-certificate#method-1-add-ssl-certificate-during-cdn-resource-creation) or [add it later](/cdn/ssl-certificates/configure-your-own-ssl-certificate#method-2-add-ssl-certificate-for-an-existing-cdn-resource). 
+1. **Custom SSL certificate.** Issue a certificate for the custom domain — `cdn.example.com` — from a third-party certificate authority, upload it in the Customer Portal, and attach it to the CDN resource. Steps: [Custom&nbsp;SSL&nbsp;certificate](/cdn/ssl-certificates/configure-your-own-ssl-certificate#method-2-add-ssl-certificate-for-an-existing-cdn-resource).
 
+2. **Free Let's Encrypt certificate.** Issue a free Let's Encrypt certificate for the custom domain. Gcore adds the certificate data automatically. Steps: [Let's&nbsp;Encrypt&nbsp;certificate](/cdn/ssl-certificates/configure-lets-encrypt-certificate#for-created-resource).
 
-  2. Free Let's Encrypt certificate. You can issue a free Let's Encrypt certificate for your custom domain. All data will be added automatically by Gcore. Either do so during [CDN resource creation](/cdn/ssl-certificates/configure-lets-encrypt-certificate#during-resource-creation) or [add it later](/cdn/ssl-certificates/configure-lets-encrypt-certificate#for-created-resource).
+## Where to configure SSL
+
+In the [Gcore Customer Portal](https://portal.gcore.com), open **CDN**, select **CDN resources**, open the resource, then open **SSL** and turn on **Enable HTTPS**. Select **Free Let's Encrypt certificate** or **Custom SSL certificate**.
+
+Upload and manage custom certificates under **CDN** > **SSL certificates** > **Add SSL certificate**.

--- a/cdn/ssl-certificates/add-an-ssl-certificate-to-deliver-content-over-https.mdx
+++ b/cdn/ssl-certificates/add-an-ssl-certificate-to-deliver-content-over-https.mdx
@@ -4,9 +4,9 @@ sidebarTitle: SSL overview
 ai-navigation: Attach SSL certificates to CDN resources for HTTPS delivery with custom domains using custom or free Let's Encrypt certificates in the Customer Portal.
 ---
 
-An SSL certificate is a digital signature for a domain that verifies authenticity and enables the HTTPS protocol. HTTPS encrypts the connection between a client and a server and is required when sensitive data is transferred, including financial transactions. Background on certificates is available in [SSL&nbsp;certificates](https://gcore.com/learning/what-are-ssl-certificates).
+An SSL certificate associates a domain with a public key and allows clients to verify the server's identity. HTTPS protects sensitive data in transit, including financial information. The [SSL&nbsp;certificate](https://gcore.com/learning/what-are-ssl-certificates) overview explains how certificates establish encrypted connections.
 
-To deliver content over HTTPS through Gcore CDN, attach an SSL certificate to the CDN resource [custom&nbsp;domain](/cdn/cdn-resource-options/general/create-and-set-a-custom-domain-for-the-content-delivery-via-cdn).
+To deliver content over HTTPS through Gcore CDN, attach an SSL certificate to a CDN resource that uses a [custom&nbsp;domain](/cdn/cdn-resource-options/general/create-and-set-a-custom-domain-for-the-content-delivery-via-cdn).
 
 <Note>
 Only one certificate can be attached per CDN resource.
@@ -16,12 +16,39 @@ Only one certificate can be attached per CDN resource.
 
 Two SSL certificate types are available:
 
-1. **Custom SSL certificate.** Issue a certificate for the custom domain — `cdn.example.com` — from a third-party certificate authority, upload it in the Customer Portal, and attach it to the CDN resource. Steps: [Custom&nbsp;SSL&nbsp;certificate](/cdn/ssl-certificates/configure-your-own-ssl-certificate#method-2-add-ssl-certificate-for-an-existing-cdn-resource).
+1. Custom SSL certificate. A third-party certificate authority issues the certificate for the custom domain — `cdn.example.com`. Upload the [custom&nbsp;certificate](/cdn/ssl-certificates/configure-your-own-ssl-certificate#method-2-add-ssl-certificate-for-an-existing-cdn-resource) in the Customer Portal and attach it to the CDN resource.
 
-2. **Free Let's Encrypt certificate.** Issue a free Let's Encrypt certificate for the custom domain. Gcore adds the certificate data automatically. Steps: [Let's&nbsp;Encrypt&nbsp;certificate](/cdn/ssl-certificates/configure-lets-encrypt-certificate#for-created-resource).
+2. Free Let's Encrypt certificate. Select a free [Let's&nbsp;Encrypt&nbsp;certificate](/cdn/ssl-certificates/configure-lets-encrypt-certificate#for-created-resource) for the custom domain. Gcore issues and attaches it automatically.
 
-## Where to configure SSL
+## SSL configuration
 
-In the [Gcore Customer Portal](https://portal.gcore.com), open **CDN**, select **CDN resources**, open the resource, then open **SSL** and turn on **Enable HTTPS**. Select **Free Let's Encrypt certificate** or **Custom SSL certificate**.
+Configure HTTPS on a CDN resource or upload a custom certificate for later use.
 
-Upload and manage custom certificates under **CDN** > **SSL certificates** > **Add SSL certificate**.
+### CDN resource HTTPS
+
+Attach a certificate from the CDN resource settings:
+
+<Steps>
+  <Step title="Open the CDN resource">
+    In the [Gcore Customer Portal](https://portal.gcore.com), navigate to **CDN** > **CDN resources** and open the resource.
+  </Step>
+  <Step title="Enable HTTPS">
+    Open **SSL** and turn on **Enable HTTPS**.
+  </Step>
+  <Step title="Select a certificate">
+    Select **Free Let's Encrypt certificate** or **Custom SSL certificate**.
+  </Step>
+</Steps>
+
+### Custom certificate upload
+
+Add a custom certificate from the CDN certificate list:
+
+<Steps>
+  <Step title="Open SSL certificates">
+    In the Customer Portal, navigate to **CDN** > **SSL certificates**.
+  </Step>
+  <Step title="Start the upload">
+    Click **Add SSL certificate**.
+  </Step>
+</Steps>

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -216,7 +216,7 @@
 - [Log viewer: view and download CDN resource logs](https://docs.gcore.com/cdn/logs/log-viewer-view-and-download-cdn-resource-logs.md): View and download CDN resource logs using Log viewer with filters for time interval, client IP, HTTP method, status code, data center, and cache status; export up to 10,000 log entries per 24-hour period.
 
 ## SSL certificates
-- [Add an SSL certificate to deliver content over HTTPS](https://docs.gcore.com/cdn/ssl-certificates/add-an-ssl-certificate-to-deliver-content-over-https.md): Attach SSL certificates to CDN resources for HTTPS delivery using custom domains, supporting both third-party certificates and free Let's Encrypt certificates via Gcore Customer Portal.
+- [Add an SSL certificate to deliver content over HTTPS](https://docs.gcore.com/cdn/ssl-certificates/add-an-ssl-certificate-to-deliver-content-over-https.md): Attach SSL certificates to CDN resources for HTTPS delivery with custom domains using custom or free Let's Encrypt certificates in the Customer Portal.
 - [Configure your own SSL certificate](https://docs.gcore.com/cdn/ssl-certificates/configure-your-own-ssl-certificate.md): Upload custom SSL certificates in PEM format with certificate chain (personal certificate, intermediate CA, root CA) and private key to Gcore CDN, then attach to CDN resources for custom domains and wildcard subdomains.
 - [Configure Let's Encrypt certificate](https://docs.gcore.com/cdn/ssl-certificates/configure-lets-encrypt-certificate.md): Enable HTTPS with free Let's Encrypt certificates on CDN resources using HTTP-01 or DNS-01 challenge validation, with optional Gcore Managed DNS delegation to ns1.gcorelabs.net and ns2.gcdn.services for domain ownership verification.
 


### PR DESCRIPTION
## Summary
- Remove outdated claim that SSL can be configured during CDN resource creation (Create form has no SSL section)
- Align labels with portal: Custom SSL certificate and Free Let''s Encrypt certificate
- Add Customer Portal path: CDN resources → SSL → Enable HTTPS

## Test plan
- [ ] Mintlify preview loads `/cdn/ssl-certificates/add-an-ssl-certificate-to-deliver-content-over-https`
- [ ] Links to custom domain and sibling SSL how-tos resolve
- [ ] Style/MDX checks already clean on branch
