### PR TITLE
[Streaming] Document SCTE-35 marker behavior

### DIFF
--- a/streaming/live-streams-and-videos-protocols-and-codecs/input-parameters-and-codecs.mdx
+++ b/streaming/live-streams-and-videos-protocols-and-codecs/input-parameters-and-codecs.mdx
@@ -18,6 +18,10 @@ After ingest or upload, Gcore transcodes the source into [adaptive bitrate strea
 
 For Live, you must produce and send the master stream to Gcore with the correct parameters. Configure OBS, FFmpeg, a hardware encoder, or your own encoding pipeline to push or expose the stream with the parameters below. Gcore receives this master stream and transcodes it for HLS and MPEG-DASH delivery.
 
+<Note>
+The Society of Cable Telecommunications Engineers 35 (SCTE-35) standard uses markers to signal ad insertion opportunities in a live stream. CDN delivery preserves these markers in an existing HLS stream, while SRT ingest requires transcoding to HLS and does not preserve them. A single workflow cannot currently combine SRT-to-HLS transcoding with SCTE-35 marker preservation.
+</Note>
+
 Recommended parameters for the master Live stream:
 
 | Parameter | Recommendation |


### PR DESCRIPTION
## What changed

Added a note explaining the tradeoff between SRT-to-HLS transcoding and preserving SCTE-35 markers. This documents when CDN delivery retains existing markers and when transcoding removes them.

Jira: https://jira.gcore.lu/browse/DOC-1966

## Files changed

- `streaming/live-streams-and-videos-protocols-and-codecs/input-parameters-and-codecs.mdx` — documented SCTE-35 marker behavior for live inputs
