### PR TITLE
DOC-1992: Sync Application Catalog article with live portal model list

### DIFF
--- a/edge-ai/everywhere-inference/application-catalog.mdx
+++ b/edge-ai/everywhere-inference/application-catalog.mdx
@@ -17,6 +17,7 @@ The catalog groups models into the following categories:
 | Embedding | Multimodal embedding models |
 | Image generation | Models that generate images from text prompts |
 | Video Super-Resolution | Models that upscale and enhance video quality |
+| Reranker | Models that re-rank retrieved documents by relevance score |
 | Speech recognition | Models that transcribe spoken audio to text |
 | Text to speech | Models that convert text to spoken audio |
 | Safety model | Models that classify content for safety and policy compliance |
@@ -78,18 +79,24 @@ Gcore creates the deployment and opens the **Deployments** page, where the deplo
 
 <AccordionGroup>
 
-<Accordion title="Text LLM (21 models)">
+<Accordion title="Text LLM (31 models)">
 
 | Model | Provider |
 |---|---|
+| deepseek-ai/DeepSeek-V4-Flash-0731 | deepseek-ai |
+| deepseek-ai/DeepSeek-V4-Flash-fp8 | deepseek-ai |
 | meta-llama/Llama-3.2-1B-Instruct | Meta |
 | MiniMaxAI/MiniMax-M2.1 | MiniMaxAI |
 | MiniMaxAI/MiniMax-M2.5 | MiniMaxAI |
+| MiniMaxAI/MiniMax-M2.7 | MiniMaxAI |
 | mistralai/Devstral-2-123B-Instruct-2512 | Mistral AI |
-| mistralai/Devstral-Small-2505 | Mistral |
 | mistralai/Ministral-3-14B-Reasoning-2512 | Mistral AI |
+| mistralai/Mistral-Medium-3.5-128B | Mistral AI |
+| moonshotai/Kimi-K2.6 | moonshotai |
+| moonshotai/Kimi-K2.6 Blackwell | moonshotai |
 | openai/gpt-oss-120b | OpenAI |
 | openai/gpt-oss-20b | OpenAI |
+| poolside/Laguna-S-2.1-FP8 | poolside |
 | Qwen/Qwen3-14B | Qwen |
 | Qwen/Qwen3-235B-A22B-Instruct-2507 | Qwen |
 | Qwen/Qwen3-30B-A3B | Qwen |
@@ -100,17 +107,23 @@ Gcore creates the deployment and opens the **Deployments** page, where the deplo
 | Qwen/Qwen3.5-122B-A10B | Qwen |
 | Qwen/Qwen3.5-35B-A3B | Qwen |
 | Qwen/Qwen3.5-397B-A17B-FP8 | Qwen |
+| Qwen/Qwen3.6-27B-FP8 | Qwen |
+| Qwen/Qwen3.6-35B-A3B | Qwen |
 | xai-org/grok-2 | xAI |
 | zai-org/GLM-4.7 | Z.ai |
 | zai-org/GLM-4.7-Flash | Z.ai |
+| zai-org/GLM-5 | Z.ai |
+| zai-org/GLM-5.1 | Z.ai |
 
 </Accordion>
 
-<Accordion title="Text + Image LLM (3 models)">
+<Accordion title="Text + Image LLM (5 models)">
 
 | Model | Provider |
 |---|---|
 | google/gemma-3-27b-it | Google |
+| google/gemma-4-26b-a4b-it | Google |
+| google/gemma-4-31b-it | Google |
 | Qwen/QVQ-72B-Preview | Qwen |
 | Qwen/Qwen3-VL-235B-A22B-Instruct | Qwen |
 
@@ -156,6 +169,14 @@ Gcore creates the deployment and opens the **Deployments** page, where the deplo
 | stable-diffusion-3.5-large | Stability AI |
 | stable-diffusion-3.5-large-turbo | Stability AI |
 | stable-diffusion-xl | Stability AI |
+
+</Accordion>
+
+<Accordion title="Reranker (1 model)">
+
+| Model | Provider |
+|---|---|
+| BAAI/bge-reranker-v2-m3 | BAAI |
 
 </Accordion>
 


### PR DESCRIPTION
Text LLM 21->31: remove Devstral-Small-2505, add DeepSeek-V4-Flash x2, MiniMax-M2.7, Mistral-Medium-3.5-128B, Kimi-K2.6 + Blackwell, Laguna-S-2.1-FP8, Qwen3.6-27B-FP8, Qwen3.6-35B-A3B, GLM-5, GLM-5.1. Text+Image LLM 3->5: add gemma-4-26b-a4b-it, gemma-4-31b-it. Add Reranker accordion (BAAI/bge-reranker-v2-m3) and category table row.