### PR TITLE
[Cloud] Add region-less flavor listing endpoint to create-instance API tab

### DIFF
--- a/cloud/virtual-instances/create-an-instance.mdx
+++ b/cloud/virtual-instances/create-an-instance.mdx
@@ -620,6 +620,13 @@ A [flavor](/api-reference/cloud/flavors/list-flavors) sets the vCPU count and RA
 export FLAVOR_ID="{FLAVOR_ID}"   # replace with a flavor_id from the response above
 ```
 
+To list available flavors across all regions without specifying a region, use the region-less endpoint. An optional `region_ids` query parameter filters results to specific regions.
+
+```bash
+curl "https://api.gcore.com/cloud/v1/projects/$GCORE_CLOUD_PROJECT_ID/instances/flavors" \
+  -H "Authorization: APIKey $GCORE_API_KEY"
+```
+
 ### Step 3. Create the instance
 
 The instance is created with a public interface - `"type": "external"` assigns a public IPv4 address automatically, without a separate floating IP.


### PR DESCRIPTION
## What changed

Added documentation for the new region-less flavor listing endpoint (`GET /cloud/v1/projects/{project_id}/instances/flavors`) introduced in GCLOUD2-28563. The endpoint allows listing VM flavors across all regions without specifying a region ID, with an optional `region_ids` filter.

Jira: https://jira.gcore.lu/browse/DOC-1981

## Files changed

- `cloud/virtual-instances/create-an-instance.mdx` — added curl example and note for the new region-less endpoint in the REST API tab, Step 2 "Select a flavor"

## TODO before publishing

- [ ] Revisit when `cloud_api.yaml` spec is updated — add Python SDK and Go SDK examples for the new endpoint
- [ ] Writer review and approval
