### PR TITLE
docs(waap): update Known Bots for categories and verification (WS-3705)

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -966,7 +966,7 @@
 
 ## Bot Management
 - [Bot Protection](https://docs.gcore.com/waap/troubleshooting/enable-troubleshoot-bot-protection.md): Enable Gcore WAAP bot protection using User-Agent detection, traffic source analysis, behavioral analysis, and headless browser detection to block unauthorized vulnerability scans; manage Known Bots allowlist and configure Lets Encrypt policy via Bot Management portal.
-- [Known Bots](https://docs.gcore.com/waap/waap-policies/known-bots.md): Configure Known Bots policies in Gcore WAAP via Customer Portal or REST API. Known bots are grouped into intent-based categories (AI Search, AI Training, User-triggered AI, Search Engines, Preview Bots, SEO and Data Crawlers, Monitoring, Security Scanners, Integrations and Services), verified beyond User-Agent, and set to Allow or Policy-based per bot.
+- [Known Bots](https://docs.gcore.com/waap/waap-policies/known-bots.md): Configure Known Bots policies in Gcore WAAP via Customer Portal or REST API, setting each verified bot to Allow or Policy-based by intent category.
 - [Anti-automation and bot protection](https://docs.gcore.com/waap/waap-policies/anti-automation-and-bot-protection.md): Configure Anti-automation and Bot Protection policies in Gcore WAAP via Customer Portal or REST API to enable or disable anti-spam, traffic anomaly, automated clients, headless browser, anti-scraping, and vulnerability scanner defenses.
 - [Invalid user agent and Unknown user agent](https://docs.gcore.com/waap/waap-policies/invalid-user-agent-and-unknown-user-agent.md): Configure Invalid user agent and Unknown user agent WAAP policies to block or challenge requests with missing or non-standard user-agent headers via Customer Portal or REST API.
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -966,7 +966,7 @@
 
 ## Bot Management
 - [Bot Protection](https://docs.gcore.com/waap/troubleshooting/enable-troubleshoot-bot-protection.md): Enable Gcore WAAP bot protection using User-Agent detection, traffic source analysis, behavioral analysis, and headless browser detection to block unauthorized vulnerability scans; manage Known Bots allowlist and configure Lets Encrypt policy via Bot Management portal.
-- [Known Bots](https://docs.gcore.com/waap/waap-policies/known-bots.md): Configure Known Bots policies in Gcore WAAP via Customer Portal or REST API to set Allow or Policy-based mode for search engine crawlers, monitoring tools, and payment processor bots.
+- [Known Bots](https://docs.gcore.com/waap/waap-policies/known-bots.md): Configure Known Bots policies in Gcore WAAP via Customer Portal or REST API. Known bots are grouped into intent-based categories (AI Search, AI Training, User-triggered AI, Search Engines, Preview Bots, SEO and Data Crawlers, Monitoring, Security Scanners, Integrations and Services), verified beyond User-Agent, and set to Allow or Policy-based per bot.
 - [Anti-automation and bot protection](https://docs.gcore.com/waap/waap-policies/anti-automation-and-bot-protection.md): Configure Anti-automation and Bot Protection policies in Gcore WAAP via Customer Portal or REST API to enable or disable anti-spam, traffic anomaly, automated clients, headless browser, anti-scraping, and vulnerability scanner defenses.
 - [Invalid user agent and Unknown user agent](https://docs.gcore.com/waap/waap-policies/invalid-user-agent-and-unknown-user-agent.md): Configure Invalid user agent and Unknown user agent WAAP policies to block or challenge requests with missing or non-standard user-agent headers via Customer Portal or REST API.
 

--- a/waap/llms.txt
+++ b/waap/llms.txt
@@ -45,7 +45,7 @@
 
 ## Bot Management
 - [Bot Protection](https://docs.gcore.com/waap/troubleshooting/enable-troubleshoot-bot-protection.md): Enable Gcore WAAP bot protection using User-Agent detection, traffic source analysis, behavioral analysis, and headless browser detection to block unauthorized vulnerability scans; manage Known Bots allowlist and configure Lets Encrypt policy via Bot Management portal.
-- [Known Bots](https://docs.gcore.com/waap/waap-policies/known-bots.md): Configure Known Bots policies in Gcore WAAP via Customer Portal or REST API to set Allow or Policy-based mode for search engine crawlers, monitoring tools, and payment processor bots.
+- [Known Bots](https://docs.gcore.com/waap/waap-policies/known-bots.md): Configure Known Bots policies in Gcore WAAP via Customer Portal or REST API. Known bots are grouped into intent-based categories (AI Search, AI Training, User-triggered AI, Search Engines, Preview Bots, SEO and Data Crawlers, Monitoring, Security Scanners, Integrations and Services), verified beyond User-Agent, and set to Allow or Policy-based per bot.
 - [Anti-automation and bot protection](https://docs.gcore.com/waap/waap-policies/anti-automation-and-bot-protection.md): Configure Anti-automation and Bot Protection policies in Gcore WAAP via Customer Portal or REST API to enable or disable anti-spam, traffic anomaly, automated clients, headless browser, anti-scraping, and vulnerability scanner defenses.
 - [Invalid user agent and Unknown user agent](https://docs.gcore.com/waap/waap-policies/invalid-user-agent-and-unknown-user-agent.md): Configure Invalid user agent and Unknown user agent WAAP policies to block or challenge requests with missing or non-standard user-agent headers via Customer Portal or REST API.
 

--- a/waap/llms.txt
+++ b/waap/llms.txt
@@ -45,7 +45,7 @@
 
 ## Bot Management
 - [Bot Protection](https://docs.gcore.com/waap/troubleshooting/enable-troubleshoot-bot-protection.md): Enable Gcore WAAP bot protection using User-Agent detection, traffic source analysis, behavioral analysis, and headless browser detection to block unauthorized vulnerability scans; manage Known Bots allowlist and configure Lets Encrypt policy via Bot Management portal.
-- [Known Bots](https://docs.gcore.com/waap/waap-policies/known-bots.md): Configure Known Bots policies in Gcore WAAP via Customer Portal or REST API. Known bots are grouped into intent-based categories (AI Search, AI Training, User-triggered AI, Search Engines, Preview Bots, SEO and Data Crawlers, Monitoring, Security Scanners, Integrations and Services), verified beyond User-Agent, and set to Allow or Policy-based per bot.
+- [Known Bots](https://docs.gcore.com/waap/waap-policies/known-bots.md): Configure Known Bots policies in Gcore WAAP via Customer Portal or REST API, setting each verified bot to Allow or Policy-based by intent category.
 - [Anti-automation and bot protection](https://docs.gcore.com/waap/waap-policies/anti-automation-and-bot-protection.md): Configure Anti-automation and Bot Protection policies in Gcore WAAP via Customer Portal or REST API to enable or disable anti-spam, traffic anomaly, automated clients, headless browser, anti-scraping, and vulnerability scanner defenses.
 - [Invalid user agent and Unknown user agent](https://docs.gcore.com/waap/waap-policies/invalid-user-agent-and-unknown-user-agent.md): Configure Invalid user agent and Unknown user agent WAAP policies to block or challenge requests with missing or non-standard user-agent headers via Customer Portal or REST API.
 

--- a/waap/waap-policies/anti-automation-and-bot-protection.mdx
+++ b/waap/waap-policies/anti-automation-and-bot-protection.mdx
@@ -47,7 +47,7 @@ The **Invalid user agent** and **Unknown user agent** policies are set to **Prot
 
 <p>Challenge or block requests from automated sessions. Automated clients are usually bots looking to hack, spam, spy, or generally compromise your website. Activating this policy will detect these requests and force human interaction. </p>
 
-<p>You can review a list of known bots and configure their mode within the [Known Bots](/waap/waap-policies/known-bots) section. Learn more about enabling and troubleshooting bot protection in [our dedicated guide](/waap/troubleshooting/enable-troubleshoot-bot-protection). </p>
+<p>You can review a list of known bots and configure their mode within the [Known Bots](/waap/waap-policies/known-bots) section. For a verified known bot set to Policy-based, these Bot Attacks checks are automatically excluded to avoid false positives — see [how Policy-based mode interacts with other protections](/waap/waap-policies/known-bots#how-policy-based-mode-interacts-with-other-protections). Learn more about enabling and troubleshooting bot protection in [our dedicated guide](/waap/troubleshooting/enable-troubleshoot-bot-protection). </p>
 
 ### Headless browsers
 

--- a/waap/waap-policies/known-bots.mdx
+++ b/waap/waap-policies/known-bots.mdx
@@ -39,7 +39,7 @@ import { MethodSwitch, MethodSection } from "/snippets/method-switch.jsx";
 
 <p>Each known bot can be set to one of two actions:</p>
 
-- **Allow** — the request bypasses all WAAP processing layers, including L7 DDoS protection, behavioral analytics, OWASP checks, and other handlers. Use this only for bots you fully trust.
+- **Allow** — the request bypasses all WAAP processing layers, including DDoS protection, behavioral analytics, OWASP checks, and other handlers. Use this only for bots you fully trust.
 - **Policy-based** — the request is inspected, but the bot-detection checks that only apply to *unknown* automation are skipped (see below). Signature-based WAF and OWASP protections, IP-reputation threat signals, and your custom rules still apply.
 
 <p>Some bots are set to **Policy-based** by default, and you can switch a bot to **Allow** to fully permit its traffic. AI Search and AI Training bots are set to **Allow** by default, while User-triggered AI bots are set to **Policy-based**. In some cases you might want to restrict a bot — for example, to enforce data-protection requirements, protect a domain from a service you don't use, or keep paid content from being scraped. In that case, adjust the action for the individual bot.</p>
@@ -71,11 +71,11 @@ Exclusions apply only to traffic that passes verification. If a request carries 
 
 <p>Identification does not rely on the User-Agent alone, which attackers can spoof. A request is treated as a known bot only when its User-Agent **and** its source match the identity published by the bot's vendor. Verification uses one or more of:</p>
 
-- Official vendor IP ranges, refreshed daily
+- Official vendor IP ranges, refreshed regularly
 - Organization ownership of the source address
 - Signed requests, where the vendor supports them
 
-<p>Traffic that passes verification is tagged with **Verified Bot** and a category tag (for example, **AI Search**, **AI Training**, or **User Triggered AI**), which you can use in analytics and custom rules. Traffic that fails verification is not classified as a known bot: it receives no exclusions and is inspected like any other request.</p>
+<p>Only traffic that passes verification is treated as a known bot and receives the handling described above. Traffic that fails verification is not classified as a known bot: it receives no exclusions and is inspected like any other request.</p>
 
 ## Configure Known Bots
 

--- a/waap/waap-policies/known-bots.mdx
+++ b/waap/waap-policies/known-bots.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Known Bots"
 sidebarTitle: "Known Bots"
-ai-navigation: Configure Known Bots policies in Gcore WAAP via Customer Portal or REST API. Known bots are grouped into intent-based categories (AI Search, AI Training, User-triggered AI, Search Engines, Preview Bots, SEO and Data Crawlers, Monitoring, Security Scanners, Integrations and Services), verified beyond User-Agent, and set to Allow or Policy-based per bot.
+ai-navigation: Configure Known Bots policies in Gcore WAAP via Customer Portal or REST API, setting each verified bot to Allow or Policy-based by intent category.
 ---
 
 import { MethodSwitch, MethodSection } from "/snippets/method-switch.jsx";

--- a/waap/waap-policies/known-bots.mdx
+++ b/waap/waap-policies/known-bots.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Known Bots"
 sidebarTitle: "Known Bots"
-ai-navigation: Configure Known Bots policies in Gcore WAAP via Customer Portal or REST API to set Allow or Policy-based mode for search engine crawlers, monitoring tools, and payment processor bots.
+ai-navigation: Configure Known Bots policies in Gcore WAAP via Customer Portal or REST API. Known bots are grouped into intent-based categories (AI Search, AI Training, User-triggered AI, Search Engines, Preview Bots, SEO and Data Crawlers, Monitoring, Security Scanners, Integrations and Services), verified beyond User-Agent, and set to Allow or Policy-based per bot.
 ---
 
 import { MethodSwitch, MethodSection } from "/snippets/method-switch.jsx";
@@ -9,24 +9,73 @@ import { MethodSwitch, MethodSection } from "/snippets/method-switch.jsx";
 <MethodSwitch>
   <MethodSection id="portal" label="Customer Portal">
 
-<p>This policy group functions uniquely in WAAP. Instead of challenging or blocking incoming traffic like other policy groups, it's designed to recognize and allow traffic from legitimate automated services.</p>
+<p>This policy group functions uniquely in WAAP. Instead of challenging or blocking incoming traffic like other policy groups, it's designed to recognize and allow traffic from legitimate automated services, such as search engine crawlers, AI agents, social media preview fetchers, monitoring tools, and payment processors.</p>
 
-<p>These services include:</p>
-
-- Common web crawlers like Google and Microsoft bots
-- Preview fetch bots like Slack, Facebook, or Twitter
-- SEO and monitoring tools
-- Other tools like Instant Payment Notification (IPN) requests from PayPal or HiPay
-
-<p>All these automation services often access your domain to gather some information and are considered beneficial or necessary for normal web activities. Note that some policies are set to **Policy-based** mode by default, and you can set them to **Allow** to fully permit traffic from the relevant services.</p>
-
-<p>In some cases, you might want to restrict automation tools from accessing your domain. For instance, you can do so to enforce specific data protection requirements on a domain, protect it from potentially harmful services, or restrict paid content from unauthorized use. In this case, adjust the mode for particular bots in the Known Bots section.</p>
+<p>These services access your domain to gather information and are generally beneficial or necessary for normal web activity. For each bot, you choose how WAAP treats its traffic once the bot has been recognized and verified.</p>
 
 <Info>
   **Info**
 
   This policy group is available in the Pro and Enterprise plans. More details on the [Security pricing page](https://gcore.com/pricing/security#waap).
 </Info>
+
+## Bot categories
+
+<p>Known bots are grouped into intent-based categories so you can understand what each bot does and make informed policy decisions. Each bot belongs to exactly one category. Policies are managed per bot; category-level policy management is not available.</p>
+
+| Category | Description |
+|---|---|
+| AI Search | Bots indexing public content for AI-powered search and answers. |
+| AI Training | Crawlers collecting public web data to train AI models. |
+| User-triggered AI | Agents that fetch or browse on behalf of a specific user request. |
+| Search Engines | Traditional search engine crawlers indexing pages for organic search. |
+| Preview Bots | Fetchers that generate link previews and metadata for social platforms. |
+| SEO and Data Crawlers | Third-party crawlers for SEO analysis, audience measurement, and content feeds. |
+| Monitoring | Automated checks for uptime, performance, and infrastructure health. |
+| Security Scanners | Crawlers performing security audits, certificate validation, and plugin checks. |
+| Integrations and Services | Webhooks, payment callbacks, and infrastructure services making automated requests. |
+
+## Bot actions
+
+<p>Each known bot can be set to one of two actions:</p>
+
+- **Allow** — the request bypasses all WAAP processing layers, including L7 DDoS protection, behavioral analytics, OWASP checks, and other handlers. Use this only for bots you fully trust.
+- **Policy-based** — the request is inspected, but the bot-detection checks that only apply to *unknown* automation are skipped (see below). Signature-based WAF and OWASP protections, IP-reputation threat signals, and your custom rules still apply.
+
+<p>Some bots are set to **Policy-based** by default, and you can switch a bot to **Allow** to fully permit its traffic. AI Search and AI Training bots are set to **Allow** by default, while User-triggered AI bots are set to **Policy-based**. In some cases you might want to restrict a bot — for example, to enforce data-protection requirements, protect a domain from a service you don't use, or keep paid content from being scraped. In that case, adjust the action for the individual bot.</p>
+
+## How Policy-based mode interacts with other protections
+
+<p>Most bot-detection checks are designed to identify *unknown* automated traffic. Once a request is matched to a verified known bot, running those same checks again produces guaranteed false positives rather than added security. For example, cloud-hosted AI fetchers would trip **Traffic from hosting services**, search crawlers would trip **Anti-scraping** (indexing pages is scraping by definition), and any high-volume crawler would trip **Traffic anomaly**.</p>
+
+<p>For this reason, when a request is matched to a known bot set to **Policy-based**, the following checks are excluded — they do not evaluate, do not generate block events, do not increment detection counters, and do not appear as triggered in the event log:</p>
+
+| Group | Excluded checks |
+|---|---|
+| IP Reputation | Bot traffic; Traffic from hosting services |
+| Bot Attacks | Unknown user agent; Automated clients; Traffic anomaly; Anti-scraping; Headless browsers; Anti-spam; Vulnerability scanner |
+
+<p>These protections remain fully active for known-bot traffic:</p>
+
+- Signature-based WAF inspection and OWASP protections
+- IP-reputation threat signals
+- Custom rules — a custom rule that targets a known-bot pattern is never suppressed
+
+<Info>
+**Info**
+
+Exclusions apply only to traffic that passes verification. If a request carries a known-bot User-Agent but fails verification, it is not treated as a known bot and every check evaluates normally.
+</Info>
+
+## Bot verification
+
+<p>Identification does not rely on the User-Agent alone, which attackers can spoof. A request is treated as a known bot only when its User-Agent **and** its source match the identity published by the bot's vendor. Verification uses one or more of:</p>
+
+- Official vendor IP ranges, refreshed daily
+- Organization ownership of the source address
+- Signed requests, where the vendor supports them
+
+<p>Traffic that passes verification is tagged with **Verified Bot** and a category tag (for example, **AI Search**, **AI Training**, or **User Triggered AI**), which you can use in analytics and custom rules. Traffic that fails verification is not classified as a known bot: it receives no exclusions and is inspected like any other request.</p>
 
 ## Configure Known Bots
 
@@ -36,13 +85,14 @@ import { MethodSwitch, MethodSection } from "/snippets/method-switch.jsx";
 
 2. In the domain dropdown at the top of the page, select the needed domain.
 
+3. Click the **Known Bots** tab to view bots grouped by category and adjust each bot's action.
 
-3. Click the **Known Bots** tab to view and adjust the list of allowed bots.
+<p>Learn more about the related detection policies in the [Anti-automation and bot protection](/waap/waap-policies/anti-automation-and-bot-protection) section.</p>
 
 </MethodSection>
 <MethodSection id="api" label="REST API">
 
-<p>Known Bots policies control how WAAP handles traffic from 136 recognized automated services — search engine crawlers, social media preview bots, monitoring tools, and payment processors. Each bot can be set to **Allow** (bypass WAF inspection) or **Policy-based** (subject to other active WAF rules).</p>
+<p>Known Bots policies control how WAAP handles traffic from recognized automated services — search engine crawlers, AI agents, social media preview bots, monitoring tools, and payment processors. In the Customer Portal these bots are grouped into intent-based categories, but the API exposes them as a flat list of policies. Each bot can be set to **Allow** (bypass all WAAP processing) or **Policy-based** (inspected, with unknown-automation detection checks skipped).</p>
 
 <Info>
 An [API token](/account-settings/api-tokens) is required, along with the ID of a [WAAP-protected domain](/waap/getting-started/configure-waap-for-a-domain) and the [Python](/developer-tools/sdks/python) or [Go](/developer-tools/sdks/go) SDK installed for SDK examples. This policy group is available on the Pro and Enterprise WAAP plans.
@@ -119,6 +169,12 @@ export WAAP_DOMAIN_ID="{YOUR_DOMAIN_ID}"
 </Tabs>
 
 <p>The API returns all policies in the group. `mode: true` means Allow; `mode: false` means Policy-based.</p>
+
+<Info>
+**Info**
+
+`mode: false` (Policy-based) carries the detector-exclusion behavior described in the Customer Portal tab: unknown-automation detection checks are skipped for verified known-bot traffic, while signature-based WAF, OWASP protections, IP-reputation threat signals, and custom rules still apply.
+</Info>
 
 ## Toggle a bot mode
 


### PR DESCRIPTION
## What

Updates the WAAP **Known Bots** documentation to match what shipped in "Known bots improvements. Stage 1" (epic WS-2816, docs ticket WS-3705). The current page described the old model: one flat list of "136 bots" with only an Allow/Policy-based toggle and no explanation of verification or how Policy-based interacts with detection.

## Changes

`waap/waap-policies/known-bots.mdx` (Customer Portal + REST API tabs):
- Group known bots into **nine intent-based categories** with descriptions (AI Search, AI Training, User-triggered AI, Search Engines, Preview Bots, SEO and Data Crawlers, Monitoring, Security Scanners, Integrations and Services). Policies are managed per bot.
- Document the two **actions**: Allow (bypass all WAAP processing) and Policy-based (inspected, unknown-automation detection checks skipped). Note the AI defaults (AI Search / AI Training = Allow, User-triggered AI = Policy-based).
- Add **How Policy-based mode interacts with other protections** — the exact checks excluded for a verified known bot, what stays active (WAF/OWASP, IP-reputation threat signals, custom rules), and why. This is a required deliverable of WS-3531.
- Add **Bot verification** — identification uses User-Agent plus vendor-published IP ranges (refreshed daily) / org ownership / signed requests; verification failure means the request is not treated as a known bot; verified traffic is tagged.
- Refresh the REST API intro and add a note that `mode:false` carries the exclusion behavior. API mechanics unchanged.

`waap/waap-policies/anti-automation-and-bot-protection.mdx`:
- One sentence + cross-link noting these Bot Attacks checks are auto-excluded for verified known bots in Policy-based mode.

## Scope notes

Documents only shipped behavior. Deliberately excludes epic-level concepts that did **not** ship in Stage 1 — Block/Rate-limit actions for known bots, the multi-state verification model (Verified/Partially/Unverified/Spoofed), JA3/JA4, mTLS, risk scoring, and category-level policies. `Allow` still means full WAAP bypass (WS-3198 was cancelled). The full bot catalog is intentionally not enumerated — the portal is the source of truth.